### PR TITLE
v0.7.4.34 — warn on illegal project name chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.33
+# LED Raster Designer v0.7.4.34
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,14 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.34 - April 29, 2026
+----------------------------
+- UX: Project name field now shows an inline warning ("Note: / will be
+  replaced with _ in exported filenames.") when it contains characters
+  the OS rejects in filenames (\ / : * ? " < > |). Gives the user a
+  chance to rename before exporting; if they don't, v0.7.4.33's export-
+  time sanitization still produces a valid filename.
+
 v0.7.4.33 - April 29, 2026
 ----------------------------
 - FIX: Multi-file PNG/PSD export failed with "Failed to execute

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.33',
-            'CFBundleVersion': '0.7.4.33',
+            'CFBundleShortVersionString': '0.7.4.34',
+            'CFBundleVersion': '0.7.4.34',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1805,8 +1805,12 @@ class LEDRasterApp {
     }
     
     updateUI() {
-        
-        document.getElementById('project-name').value = this.project.name;
+
+        const projectNameEl = document.getElementById('project-name');
+        projectNameEl.value = this.project.name;
+        // Refresh illegal-character warning whenever the project name changes
+        // programmatically (e.g. on project load).
+        projectNameEl.dispatchEvent(new Event('input'));
 
         // Load project notes
         const notesEl = document.getElementById('project-notes');
@@ -1832,13 +1836,31 @@ class LEDRasterApp {
     setupEventListeners() {
         // Project name editing
         const projectNameInput = document.getElementById('project-name');
+        const projectNameWarning = document.getElementById('project-name-warning');
+        const ILLEGAL_FILENAME_CHARS = /[\\/:*?"<>|]/;
+        const updateProjectNameWarning = () => {
+            if (!projectNameWarning) return;
+            const v = projectNameInput.value || '';
+            const bad = v.match(/[\\/:*?"<>|]/g);
+            if (bad && bad.length > 0) {
+                const unique = [...new Set(bad)].join(' ');
+                projectNameWarning.textContent = `Note: ${unique} will be replaced with _ in exported filenames.`;
+                projectNameWarning.style.display = 'block';
+            } else {
+                projectNameWarning.style.display = 'none';
+            }
+        };
         if (projectNameInput) {
+            projectNameInput.addEventListener('input', updateProjectNameWarning);
             projectNameInput.addEventListener('change', () => {
                 if (this.project) {
                     this.project.name = projectNameInput.value.trim() || 'Untitled Project';
                     this.saveProject();
                 }
+                updateProjectNameWarning();
             });
+            // Run once on init in case a loaded project has illegal chars
+            updateProjectNameWarning();
         }
         
         // Project Notes

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -75,8 +75,10 @@
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
                 <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.34</span></h1>
-                <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
-                <div id="project-name-warning" style="display:none; font-size:11px; color:#f5a623; margin-top:2px;"></div>
+                <div style="position:relative;">
+                    <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
+                    <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
+                </div>
             </div>
             <div class="toolbar-section toolbar-actions">
                 <button id="btn-new" class="btn" data-tooltip="Create a new project">New</button>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.33</title>
+    <title>LED Raster Designer v0.7.4.34</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,8 +74,9 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.33</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.34</span></h1>
                 <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
+                <div id="project-name-warning" style="display:none; font-size:11px; color:#f5a623; margin-top:2px;"></div>
             </div>
             <div class="toolbar-section toolbar-actions">
                 <button id="btn-new" class="btn" data-tooltip="Create a new project">New</button>


### PR DESCRIPTION
## Summary
Companion to v0.7.4.33's silent sanitization. The project name input now shows an inline amber warning under the field listing characters that will be replaced with `_` in exported filenames (\\ / : * ? \" < > |). Defensive sanitization at export time still applies if the user keeps the name as-is.

## Test plan
- [ ] Type `Foo/Bar` → warning appears under input: "Note: / will be replaced with _ in exported filenames."
- [ ] Type `Foo:Bar?` → warning lists `:` and `?` deduped
- [ ] Clear illegal chars → warning hides
- [ ] Toolbar layout unchanged (warning is absolutely positioned)
- [ ] Loading a saved project with illegal chars triggers the warning on load