### PR TITLE
Stale info label fix + Help>Show Logs viewer (v0.7.4.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.20
+# LED Raster Designer v0.7.4.21
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,18 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.21 - April 22, 2026
+----------------------------
+- FIX: Info labels (Data tab's "X Mains, Y Backups | Z Ports" and Power tab's
+  "X Multi, Y Circuits | A 1φ / B 3φ") now update immediately when you change
+  a setting on multiple selected screens. Previously the cached port/circuit
+  counts were only refreshed for the currently selected layer's side panel,
+  so other selected screens kept stale labels until clicked.
+- NEW: Help → Show Logs… Opens an in-app viewer for the application log.
+  Features: adjustable line count (250/500/1000/5000/20000), auto-refresh
+  every 2s, wrap-lines toggle, Copy button, Open Folder (reveals in Finder/
+  Explorer), and Clear Logs (truncates current log, preserves archives).
+
 v0.7.4.20 - April 16, 2026
 ----------------------------
 - NEW: Screen Layer Presets. Save the currently selected layer's settings as

--- a/src/app.py
+++ b/src/app.py
@@ -621,6 +621,87 @@ def delete_preset(name):
     socketio.emit('presets_updated')
     return jsonify({'status': 'success'})
 
+# ── Logs (in-app viewer) ──
+@app.route('/api/logs', methods=['GET'])
+def get_logs():
+    """Return last N lines of the current log file (most recent at bottom)."""
+    try:
+        lines_arg = int(request.args.get('lines', '500'))
+    except ValueError:
+        lines_arg = 500
+    lines_arg = max(50, min(lines_arg, 20000))
+    result_lines = []
+    file_size = 0
+    try:
+        if os.path.isfile(LOG_FILE_PATH):
+            file_size = os.path.getsize(LOG_FILE_PATH)
+            tail_bytes = b''
+            chunk_size = 0
+            # Read up to 4 MB from the end (plenty for ~20k lines)
+            max_chunk = 4 * 1024 * 1024
+            try:
+                with open(LOG_FILE_PATH, 'rb') as f:
+                    f.seek(0, os.SEEK_END)
+                    pos = f.tell()
+                    chunk_size = min(pos, max_chunk)
+                    f.seek(pos - chunk_size, os.SEEK_SET)
+                    tail_bytes = f.read()
+            except OSError:
+                pass
+            text = tail_bytes.decode('utf-8', errors='replace')
+            # Drop a partial first line if we didn't read from byte 0
+            if 0 < chunk_size < file_size and text:
+                nl = text.find('\n')
+                if nl != -1:
+                    text = text[nl + 1:]
+            all_lines = text.splitlines()
+            result_lines = all_lines[-lines_arg:]
+    except OSError:
+        pass
+    # Count archived log files in the same directory
+    archive_count = 0
+    try:
+        for fname in os.listdir(LOG_DIR_PATH):
+            if fname.startswith('led_raster_designer_') and fname.endswith('.log'):
+                archive_count += 1
+    except OSError:
+        pass
+    return jsonify({
+        'lines': result_lines,
+        'file_size_bytes': file_size,
+        'file_path': LOG_FILE_PATH,
+        'dir_path': LOG_DIR_PATH,
+        'archive_count': archive_count,
+        'returned_count': len(result_lines)
+    })
+
+@app.route('/api/logs', methods=['DELETE'])
+def clear_logs():
+    """Truncate the active log file. Archived (rotated) logs are preserved."""
+    try:
+        os.makedirs(LOG_DIR_PATH, exist_ok=True)
+        with open(LOG_FILE_PATH, 'w', encoding='utf-8') as f:
+            f.write('')
+    except OSError as e:
+        return jsonify({'error': f'Failed to clear logs: {e}'}), 500
+    log_event('clear_logs')
+    return jsonify({'status': 'success'})
+
+@app.route('/api/logs/reveal', methods=['POST'])
+def reveal_logs_folder():
+    """Open the logs directory in the OS file manager (Finder / Explorer / xdg-open)."""
+    try:
+        os.makedirs(LOG_DIR_PATH, exist_ok=True)
+        if sys.platform == 'darwin':
+            subprocess.Popen(['open', LOG_DIR_PATH])
+        elif sys.platform == 'win32':
+            os.startfile(LOG_DIR_PATH)  # type: ignore[attr-defined]
+        else:
+            subprocess.Popen(['xdg-open', LOG_DIR_PATH])
+    except Exception as e:
+        return jsonify({'error': f'Failed to open logs folder: {e}'}), 500
+    return jsonify({'status': 'success', 'path': LOG_DIR_PATH})
+
 @app.route('/api/project/new', methods=['POST'])
 def new_project():
     global current_project, next_layer_id

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.20',
-            'CFBundleVersion': '0.7.4.20',
+            'CFBundleShortVersionString': '0.7.4.21',
+            'CFBundleVersion': '0.7.4.21',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7184,6 +7184,9 @@ class LEDRasterApp {
             case 'keyboard-shortcuts':
                 this.openShortcutsModal();
                 break;
+            case 'show-logs':
+                this.openLogsModal();
+                break;
             case 'about':
                 this.openAboutModal();
                 break;
@@ -7227,6 +7230,158 @@ class LEDRasterApp {
         modal.onclick = function(e) {
             if (e.target === modal) modal.style.display = 'none';
         };
+    }
+
+    // ── Logs Viewer (Help → Show Logs…) ──
+    openLogsModal() {
+        const modal = document.getElementById('logs-modal');
+        if (!modal) return;
+        modal.style.display = 'block';
+        this._ensureLogsModalWired();
+        this._logsUserScrolledUp = false;
+        this.refreshLogs(true);
+    }
+
+    closeLogsModal() {
+        const modal = document.getElementById('logs-modal');
+        if (modal) modal.style.display = 'none';
+        this._stopLogsAutoRefresh();
+    }
+
+    _ensureLogsModalWired() {
+        if (this._logsModalWired) return;
+        this._logsModalWired = true;
+        const modal = document.getElementById('logs-modal');
+        const closeBtn = document.getElementById('logs-close');
+        const refreshBtn = document.getElementById('logs-refresh');
+        const copyBtn = document.getElementById('logs-copy');
+        const revealBtn = document.getElementById('logs-reveal');
+        const clearBtn = document.getElementById('logs-clear');
+        const linesSel = document.getElementById('logs-lines');
+        const autoCb = document.getElementById('logs-autorefresh');
+        const wrapCb = document.getElementById('logs-wrap');
+        const pre = document.getElementById('logs-content');
+
+        if (closeBtn) closeBtn.addEventListener('click', () => this.closeLogsModal());
+        if (refreshBtn) refreshBtn.addEventListener('click', () => this.refreshLogs(true));
+        if (copyBtn) copyBtn.addEventListener('click', () => this.copyLogs());
+        if (revealBtn) revealBtn.addEventListener('click', () => this.revealLogsFolder());
+        if (clearBtn) clearBtn.addEventListener('click', () => this.clearLogs());
+        if (linesSel) linesSel.addEventListener('change', () => this.refreshLogs(true));
+        if (autoCb) autoCb.addEventListener('change', () => {
+            if (autoCb.checked) this._startLogsAutoRefresh();
+            else this._stopLogsAutoRefresh();
+        });
+        if (wrapCb && pre) {
+            wrapCb.addEventListener('change', () => {
+                pre.style.whiteSpace = wrapCb.checked ? 'pre-wrap' : 'pre';
+            });
+        }
+        if (pre) {
+            pre.addEventListener('scroll', () => {
+                // If user scrolls away from the bottom, stop auto-scrolling on refresh
+                const atBottom = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 16;
+                this._logsUserScrolledUp = !atBottom;
+            });
+        }
+        if (modal) {
+            modal.addEventListener('click', (e) => {
+                if (e.target === modal) this.closeLogsModal();
+            });
+        }
+    }
+
+    _startLogsAutoRefresh() {
+        this._stopLogsAutoRefresh();
+        this._logsAutoInterval = setInterval(() => this.refreshLogs(false), 2000);
+    }
+
+    _stopLogsAutoRefresh() {
+        if (this._logsAutoInterval) {
+            clearInterval(this._logsAutoInterval);
+            this._logsAutoInterval = null;
+        }
+    }
+
+    refreshLogs(force) {
+        const linesSel = document.getElementById('logs-lines');
+        const lines = linesSel ? parseInt(linesSel.value, 10) || 500 : 500;
+        fetch(`/api/logs?lines=${lines}`)
+            .then(r => r.json())
+            .then(data => this._renderLogs(data, force))
+            .catch(err => this._renderLogsError(err));
+    }
+
+    _renderLogs(data, force) {
+        const pre = document.getElementById('logs-content');
+        const meta = document.getElementById('logs-meta');
+        if (!pre) return;
+        const linesArr = Array.isArray(data.lines) ? data.lines : [];
+        pre.textContent = linesArr.join('\n');
+        if (meta) {
+            const sizeKB = (data.file_size_bytes || 0) / 1024;
+            const sizeStr = sizeKB >= 1024
+                ? `${(sizeKB / 1024).toFixed(1)} MB`
+                : `${sizeKB.toFixed(1)} KB`;
+            const archives = data.archive_count || 0;
+            const archiveStr = archives > 0 ? ` · ${archives} archived` : '';
+            meta.textContent = `${linesArr.length} lines shown · ${sizeStr}${archiveStr}`;
+        }
+        // Auto-scroll to bottom unless the user scrolled up
+        if (force || !this._logsUserScrolledUp) {
+            pre.scrollTop = pre.scrollHeight;
+            this._logsUserScrolledUp = false;
+        }
+    }
+
+    _renderLogsError(err) {
+        const pre = document.getElementById('logs-content');
+        if (pre) pre.textContent = `Failed to load logs: ${err && err.message || err}`;
+    }
+
+    copyLogs() {
+        const pre = document.getElementById('logs-content');
+        if (!pre) return;
+        const text = pre.textContent || '';
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(() => this._flashCopyButton());
+        } else {
+            // Fallback: temporary textarea
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+            document.body.removeChild(ta);
+            this._flashCopyButton();
+        }
+    }
+
+    _flashCopyButton() {
+        const btn = document.getElementById('logs-copy');
+        if (!btn) return;
+        const orig = btn.textContent;
+        btn.textContent = 'Copied ✓';
+        setTimeout(() => { btn.textContent = orig; }, 1200);
+    }
+
+    revealLogsFolder() {
+        fetch('/api/logs/reveal', { method: 'POST' })
+            .then(r => {
+                if (!r.ok) return r.json().then(e => Promise.reject(e));
+            })
+            .catch(err => alert('Failed to open logs folder: ' + (err && err.error || 'unknown')));
+    }
+
+    clearLogs() {
+        if (!confirm('Clear the current log file? Archived (rotated) logs will be preserved.')) return;
+        fetch('/api/logs', { method: 'DELETE' })
+            .then(r => {
+                if (!r.ok) return r.json().then(e => Promise.reject(e));
+                return r.json();
+            })
+            .then(() => this.refreshLogs(true))
+            .catch(err => alert('Failed to clear logs: ' + (err && err.error || 'unknown')));
     }
 
     // ── Recent Files ──────────────────────────────────────────────

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -2622,16 +2622,28 @@ class CanvasRenderer {
                 centerLines.push(`Weight ${totalWeightKg.toFixed(1)} kg / ${totalWeightLb.toFixed(1)} lb`);
             }
         } else if (this.viewMode === 'data-flow') {
-            if (layer.showDataFlowPortInfo) {
-                let portsRequired = layer._portsRequired || 0;
-                // Fallback: recalculate if not yet computed (e.g. right after file load)
-                if (portsRequired <= 0 && window.app && typeof window.app.calculatePortAssignments === 'function') {
-                    const assignments = window.app.calculatePortAssignments(layer);
-                    if (Array.isArray(assignments)) {
-                        portsRequired = assignments.reduce((max, a) => Math.max(max, a.port || 0), 0);
-                    }
-                    if (portsRequired <= 0 && layer._autoPortsRequired) {
-                        portsRequired = layer._autoPortsRequired;
+            if (layer.showDataFlowPortInfo && window.app) {
+                // Always recompute from current layer state. Cached `_portsRequired`
+                // is only refreshed for the currently-selected layer by
+                // `updatePortCapacityDisplay`, so other layers' labels would go
+                // stale until clicked. `renderDataFlowArrows` ran just above and
+                // populated fresh `_autoPortsRequired` on this layer.
+                let portsRequired = 0;
+                const isCustom = typeof window.app.isCustomFlow === 'function'
+                    ? window.app.isCustomFlow(layer)
+                    : (layer.flowPattern === 'custom');
+                if (isCustom && layer.customPortPaths) {
+                    const customPorts = Object.keys(layer.customPortPaths)
+                        .map(p => parseInt(p, 10))
+                        .filter(p => (layer.customPortPaths[p] || []).length > 0);
+                    portsRequired = customPorts.length > 0
+                        ? Math.max(...customPorts)
+                        : (layer._autoPortsRequired || layer.customPortIndex || 0);
+                } else {
+                    portsRequired = layer._autoPortsRequired || 0;
+                    if (portsRequired <= 0 && typeof window.app.calculatePortAssignments === 'function') {
+                        window.app.calculatePortAssignments(layer);
+                        portsRequired = layer._autoPortsRequired || 0;
                     }
                 }
                 if (portsRequired > 0) {
@@ -2641,14 +2653,18 @@ class CanvasRenderer {
                 }
             }
         } else if (this.viewMode === 'power') {
-            if (layer.showPowerCircuitInfo) {
-                let circuits = Number(layer._powerCircuitsRequired) || 0;
-                if (circuits <= 0 && Array.isArray(layer._powerCircuits)) {
-                    circuits = layer._powerCircuits.filter(c => Array.isArray(c) && c.length > 0).length;
-                }
-                if (circuits <= 0 && window.app && typeof window.app.calculatePowerAssignments === 'function') {
+            if (layer.showPowerCircuitInfo && window.app) {
+                // Always recompute from current layer state. `renderPowerArrows`
+                // (or `preparePowerLayerRenderData`) ran just above and populated
+                // `_powerCircuits` on this layer, so use that directly rather
+                // than trusting `_powerCircuitsRequired` (only refreshed for
+                // the currently-selected layer by `updatePowerStatsDisplay`).
+                let circuits = Array.isArray(layer._powerCircuits)
+                    ? layer._powerCircuits.filter(c => Array.isArray(c) && c.length > 0).length
+                    : 0;
+                if (circuits <= 0 && typeof window.app.calculatePowerAssignments === 'function') {
                     const assignments = window.app.calculatePowerAssignments(layer);
-                    if (!assignments.error && Array.isArray(assignments.circuits)) {
+                    if (assignments && !assignments.error && Array.isArray(assignments.circuits)) {
                         circuits = assignments.circuits.filter(c => Array.isArray(c) && c.length > 0).length;
                     }
                 }
@@ -2658,15 +2674,15 @@ class CanvasRenderer {
                     ? layer.panels
                         .filter(p => !p.hidden)
                         .reduce((sum, p) => {
-                            if (window.app && typeof window.app.getPanelLoadFactor === 'function') {
+                            if (typeof window.app.getPanelLoadFactor === 'function') {
                                 return sum + window.app.getPanelLoadFactor(layer, p);
                             }
                             return sum + 1;
                         }, 0)
                     : 0;
                 const totalWatts = panelWatts * equivalentPanels;
-                const amps1 = voltage > 0 ? (totalWatts / voltage) : (Number(layer._powerTotalAmps1) || 0);
-                const amps3 = voltage > 0 ? (totalWatts / (voltage * 1.73)) : (Number(layer._powerTotalAmps3) || 0);
+                const amps1 = voltage > 0 ? (totalWatts / voltage) : 0;
+                const amps3 = voltage > 0 ? (totalWatts / (voltage * 1.73)) : 0;
                 const multis = circuits > 0 ? Math.ceil(circuits / 6) : 0;
                 centerLines.push(`${multis} Multi, ${circuits} Circuits | ${amps1.toFixed(2)}A 1φ / ${amps3.toFixed(2)}A 3φ`);
             }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.20</title>
+    <title>LED Raster Designer v0.7.4.21</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -53,6 +53,7 @@
 
         <div id="menu-help" class="menu-dropdown">
             <div class="menu-option" data-action="keyboard-shortcuts" data-label="Keyboard Shortcuts"></div>
+            <div class="menu-option" data-action="show-logs" data-label="Show Logs…"></div>
             <div class="menu-option" data-action="check-updates" data-label="Check for Updates…"></div>
             <div class="menu-divider"></div>
             <div class="menu-option" data-action="about" data-label="About LED Raster Designer"></div>
@@ -73,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.20</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.21</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">
@@ -1551,6 +1552,44 @@
             <div style="display: flex; justify-content: flex-end; gap: 8px;">
                 <button id="preset-save-cancel" class="btn" style="background: #3a3a3a; padding: 8px 16px;">Cancel</button>
                 <button id="preset-save-confirm" class="btn btn-primary" style="padding: 8px 16px;">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="logs-modal" class="modal" style="display: none;">
+        <div class="modal-content" style="background: #252525; border-radius: 8px; padding: 20px; max-width: 960px; width: 90%; margin: 40px auto; border: 1px solid #3a3a3a; display: flex; flex-direction: column; max-height: calc(100vh - 80px);">
+            <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px;">
+                <h2 style="margin: 0; color: #fff; font-size: 18px;">Application Logs</h2>
+                <div id="logs-meta" style="color: #888; font-size: 12px;"></div>
+            </div>
+            <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 10px; flex-wrap: wrap;">
+                <label style="color: #ccc; font-size: 12px;">Lines:
+                    <select id="logs-lines" style="background: #1a1a1a; border: 1px solid #333; color: #fff; padding: 4px; border-radius: 4px; margin-left: 4px;">
+                        <option value="250">250</option>
+                        <option value="500" selected>500</option>
+                        <option value="1000">1000</option>
+                        <option value="5000">5000</option>
+                        <option value="20000">20000 (max)</option>
+                    </select>
+                </label>
+                <label style="color: #ccc; font-size: 12px; display: inline-flex; align-items: center; gap: 6px;">
+                    <input id="logs-autorefresh" type="checkbox">
+                    Auto-refresh (2s)
+                </label>
+                <label style="color: #ccc; font-size: 12px; display: inline-flex; align-items: center; gap: 6px;">
+                    <input id="logs-wrap" type="checkbox">
+                    Wrap lines
+                </label>
+                <button id="logs-refresh" class="btn" style="background: #3a3a3a; padding: 4px 12px; font-size: 12px;">Refresh</button>
+            </div>
+            <pre id="logs-content" style="flex: 1; min-height: 360px; background: #0d0d0d; border: 1px solid #333; border-radius: 4px; padding: 10px; color: #ddd; font-family: Menlo, Consolas, monospace; font-size: 11px; overflow: auto; white-space: pre; margin: 0;"></pre>
+            <div style="display: flex; justify-content: space-between; gap: 8px; margin-top: 12px; flex-wrap: wrap;">
+                <div style="display: flex; gap: 8px;">
+                    <button id="logs-copy" class="btn" style="background: #3a3a3a; padding: 6px 14px;">Copy</button>
+                    <button id="logs-reveal" class="btn" style="background: #3a3a3a; padding: 6px 14px;">Open Folder</button>
+                    <button id="logs-clear" class="btn" style="background: #552020; padding: 6px 14px; color: #fff;">Clear Logs</button>
+                </div>
+                <button id="logs-close" class="btn" style="background: #3a3a3a; padding: 6px 16px;">Close</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- **Bug fix:** Info labels on the Data and Power tabs now update immediately when a setting is changed on multiple selected screens. Previously, cached `_portsRequired` / `_powerCircuitsRequired` only got refreshed for the currently selected layer's side panel, so other selected screens kept showing stale numbers until clicked.
- **New feature:** Help → Show Logs… — in-app log viewer with adjustable tail length, auto-refresh, wrap toggle, copy-to-clipboard, "Open Folder" (reveals in Finder/Explorer), and Clear Logs (truncates current log, preserves rotated archives).

## Details
**Stale cache fix (canvas.js)** — `renderLayerLabels` now reads from `_autoPortsRequired` (set fresh by `renderDataFlowArrows` for every rendered layer on every frame) and from `_powerCircuits` (set fresh by `preparePowerLayerRenderData`). Those arrays are always current for any visible layer, unlike `_portsRequired` / `_powerCircuitsRequired` which only update via the side-panel code path for the current layer.

**Logs viewer (app.py + index.html + app.js)** — three new endpoints: `GET /api/logs?lines=N`, `DELETE /api/logs`, `POST /api/logs/reveal`. Frontend modal reads tail efficiently by seeking from the end of the file (max 4 MB read).

## Test plan
- [ ] Data tab: box-select 3 screens, change bit-depth — info label on all 3 updates instantly
- [ ] Power tab: box-select 3 screens, change voltage/amperage/panelWatts — info label on all 3 updates instantly
- [ ] Help → Show Logs: modal opens, shows tail of log
- [ ] Toggle Auto-refresh — new entries appear every 2s
- [ ] Toggle Wrap lines — long lines wrap
- [ ] Change lines dropdown (250/500/1000/5000/20000)
- [ ] Copy — clipboard receives log text, button flashes "Copied ✓"
- [ ] Open Folder — OS file manager opens logs directory
- [ ] Clear Logs — confirm dialog, log truncates to 1 line (the `clear_logs` event itself), archived `.log` files untouched