### PR TITLE
Screen Layer Presets (v0.7.4.20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ env/
 logs/
 *.log
 
+# User presets (per-install user data, not source)
+presets/
+
+# Claude Code local config
+.claude/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.19
+# LED Raster Designer v0.7.4.20
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.20 - April 16, 2026
+----------------------------
+- NEW: Screen Layer Presets. Save the currently selected layer's settings as
+  a reusable preset, then pick from saved presets when adding new screens.
+  Presets are stored server-side in <app>/presets/*.json and shared across
+  clients. Clicking "+ Add Screen" opens a picker showing each preset's
+  dimensions and watts/panel; "💾 Save as Preset" captures ~90 layer
+  properties (colors, data flow, power, labels, etc.) — excludes identity,
+  position, panels array, and runtime caches. Duplicate names prompt to
+  overwrite; each preset row has a delete button.
+
 v0.7.4.19 - April 7, 2026
 ----------------------------
 - FIX: Backup ports now correctly counted in aggregate info labels (was always

--- a/src/app.py
+++ b/src/app.py
@@ -39,6 +39,10 @@ LOG_BACKUPS = 2
 os.environ['_LRD_LOG_DIR'] = LOG_DIR_PATH
 print(f'[LED Raster Designer] Log directory: {LOG_DIR_PATH}')
 
+PRESETS_DIR_PATH = os.path.join(_APP_DIR, 'presets')
+os.makedirs(PRESETS_DIR_PATH, exist_ok=True)
+print(f'[LED Raster Designer] Presets directory: {PRESETS_DIR_PATH}')
+
 def prune_log_files():
     try:
         if not os.path.isdir(LOG_DIR_PATH):
@@ -513,6 +517,108 @@ def save_preferences():
     server_preferences = data
     log_event('save_preferences', {'keys': list(data.keys())})
     socketio.emit('preferences_updated', server_preferences)
+    return jsonify({'status': 'success'})
+
+# ── Screen Layer Presets (persisted to disk, shared across all clients) ──
+def _sanitize_preset_name(name):
+    """Strip path separators and control chars. Returns (safe_name, error_msg|None)."""
+    if not isinstance(name, str):
+        return None, 'Preset name must be a string'
+    name = name.strip()
+    if not name:
+        return None, 'Preset name cannot be empty'
+    if len(name) > 80:
+        return None, 'Preset name too long (max 80 chars)'
+    # Disallow path traversal and filesystem-unsafe chars
+    for ch in ('/', '\\', '..', '\x00'):
+        if ch in name:
+            return None, f'Preset name cannot contain "{ch}"'
+    # Strip control chars
+    if any(ord(c) < 32 for c in name):
+        return None, 'Preset name cannot contain control characters'
+    return name, None
+
+def _preset_path(safe_name):
+    return os.path.join(PRESETS_DIR_PATH, f'{safe_name}.json')
+
+@app.route('/api/presets', methods=['GET'])
+def list_presets():
+    """Return preset summaries (name + key dimensions) sorted alphabetically.
+    Each entry: {name, columns, rows, cabinet_width, cabinet_height, panel_width_mm, panel_height_mm}."""
+    entries = []
+    try:
+        for fname in os.listdir(PRESETS_DIR_PATH):
+            if not fname.endswith('.json'):
+                continue
+            name = fname[:-5]
+            summary = {'name': name}
+            try:
+                with open(os.path.join(PRESETS_DIR_PATH, fname), 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                for key in ('columns', 'rows', 'cabinet_width', 'cabinet_height',
+                            'panel_width_mm', 'panel_height_mm', 'panelWatts'):
+                    if key in data:
+                        summary[key] = data[key]
+            except (OSError, json.JSONDecodeError):
+                pass  # Keep the name even if the file is corrupt; frontend handles missing fields
+            entries.append(summary)
+    except FileNotFoundError:
+        pass
+    entries.sort(key=lambda e: e['name'].lower())
+    log_event('list_presets', {'count': len(entries)})
+    # Backwards-compat: keep `presets` as list of names; add `entries` with summaries.
+    return jsonify({'presets': [e['name'] for e in entries], 'entries': entries})
+
+@app.route('/api/presets/<name>', methods=['GET'])
+def get_preset(name):
+    safe_name, err = _sanitize_preset_name(name)
+    if err:
+        return jsonify({'error': err}), 400
+    path = _preset_path(safe_name)
+    if not os.path.isfile(path):
+        return jsonify({'error': 'Preset not found'}), 404
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return jsonify({'error': f'Failed to read preset: {e}'}), 500
+    log_event('get_preset', {'name': safe_name})
+    return jsonify({'name': safe_name, 'data': data})
+
+@app.route('/api/presets/<name>', methods=['PUT'])
+def save_preset(name):
+    safe_name, err = _sanitize_preset_name(name)
+    if err:
+        return jsonify({'error': err}), 400
+    payload = request.json or {}
+    data = payload.get('data')
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Preset data must be an object'}), 400
+    path = _preset_path(safe_name)
+    existed = os.path.isfile(path)
+    try:
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+    except OSError as e:
+        return jsonify({'error': f'Failed to write preset: {e}'}), 500
+    log_event('save_preset', {'name': safe_name, 'overwrote': existed, 'keys': list(data.keys())})
+    socketio.emit('presets_updated')
+    return jsonify({'status': 'success', 'name': safe_name, 'overwrote': existed})
+
+@app.route('/api/presets/<name>', methods=['DELETE'])
+def delete_preset(name):
+    safe_name, err = _sanitize_preset_name(name)
+    if err:
+        return jsonify({'error': err}), 400
+    path = _preset_path(safe_name)
+    if not os.path.isfile(path):
+        return jsonify({'error': 'Preset not found'}), 404
+    try:
+        os.remove(path)
+    except OSError as e:
+        return jsonify({'error': f'Failed to delete preset: {e}'}), 500
+    log_event('delete_preset', {'name': safe_name})
+    socketio.emit('presets_updated')
     return jsonify({'status': 'success'})
 
 @app.route('/api/project/new', methods=['POST'])

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.19',
-            'CFBundleVersion': '0.7.4.19',
+            'CFBundleShortVersionString': '0.7.4.20',
+            'CFBundleVersion': '0.7.4.20',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1916,8 +1916,13 @@ class LEDRasterApp {
         });
         
         document.getElementById('btn-add-layer').addEventListener('click', () => {
-            this.addLayer();
+            this.openPresetPicker();
         });
+        const savePresetBtn = document.getElementById('btn-save-preset');
+        if (savePresetBtn) {
+            savePresetBtn.addEventListener('click', () => this.openPresetSaveModal());
+        }
+        this.setupPresetModals();
         const addImageBtn = document.getElementById('btn-add-image');
         const addImageInput = document.getElementById('add-image-input');
         if (addImageBtn && addImageInput) {
@@ -3526,35 +3531,47 @@ class LEDRasterApp {
         return `Screen${maxNum + 1}`;
     }
 
-    addLayer() {
+    addLayer(presetData) {
+        // Server-side props control panel generation (columns/rows/cabinet sizes/colors/etc.)
+        // Client-side props (data flow, power, labels...) are applied after the layer is returned.
         const prefs = this.getPreferences();
-        const columns = prefs.columns;
-        const rows = prefs.rows;
-        const cabinetWidth = prefs.panelWidth;
-        const cabinetHeight = prefs.panelHeight;
-        const offsetX = 0;
-        const offsetY = 0;
-        const color1 = this.hexToRgb(prefs.color1);
-        const color2 = this.hexToRgb(prefs.color2);
-        
+        let serverProps;
+        if (presetData && typeof presetData === 'object') {
+            serverProps = {
+                columns: presetData.columns != null ? presetData.columns : prefs.columns,
+                rows: presetData.rows != null ? presetData.rows : prefs.rows,
+                cabinet_width: presetData.cabinet_width != null ? presetData.cabinet_width : prefs.panelWidth,
+                cabinet_height: presetData.cabinet_height != null ? presetData.cabinet_height : prefs.panelHeight,
+                color1: presetData.color1 || this.hexToRgb(prefs.color1),
+                color2: presetData.color2 || this.hexToRgb(prefs.color2),
+                border_color: presetData.border_color || prefs.borderColor,
+                panel_weight: presetData.panel_weight != null ? presetData.panel_weight : prefs.panelWeight,
+                weight_unit: presetData.weight_unit || prefs.weightUnit
+            };
+        } else {
+            serverProps = {
+                columns: prefs.columns,
+                rows: prefs.rows,
+                cabinet_width: prefs.panelWidth,
+                cabinet_height: prefs.panelHeight,
+                color1: this.hexToRgb(prefs.color1),
+                color2: this.hexToRgb(prefs.color2),
+                border_color: prefs.borderColor,
+                panel_weight: prefs.panelWeight,
+                weight_unit: prefs.weightUnit
+            };
+        }
+
         this.saveState('Add Layer');
-        
+
         fetch('/api/layer/add', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 name: this.getNextScreenName(),
-                columns,
-                rows,
-                cabinet_width: cabinetWidth,
-                cabinet_height: cabinetHeight,
-                offset_x: offsetX,
-                offset_y: offsetY,
-                color1,
-                color2,
-                border_color: prefs.borderColor,
-                panel_weight: prefs.panelWeight,
-                weight_unit: prefs.weightUnit
+                offset_x: 0,
+                offset_y: 0,
+                ...serverProps
             })
         })
         .then(res => res.json())
@@ -3564,18 +3581,305 @@ class LEDRasterApp {
                 columns: layer.columns, rows: layer.rows,
                 cabinet_width: layer.cabinet_width, cabinet_height: layer.cabinet_height,
                 offset_x: layer.offset_x, offset_y: layer.offset_y,
+                preset: presetData ? (presetData._presetName || true) : false,
                 totalLayers: this.project.layers ? this.project.layers.length + 1 : 1
             });
-            // Initialize client-side defaults for new layer
+            // Initialize client-side defaults first (baseline)
             this.initializeLayerDefaults(layer);
-            
+            // Then overlay preset client-side props on top
+            if (presetData && typeof presetData === 'object') {
+                this.applyPresetClientProps(layer, presetData);
+            }
+
             this.upsertProjectLayer(layer);
             this.selectLayer(layer);
             window.canvasRenderer.fitToView();
-            
+
             // Save the new defaults to localStorage
             this.saveClientSideProperties();
         });
+    }
+
+    // Properties excluded from presets (identity, runtime position, cached computations).
+    // Everything else on a layer can be preserved as a preset.
+    getPresetExcludedKeys() {
+        return new Set([
+            'id', 'name', 'visible', 'locked',
+            'offset_x', 'offset_y',
+            'panels',  // panel array is regenerated from columns/rows on server
+            '_powerError', '_powerCircuits', '_powerPanelCircuitMap', '_powerPanelIndexMap',
+            '_powerCircuitNumKeys', '_powerTotalAmps1', '_powerTotalAmps3',
+            '_powerCircuitsRequired', '_capacityError', '_portsRequired', '_autoPortsRequired',
+            '_imageObj', 'imageData'
+        ]);
+    }
+
+    serializeLayerAsPreset(layer) {
+        if (!layer) return null;
+        const excluded = this.getPresetExcludedKeys();
+        const out = {};
+        Object.keys(layer).forEach(k => {
+            if (excluded.has(k)) return;
+            if (k.startsWith('_')) return;  // skip runtime caches
+            out[k] = layer[k];
+        });
+        return out;
+    }
+
+    applyPresetClientProps(layer, presetData) {
+        const excluded = this.getPresetExcludedKeys();
+        // Server-side structural props already applied via /api/layer/add; skip them here.
+        const serverKeys = new Set(['columns', 'rows', 'cabinet_width', 'cabinet_height',
+            'color1', 'color2', 'border_color', 'panel_weight', 'weight_unit']);
+        Object.keys(presetData).forEach(k => {
+            if (excluded.has(k)) return;
+            if (serverKeys.has(k)) return;
+            if (k.startsWith('_')) return;
+            layer[k] = presetData[k];
+        });
+    }
+
+    // ── Preset CRUD (server) ──
+    fetchPresetList() {
+        // Returns list of names (compat).
+        return fetch('/api/presets').then(r => r.json()).then(d => d.presets || []);
+    }
+
+    fetchPresetEntries() {
+        // Returns list of {name, columns, rows, cabinet_width, cabinet_height, panel_width_mm, panel_height_mm}
+        return fetch('/api/presets').then(r => r.json()).then(d => d.entries || []);
+    }
+
+    formatPresetSublabel(entry) {
+        if (!entry) return 'Saved preset';
+        const parts = [];
+        if (entry.columns != null && entry.rows != null) {
+            parts.push(`${entry.columns}×${entry.rows}`);
+        }
+        if (entry.cabinet_width != null && entry.cabinet_height != null) {
+            parts.push(`${entry.cabinet_width}×${entry.cabinet_height}px`);
+        }
+        if (entry.panel_width_mm != null && entry.panel_height_mm != null) {
+            parts.push(`${entry.panel_width_mm}×${entry.panel_height_mm}mm`);
+        }
+        if (entry.panelWatts != null) {
+            parts.push(`${entry.panelWatts}W/panel`);
+        }
+        return parts.length > 0 ? parts.join(' • ') : 'Saved preset';
+    }
+
+    fetchPreset(name) {
+        return fetch(`/api/presets/${encodeURIComponent(name)}`).then(r => {
+            if (!r.ok) return r.json().then(e => Promise.reject(e));
+            return r.json();
+        });
+    }
+
+    savePresetToServer(name, data) {
+        return fetch(`/api/presets/${encodeURIComponent(name)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ data })
+        }).then(r => r.json().then(body => r.ok ? body : Promise.reject(body)));
+    }
+
+    deletePresetOnServer(name) {
+        return fetch(`/api/presets/${encodeURIComponent(name)}`, { method: 'DELETE' })
+            .then(r => r.json().then(body => r.ok ? body : Promise.reject(body)));
+    }
+
+    // ── Preset Picker Modal (triggered by + Add Screen) ──
+    openPresetPicker() {
+        const modal = document.getElementById('preset-picker-modal');
+        const list = document.getElementById('preset-picker-list');
+        if (!modal || !list) return;
+        list.innerHTML = '<div style="padding: 12px; color: #888; font-size: 12px;">Loading…</div>';
+        modal.style.display = 'block';
+        this._presetPickerSelection = '__default__';
+        this.fetchPresetEntries().then(entries => {
+            list.innerHTML = '';
+            // Default row: describe current preferences so the user knows what they'll get
+            const prefs = this.getPreferences() || {};
+            const prefEntry = {
+                columns: prefs.columns,
+                rows: prefs.rows,
+                cabinet_width: prefs.panelWidth,
+                cabinet_height: prefs.panelHeight,
+                panel_width_mm: prefs.panelWidthMM,
+                panel_height_mm: prefs.panelHeightMM,
+                panelWatts: prefs.powerWatts
+            };
+            const rows = [
+                { key: '__default__', label: 'Default (from Preferences)', sublabel: this.formatPresetSublabel(prefEntry) }
+            ];
+            entries.forEach(entry => rows.push({
+                key: entry.name,
+                label: entry.name,
+                sublabel: this.formatPresetSublabel(entry)
+            }));
+            rows.forEach((row, idx) => {
+                const item = document.createElement('div');
+                item.className = 'preset-picker-row';
+                item.dataset.key = row.key;
+                item.style.cssText = 'padding: 10px 12px; border-radius: 4px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; gap: 8px;';
+                if (idx === 0) {
+                    item.style.background = '#2d4a7a';
+                }
+                const leftCol = document.createElement('div');
+                leftCol.innerHTML = `<div style="color:#fff; font-size:13px; font-weight:500;">${this.escapeHtml(row.label)}</div><div style="color:#888; font-size:11px;">${row.sublabel}</div>`;
+                item.appendChild(leftCol);
+                if (row.key !== '__default__') {
+                    const delBtn = document.createElement('button');
+                    delBtn.className = 'btn';
+                    delBtn.textContent = '🗑';
+                    delBtn.title = `Delete preset "${row.key}"`;
+                    delBtn.style.cssText = 'background: transparent; color: #c55; font-size: 14px; padding: 2px 8px; border: 1px solid #444;';
+                    delBtn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        if (!confirm(`Delete preset "${row.key}"?`)) return;
+                        this.deletePresetOnServer(row.key).then(() => {
+                            this.openPresetPicker();  // refresh
+                        }).catch(err => alert('Failed to delete preset: ' + (err && err.error || 'unknown')));
+                    });
+                    item.appendChild(delBtn);
+                }
+                item.addEventListener('click', () => {
+                    this._presetPickerSelection = row.key;
+                    list.querySelectorAll('.preset-picker-row').forEach(el => {
+                        el.style.background = el.dataset.key === row.key ? '#2d4a7a' : 'transparent';
+                    });
+                });
+                list.appendChild(item);
+            });
+        });
+    }
+
+    closePresetPicker() {
+        const modal = document.getElementById('preset-picker-modal');
+        if (modal) modal.style.display = 'none';
+    }
+
+    confirmPresetPicker() {
+        const selection = this._presetPickerSelection || '__default__';
+        this.closePresetPicker();
+        if (selection === '__default__') {
+            this.addLayer();
+            return;
+        }
+        this.fetchPreset(selection).then(resp => {
+            const data = resp && resp.data ? resp.data : null;
+            if (data) data._presetName = selection;
+            this.addLayer(data);
+        }).catch(err => {
+            alert('Failed to load preset: ' + (err && err.error || 'unknown'));
+            this.addLayer();  // fall back to default
+        });
+    }
+
+    // ── Save-as-Preset Modal ──
+    openPresetSaveModal() {
+        if (!this.currentLayer || (this.currentLayer.type || 'screen') !== 'screen') {
+            alert('Select a screen layer first to save as a preset.');
+            return;
+        }
+        const modal = document.getElementById('preset-save-modal');
+        const nameInput = document.getElementById('preset-save-name');
+        const warning = document.getElementById('preset-save-warning');
+        const sublabel = document.getElementById('preset-save-sublabel');
+        if (!modal || !nameInput) return;
+        nameInput.value = this.currentLayer.name || '';
+        warning.textContent = '';
+        if (sublabel) sublabel.textContent = `Saving settings from "${this.currentLayer.name || 'current layer'}".`;
+        modal.style.display = 'block';
+        setTimeout(() => nameInput.focus(), 50);
+        this._presetSaveExistingNames = null;
+        this.fetchPresetList().then(list => {
+            this._presetSaveExistingNames = list;
+            this.updatePresetSaveWarning();
+        });
+    }
+
+    closePresetSaveModal() {
+        const modal = document.getElementById('preset-save-modal');
+        if (modal) modal.style.display = 'none';
+    }
+
+    updatePresetSaveWarning() {
+        const nameInput = document.getElementById('preset-save-name');
+        const warning = document.getElementById('preset-save-warning');
+        if (!nameInput || !warning) return;
+        const name = nameInput.value.trim();
+        if (!name) {
+            warning.textContent = '';
+            return;
+        }
+        const existing = this._presetSaveExistingNames || [];
+        if (existing.includes(name)) {
+            warning.textContent = `⚠ A preset named "${name}" already exists. Saving will overwrite it.`;
+        } else {
+            warning.textContent = '';
+        }
+    }
+
+    confirmPresetSave() {
+        const nameInput = document.getElementById('preset-save-name');
+        const warning = document.getElementById('preset-save-warning');
+        if (!nameInput) return;
+        const name = nameInput.value.trim();
+        if (!name) {
+            warning.textContent = 'Please enter a name.';
+            return;
+        }
+        const existing = this._presetSaveExistingNames || [];
+        if (existing.includes(name)) {
+            if (!confirm(`A preset named "${name}" already exists. Overwrite it?`)) return;
+        }
+        const data = this.serializeLayerAsPreset(this.currentLayer);
+        if (!data) {
+            warning.textContent = 'No layer selected.';
+            return;
+        }
+        this.savePresetToServer(name, data).then(() => {
+            this.closePresetSaveModal();
+        }).catch(err => {
+            warning.textContent = 'Failed: ' + (err && err.error || 'unknown error');
+        });
+    }
+
+    setupPresetModals() {
+        const pickerCancel = document.getElementById('preset-picker-cancel');
+        const pickerAdd = document.getElementById('preset-picker-add');
+        if (pickerCancel) pickerCancel.addEventListener('click', () => this.closePresetPicker());
+        if (pickerAdd) pickerAdd.addEventListener('click', () => this.confirmPresetPicker());
+
+        const saveCancel = document.getElementById('preset-save-cancel');
+        const saveConfirm = document.getElementById('preset-save-confirm');
+        const saveName = document.getElementById('preset-save-name');
+        if (saveCancel) saveCancel.addEventListener('click', () => this.closePresetSaveModal());
+        if (saveConfirm) saveConfirm.addEventListener('click', () => this.confirmPresetSave());
+        if (saveName) {
+            saveName.addEventListener('input', () => this.updatePresetSaveWarning());
+            saveName.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') this.confirmPresetSave();
+                else if (e.key === 'Escape') this.closePresetSaveModal();
+            });
+        }
+        // Close modals on backdrop click
+        ['preset-picker-modal', 'preset-save-modal'].forEach(id => {
+            const m = document.getElementById(id);
+            if (m) {
+                m.addEventListener('click', (e) => {
+                    if (e.target === m) m.style.display = 'none';
+                });
+            }
+        });
+    }
+
+    escapeHtml(s) {
+        if (s == null) return '';
+        return String(s).replace(/[&<>"']/g, ch => (
+            { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]
+        ));
     }
 
     addImageLayer(imageData, imageWidth, imageHeight) {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.19</title>
+    <title>LED Raster Designer v0.7.4.20</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -73,7 +73,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.19</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.20</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">
@@ -1201,7 +1201,8 @@
                         <button id="btn-layer-up" class="btn btn-secondary" data-tooltip="Move selected layer up in draw order">▲ Up</button>
                         <button id="btn-layer-down" class="btn btn-secondary" data-tooltip="Move selected layer down in draw order">▼ Down</button>
                     </div>
-                    <button id="btn-add-layer" class="btn btn-primary full-width" data-tooltip="Add a new LED screen layer">+ Add Screen</button>
+                    <button id="btn-add-layer" class="btn btn-primary full-width" data-tooltip="Add a new LED screen layer — pick from saved presets or use default preferences">+ Add Screen</button>
+                    <button id="btn-save-preset" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Save the currently selected layer's settings as a reusable preset">💾 Save as Preset</button>
                     <button id="btn-add-image" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add an image or logo layer">+ Add Image/Logo</button>
                     <button id="btn-add-text" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add a text label layer">+ Add Text Label</button>
                 </div>
@@ -1527,6 +1528,33 @@
     </div>
 
     <!-- About Modal -->
+    <div id="preset-picker-modal" class="modal" style="display: none;">
+        <div class="modal-content" style="background: #252525; border-radius: 8px; padding: 24px; max-width: 480px; margin: 80px auto; border: 1px solid #3a3a3a;">
+            <h2 style="margin-top: 0; color: #fff; margin-bottom: 4px; font-size: 18px;">Add Screen — Choose Preset</h2>
+            <div style="color: #888; font-size: 12px; margin-bottom: 16px;">Pick a saved preset or use your default preferences.</div>
+            <div id="preset-picker-list" style="max-height: 320px; overflow-y: auto; border: 1px solid #333; border-radius: 4px; background: #1a1a1a; padding: 4px; margin-bottom: 16px;"></div>
+            <div style="display: flex; justify-content: flex-end; gap: 8px;">
+                <button id="preset-picker-cancel" class="btn" style="background: #3a3a3a; padding: 8px 16px;">Cancel</button>
+                <button id="preset-picker-add" class="btn btn-primary" style="padding: 8px 16px;">Add Screen</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="preset-save-modal" class="modal" style="display: none;">
+        <div class="modal-content" style="background: #252525; border-radius: 8px; padding: 24px; max-width: 420px; margin: 120px auto; border: 1px solid #3a3a3a;">
+            <h2 style="margin-top: 0; color: #fff; margin-bottom: 4px; font-size: 18px;">Save Layer as Preset</h2>
+            <div id="preset-save-sublabel" style="color: #888; font-size: 12px; margin-bottom: 12px;">Save the current layer's settings for reuse.</div>
+            <label style="color: #ccc; font-size: 12px; display: block; margin-bottom: 4px;">Preset name</label>
+            <input id="preset-save-name" type="text" maxlength="80" placeholder="e.g., Standard SRR Pillar"
+                   style="width: 100%; padding: 8px; background: #1a1a1a; border: 1px solid #333; border-radius: 4px; color: #fff; font-size: 13px; box-sizing: border-box; margin-bottom: 8px;">
+            <div id="preset-save-warning" style="color: #f0ad4e; font-size: 12px; min-height: 18px; margin-bottom: 12px;"></div>
+            <div style="display: flex; justify-content: flex-end; gap: 8px;">
+                <button id="preset-save-cancel" class="btn" style="background: #3a3a3a; padding: 8px 16px;">Cancel</button>
+                <button id="preset-save-confirm" class="btn btn-primary" style="padding: 8px 16px;">Save</button>
+            </div>
+        </div>
+    </div>
+
     <div id="about-modal" class="modal" style="display: none;">
         <div class="modal-content" style="background: #252525; border-radius: 8px; padding: 32px; max-width: 420px; margin: 80px auto; border: 1px solid #3a3a3a; text-align: center;">
             <h2 style="margin-top: 0; color: #fff; margin-bottom: 4px; font-size: 20px;">LED Raster Designer</h2>


### PR DESCRIPTION
## Summary
- New **Screen Layer Presets** feature: save the current layer's settings as a named preset, then pick from saved presets when adding new screens
- Presets are stored server-side in `<app>/presets/*.json` and shared across clients via Socket.IO
- `+ Add Screen` opens a picker modal showing each preset's dimensions (columns × rows), cabinet pixel size, panel mm size, and watts/panel
- `💾 Save as Preset` button captures ~90 layer properties (colors, data flow, power, labels, etc.) — excludes identity, position, panels array, and runtime caches
- Duplicate-name warning with overwrite confirm; per-row delete button in the picker

## Backend
- 4 new endpoints: `GET /api/presets` (list with summaries), `GET /api/presets/<name>`, `PUT /api/presets/<name>`, `DELETE /api/presets/<name>`
- Filename sanitization: blocks `/`, `\`, `..`, control chars, empty/oversized names
- Broadcasts `presets_updated` over Socket.IO on save/delete

## Test plan
- [ ] Click `+ Add Screen` — picker modal opens with Default + saved presets
- [ ] Each row shows sublabel: `8×5 • 128×128px • 500×500mm • 200W/panel`
- [ ] Select preset, click Add Screen — new layer inherits all preset settings
- [ ] Click `💾 Save as Preset` — modal prefills with current layer name
- [ ] Typing an existing preset name shows orange overwrite warning live
- [ ] Saving existing name prompts confirm before overwriting
- [ ] Delete button on a preset row asks for confirmation, then removes it
- [ ] Preset data survives server restart (files persist to disk)