### PR TITLE
v0.7 — Novastar bounding rect, label occlusion, version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.6.5.19
+# LED Raster Designer v0.7
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,7 +1,7 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
-v0.6.5.19 - March 21, 2026
+v0.7 - March 21, 2026
 ----------------------------
 - FIX: Novastar Legacy port capacity now calculates using bounding rectangle instead of sum of visible panel pixels
 - FIX: Non-rectangular layouts (stair-step, L-shape) now correctly account for the full rectangle the processor reserves

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.6.5.19',
-            'CFBundleVersion': '0.6.5.19',
+            'CFBundleShortVersionString': '0.7',
+            'CFBundleVersion': '0.7',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.6.5.19</title>
+    <title>LED Raster Designer v0.7</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -66,7 +66,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.6.5.19</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">


### PR DESCRIPTION
## Summary
- **Novastar Legacy bounding rectangle fix**: Port capacity now calculated using the extent of visible panels, not full grid width. Non-rectangular layouts correctly fit more rows per port.
- **Label bleed-through fix**: Screen name labels render in the first pass so upper layers naturally paint over lower layers' labels.
- **Version bump to v0.7**: Major milestone — Resolume XML export, launcher overhaul, CI integrity, and rendering fixes.

## Test plan
- [ ] Non-rectangular Novastar Legacy projects — verify port assignments use visible panel bounding rect
- [ ] Overlapping screen layers — verify only top layer's label visible in overlap regions
- [ ] All tabs render labels correctly (Pixel Map, Cabinet ID, Data, Power)
- [ ] CI passes on all OS runners