### PR TITLE
v0.7.4.33 — sanitize filenames on multi-file export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.32
+# LED Raster Designer v0.7.4.33
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,18 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.33 - April 29, 2026
+----------------------------
+- FIX: Multi-file PNG/PSD export failed with "Failed to execute
+  'getFileHandle' on 'FileSystemDirectoryHandle': Name is not allowed."
+  when the project name (used as the filename prefix) contained a forward
+  slash, backslash, colon, or other characters the OS rejects in
+  filenames. Common case: project named "Foo/Bar" produced filenames like
+  "Foo/Bar_pixel-map.png", which the File System Access API refuses.
+  Filenames are now sanitized — illegal characters are replaced with "_"
+  before being passed to the picker / directory handle. Single-file
+  exports (PDF, JSON save, etc.) get the same treatment.
+
 v0.7.4.32 - April 29, 2026
 ----------------------------
 - FIX: Power circuit label templates other than the default "S1-#" did not

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.32',
-            'CFBundleVersion': '0.7.4.32',
+            'CFBundleShortVersionString': '0.7.4.33',
+            'CFBundleVersion': '0.7.4.33',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -6904,6 +6904,9 @@ class LEDRasterApp {
     }
 
     async saveBlobWithPicker(blob, filename, mimeType) {
+        // Sanitize so a project name with "/" or other illegal chars doesn't
+        // get rejected by showSaveFilePicker / OS file APIs.
+        filename = this.sanitizeFilename(filename);
         // 1. Try the File System Access API (Chrome/Edge on secure contexts)
         if (window.showSaveFilePicker) {
             try {
@@ -6942,7 +6945,21 @@ class LEDRasterApp {
         }
     }
 
+    sanitizeFilename(name) {
+        // Strip path separators and characters Windows/macOS reject in filenames.
+        // Also collapse leading/trailing dots & whitespace which Windows rejects.
+        if (!name) return 'untitled';
+        const cleaned = String(name)
+            .replace(/[\\/:*?"<>|\x00-\x1F]/g, '_')
+            .replace(/^[\s.]+|[\s.]+$/g, '')
+            .trim();
+        return cleaned || 'untitled';
+    }
+
     async saveMultipleFiles(files) {
+        // Sanitize each filename so path separators (e.g. "/" in a project name)
+        // don't break getFileHandle() with "Name is not allowed."
+        files = files.map(f => ({ ...f, filename: this.sanitizeFilename(f.filename) }));
         sendClientLog('save_multiple_files_start', {
             count: files.length,
             hasDirectoryPicker: !!window.showDirectoryPicker,

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.32</title>
+    <title>LED Raster Designer v0.7.4.33</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.32</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.33</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
             </div>
             <div class="toolbar-section toolbar-actions">


### PR DESCRIPTION
## Summary
Project names containing path separators (e.g. `Rockfest/Hoofbeat Video Maps ALL`) caused multi-file PNG/PSD export to fail on Windows with `Failed to execute 'getFileHandle' on 'FileSystemDirectoryHandle': Name is not allowed.` Filenames are now sanitized before being passed to the File System Access API.

## Test plan
- [ ] Project named `Foo/Bar` → multi-PNG export to a directory writes `Foo_Bar_pixel-map.png` etc., no error
- [ ] Project with normal name still exports normally
- [ ] Single-file PDF export with `:` or `?` in project name no longer fails on Windows