### PR TITLE
v0.7.4.32 — undo + power label fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.31
+# LED Raster Designer v0.7.4.32
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.30
+# LED Raster Designer v0.7.4.31
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,16 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.31 - April 27, 2026
+----------------------------
+- FIX: Deleting a layer and pressing Undo could revert port-label or
+  circuit-label edits made on other screens since the previous undoable
+  action. The inline rename inputs in the Data Flow and Power sidebars
+  saved their edits to state but never pushed an undo snapshot, so Undo
+  jumped past them to an older snapshot and reverted them along with the
+  delete. Each port-label and circuit-label edit now records its own
+  history entry, so Undo only steps back one edit at a time.
+
 v0.7.4.30 - April 28, 2026
 ----------------------------
 - FIX: In Data Flow and Power views, clicking a different screen left the

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.32 - April 29, 2026
+----------------------------
+- FIX: Power circuit label templates other than the default "S1-#" did not
+  auto-increment the soca number after every 6 circuits. With "S1-#" the
+  labels correctly wrapped S1-1..S1-6, S2-1..S2-6, etc., but typing any
+  other starting number ("S2-#", "MULTI3-#", etc.) fell back to a plain
+  "#" → circuit-number substitution, so circuits 7+ rolled past 6 instead
+  of starting a new soca. The auto-increment now works for any template
+  shaped <prefix><number><sep># — "S2-#" produces S2-1..S2-6, S3-1..S3-6;
+  "MULTI3-#" produces MULTI3-1..MULTI3-6, MULTI4-1..MULTI4-6.
+
 v0.7.4.31 - April 27, 2026
 ----------------------------
 - FIX: Deleting a layer and pressing Undo could revert port-label or

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.31',
-            'CFBundleVersion': '0.7.4.31',
+            'CFBundleShortVersionString': '0.7.4.32',
+            'CFBundleVersion': '0.7.4.32',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.30',
-            'CFBundleVersion': '0.7.4.30',
+            'CFBundleShortVersionString': '0.7.4.31',
+            'CFBundleVersion': '0.7.4.31',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -8341,13 +8341,19 @@ class LEDRasterApp {
         const template = layer.powerLabelTemplate || 'S1-#';
         const overrides = layer.powerLabelOverrides || {};
         if (overrides && overrides[circuitNum]) return overrides[circuitNum];
-        // Default power labeling is 6 circuits per multi:
-        // S1-1 ... S1-6, then S2-1 ... S2-6, etc.
-        if (template === 'S1-#') {
+        // A multi/soca has 6 ports, so labels wrap every 6 circuits and the
+        // soca number in the template increments. Works for any template
+        // shaped like <prefix><number><separator># — e.g. S1-#, S2-#, MULTI3-#.
+        const m = String(template).match(/^(.*?)(\d+)([^#\d]*)#(.*)$/);
+        if (m) {
+            const prefix = m[1];
+            const startMulti = parseInt(m[2], 10) || 1;
+            const sep = m[3];
+            const suffix = m[4];
             const n = Math.max(1, parseInt(circuitNum, 10) || 1);
-            const multi = Math.floor((n - 1) / 6) + 1;
+            const multi = startMulti + Math.floor((n - 1) / 6);
             const circuitInMulti = ((n - 1) % 6) + 1;
-            return `S${multi}-${circuitInMulti}`;
+            return `${prefix}${multi}${sep}${circuitInMulti}${suffix}`;
         }
         return template.replace('#', circuitNum);
     }

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -8480,6 +8480,7 @@ class LEDRasterApp {
                 this.saveClientSideProperties();
                 this.updateLayers(this.getSelectedLayers());
                 window.canvasRenderer.render();
+                this.saveState('Edit Port Label');
             });
 
             const returnInput = document.createElement('input');
@@ -8506,6 +8507,7 @@ class LEDRasterApp {
                 this.saveClientSideProperties();
                 this.updateLayers(this.getSelectedLayers());
                 window.canvasRenderer.render();
+                this.saveState('Edit Port Label');
             });
 
             row.appendChild(cb);
@@ -8589,6 +8591,7 @@ class LEDRasterApp {
                 this.saveClientSideProperties();
                 this.updateLayers(this.getSelectedLayers());
                 window.canvasRenderer.render();
+                this.saveState('Edit Circuit Label');
             });
 
             row.appendChild(cb);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.31</title>
+    <title>LED Raster Designer v0.7.4.32</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.31</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.32</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.30</title>
+    <title>LED Raster Designer v0.7.4.31</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.30</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.31</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">


### PR DESCRIPTION
## Summary
- v0.7.4.31 — fix undo reverting unrelated port/circuit label edits after a layer delete (inline rename inputs now push their own history snapshot)
- v0.7.4.32 — power circuit labels auto-increment the soca number for any starting template (S2-#, MULTI3-#, etc.), not just the default S1-#

## Test plan
- [ ] Edit port label R3 on screen A, R4 on screen B, then delete screen C → undo restores screen C only; R3/R4 unchanged
- [ ] Set power label template to `S2-#` on a 10-circuit layer → labels read S2-1..S2-6, S3-1..S3-4
- [ ] Default `S1-#` still wraps S1-1..S1-6, S2-1..S2-6