### PR TITLE
Fix port/circuit rename sidebar empty on first layer-click (v0.7.4.30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.29
+# LED Raster Designer v0.7.4.30
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,15 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.30 - April 28, 2026
+----------------------------
+- FIX: In Data Flow and Power views, clicking a different screen left the
+  port-rename / circuit-rename sidebar empty until you clicked a second
+  time. selectLayer() updated the canvas and the right-hand inputs but
+  never re-populated the left-side label editor; the editor only refreshed
+  the next time something else nudged it. Now it's repainted in lockstep
+  with the layer change.
+
 v0.7.4.29 - April 28, 2026
 ----------------------------
 - FIX: Toggling Offset TL/TR/BL/BR (or any other property checkbox) with

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.29',
-            'CFBundleVersion': '0.7.4.29',
+            'CFBundleShortVersionString': '0.7.4.30',
+            'CFBundleVersion': '0.7.4.30',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5123,10 +5123,21 @@ class LEDRasterApp {
             arrowColor: this.currentLayer.arrowColor,
             dataFlowLabelSize: this.currentLayer.dataFlowLabelSize
         });
-        
+
         this.renderLayers();
         this.loadLayerToInputs();
         this.loadTextLayerToInputs();
+        // Repopulate the active view's per-layer label editor so the port-rename
+        // (data-flow view) or circuit-rename (power view) sidebar reflects the
+        // newly selected layer immediately. Without this, the editor only
+        // refreshed the next time something else nudged it — which made the
+        // first click after a layer-change appear empty until a second click.
+        const viewMode = window.canvasRenderer && window.canvasRenderer.viewMode;
+        if (viewMode === 'data-flow') {
+            this.updatePortLabelEditor();
+        } else if (viewMode === 'power') {
+            this.updatePowerLabelEditor();
+        }
         window.canvasRenderer.render();
     }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.29</title>
+    <title>LED Raster Designer v0.7.4.30</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.29</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.30</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">


### PR DESCRIPTION
## Bug
In Data Flow and Power views, clicking a different screen left the port-rename / circuit-rename sidebar empty until you clicked a second time.

## Cause
`selectLayer()` updated the canvas + the right-hand inputs but never re-populated the left-side label editor. The editor only refreshed the next time something else triggered it (typing, switching views, opening a modal).

## Fix
At the end of `selectLayer()`, call `updatePortLabelEditor()` in data-flow view and `updatePowerLabelEditor()` in power view, so the editor reflects the new layer on the first click.

## Test
- [ ] Open a project with multiple screens, switch to Data Flow tab
- [ ] Click screen A — port rename inputs show A's overrides immediately
- [ ] Click screen B — port rename inputs flip to B's overrides on the first click
- [ ] Same in Power view for circuit rename