### PR TITLE
Fix label-size clobber on multi-select + Node 24 actions (v0.7.4.29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
             "led_raster_designer_v${VERSION}_macos.zip"
 
       - name: Upload macOS artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: macos-build
           path: led_raster_designer_v*_macos.zip
@@ -178,7 +178,7 @@ jobs:
             -DestinationPath "led_raster_designer_v${version}_windows.zip"
 
       - name: Upload Windows artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: windows-build
           path: led_raster_designer_v*_windows.zip
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -208,7 +208,7 @@ jobs:
           cat checksums.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "LED Raster Designer ${{ github.ref_name }}"
           draft: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.28
+# LED Raster Designer v0.7.4.29
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,21 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.29 - April 28, 2026
+----------------------------
+- FIX: Toggling Offset TL/TR/BL/BR (or any other property checkbox) with
+  multiple screens selected was clobbering each layer's "Labels Font Size"
+  and "Info Label Size" to null whenever the selected layers had mixed
+  values for those fields. The shared input shows blank for mixed values,
+  parseInt('') returns NaN, and the NaN guard slipped past the null check
+  — so every selected layer ended up with labelsFontSize=null. Switched
+  both inputs to use the same readNumber() helper the other numeric
+  fields in this code path already use, which correctly returns null for
+  blank/NaN reads and skips the apply.
+- INTERNAL: Bumped GitHub Actions to Node.js 24-compatible majors —
+  upload-artifact v6→v7, download-artifact v6→v8, action-gh-release v2→v3
+  (resolves the deprecation warning surfaced on PR #34).
+
 v0.7.4.28 - April 25, 2026
 ----------------------------
 - NEW: "Found bad specs? Submit a correction →" link in the panel

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.28',
-            'CFBundleVersion': '0.7.4.28',
+            'CFBundleShortVersionString': '0.7.4.29',
+            'CFBundleVersion': '0.7.4.29',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5618,9 +5618,12 @@ class LEDRasterApp {
         const showLabelInfoVal = showLabelInfoEl && !showLabelInfoEl.indeterminate ? showLabelInfoEl.checked : null;
         const showLabelWeightVal = showLabelWeightEl && !showLabelWeightEl.indeterminate ? showLabelWeightEl.checked : null;
         const labelsColorVal = labelsColorEl ? labelsColorEl.value : null;
-        const labelsFontSizeVal = labelsFontSizeEl ? parseInt(labelsFontSizeEl.value) : null;
-        const infoLabelSizeEl = document.getElementById('info-label-size');
-        const infoLabelSizeVal = infoLabelSizeEl ? parseInt(infoLabelSizeEl.value, 10) : null;
+        // Use readNumber() so blank/NaN reads come back as null and are skipped
+        // by the `!== null` guard below. Without this, multi-select with mixed
+        // values shows an empty input, parseInt('') = NaN, and every selected
+        // layer's labelsFontSize gets clobbered to NaN → null on the server.
+        const labelsFontSizeVal = readNumber('labels-fontsize').value;
+        const infoLabelSizeVal = readNumber('info-label-size').value;
         const useFractionalInchesVal = useFractionalInchesEl && !useFractionalInchesEl.indeterminate ? useFractionalInchesEl.checked : null;
         
         // Per-layer offset settings

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.28</title>
+    <title>LED Raster Designer v0.7.4.29</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.28</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.29</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">


### PR DESCRIPTION
## Summary
- **Bug fix:** toggling any property checkbox (e.g. Offset TL) while multiple screens are selected with mixed Labels Font Size values was nulling every selected layer's labelsFontSize / infoLabelSize. Root cause: parseInt('') = NaN, and NaN passed the null guard before being applied.
- **CI hygiene:** bumped three GitHub Actions to Node 24-compatible majors (upload-artifact v6→v7, download-artifact v6→v8, action-gh-release v2→v3) — resolves the deprecation warning on PR #34.

## Repro for the bug fix
1. Make 2+ screens with different Labels Font Size values
2. Multi-select them (drag-box)
3. Toggle any property checkbox (e.g. Offset TL)
4. **Before:** all selected screens lose their Labels Font Size value
5. **After:** font sizes preserved