### PR TITLE
v0.7.4.35 — fix port count not updating with custom data flow paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.34
+# LED Raster Designer v0.7.4.35
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,19 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.4.35 - April 29, 2026
+----------------------------
+- FIX: Ports Required count and the port-rename editor showed too few
+  ports when using custom data flow paths — e.g. 8 custom paths drawn
+  but the count stayed at the auto-pattern's 5. The client-computed
+  _portsRequired and _autoPortsRequired fields were being clobbered by
+  the server's stale echo on every PUT round-trip (server's whitelist
+  ignores these underscore-prefixed derived fields, but the response
+  body still carried the old values). Both fields are now preserved
+  client-side across the round-trip, and the toggle handler recomputes
+  the count before sending so the freshly computed value is what gets
+  preserved.
+
 v0.7.4.34 - April 29, 2026
 ----------------------------
 - UX: Project name field now shows an inline warning ("Note: / will be

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.34',
-            'CFBundleVersion': '0.7.4.34',
+            'CFBundleShortVersionString': '0.7.4.35',
+            'CFBundleVersion': '0.7.4.35',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5516,6 +5516,14 @@ class LEDRasterApp {
                 _powerTotalAmps1: layer._powerTotalAmps1,
                 _powerTotalAmps3: layer._powerTotalAmps3,
                 _powerCircuitsRequired: layer._powerCircuitsRequired,
+                // Preserve client-computed port counts across the server
+                // roundtrip — server doesn't whitelist these fields, so its
+                // echo carries stale values that would otherwise overwrite
+                // the freshly recomputed numbers (causes ports-required and
+                // the port-rename editor to show too few ports in custom
+                // flow mode after toggling).
+                _portsRequired: layer._portsRequired,
+                _autoPortsRequired: layer._autoPortsRequired,
                 panel_weight: layer.panel_weight,
                 weight_unit: layer.weight_unit,
                 infoLabelSize: layer.infoLabelSize,
@@ -8715,8 +8723,10 @@ class LEDRasterApp {
         }
         this.saveState('Custom Mode Toggle');
         this.saveClientSideProperties();
-        this.updateLayers(this.getSelectedLayers());
+        // Recompute port count BEFORE the server roundtrip so the layer's
+        // _portsRequired is fresh when preservedProps captures it.
         this.updatePortCapacityDisplay();
+        this.updateLayers(this.getSelectedLayers());
         this.updateCustomFlowUI();
         window.canvasRenderer.render();
     }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.34</title>
+    <title>LED Raster Designer v0.7.4.35</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -74,7 +74,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.34</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.35</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
With custom data flow paths drawn (e.g. 8 paths), Ports Required and the port-rename editor stayed stuck at the auto-pattern's count (e.g. 5). Client-computed \`_portsRequired\` / \`_autoPortsRequired\` were being clobbered by the server's stale echo on every layer PUT. Both fields are now preserved client-side, and the toggle handler recomputes before sending so the preserved value is fresh.

## Test plan
- [ ] Draw 8 custom paths → Ports Required shows 8, port-rename editor lists 8 inputs
- [ ] Toggle custom mode off → on → off → on, count stays consistent each time
- [ ] Edit any other property (color, label size, etc.) → port count not lost