### PR TITLE
⭐ verified marker recognizes ROE/dealer sources (v0.7.4.27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.26
+# LED Raster Designer v0.7.4.27
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,16 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.27 - April 25, 2026
+----------------------------
+- FIX: ⭐ verified marker now correctly recognizes ROE panels sourced
+  from roevisual.com (brochures + PDFs) and authoritative dealer
+  datasheets (ledwallcentral, xled.pro). Verified panel count jumped
+  from ~28 to 75 — primarily 50 ROE models (Carbon, Topaz, Vanish,
+  Black Pearl/Onyx, Ruby, Graphite, etc.) plus existing Absen / INFiLED
+  / UniLumin / Gloshine entries. Entries flagged as "estimated" or
+  "derived" are still excluded.
+
 v0.7.4.26 - April 25, 2026
 ----------------------------
 - NEW: Add Screen modal redesigned. Picking a panel from the built-in

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.26',
-            'CFBundleVersion': '0.7.4.26',
+            'CFBundleShortVersionString': '0.7.4.27',
+            'CFBundleVersion': '0.7.4.27',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -3834,11 +3834,22 @@ class LEDRasterApp {
     _isPanelVerified(p) {
         const s = (p && p.source || '').toLowerCase();
         if (!s) return false;
-        // Cross-checked against the manufacturer's own published spec sheet
+        // Anti-patterns: any entry whose specs were inferred rather than read
+        // off a real spec sheet/PDF/website is not verified, even if the
+        // source string mentions an authoritative site.
+        if (/\b(est|estimated|derived|same as|inferred|approx)\b/.test(s)) return false;
+        if (/\+\s*(frame|air frame|t4|ladder|windbrace|spotlight)/.test(s)) return false;
+        // Trusted sources — manufacturer's own site / PDF, or a reputable
+        // third-party dealer that publishes the full datasheet.
         if (s.startsWith('official:')) return true;
+        if (s.startsWith('roevisual')) return true;          // roevisual.com (ROE)
+        if (s.startsWith('absen ')) return true;             // absen JP / VN spec PDFs
+        if (s.startsWith('ledwallcentral')) return true;     // dealer with full datasheets
+        if (s.startsWith('xled.pro')) return true;           // dealer datasheet
         if (s.includes('spec pdf')) return true;
-        // Legacy entries that pre-dated the "official:" prefix
-        if (s.includes('absen ') && s.includes('pdf')) return true;
+        if (s.includes('-specification.pdf')) return true;
+        if (s.includes('brochure')) return true;             // any "...brochure" reference
+        if (s.includes('per brochure')) return true;
         return false;
     }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.26</title>
+    <title>LED Raster Designer v0.7.4.27</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.26</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.27</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">


### PR DESCRIPTION
## Summary
Tiny fix-up to the ⭐ verified marker introduced in v0.7.4.26. The check was only matching Absen and INFiLED-style source strings, so ROE panels sourced from roevisual.com brochures/PDFs (which were already in the catalog from earlier research) weren't getting the star.

After this PR: **75 panels marked verified** (was 28) — including 50 ROE models across the Carbon, Topaz, Vanish, Black Pearl/Onyx, Ruby, and Graphite series. Entries flagged "estimated" or "derived" are still excluded.

## Test plan
- [ ] Open Add Screen modal, filter by ROE — most entries show ⭐
- [ ] Topaz/Carbon entries with "derived from..." source still show no ⭐
- [ ] No regression in other manufacturers' verified counts