### PR TITLE
v0.7.5.0 — per-panel half-tile editing + NovaStar rect fix + blank-resize fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.4.35
+# LED Raster Designer v0.7.5.0
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,46 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.5.0 - April 30, 2026
+----------------------------
+- FEATURE: Per-panel half-tile editing replaces the four screen-level
+  "Half First/Last Column/Row" checkboxes. Mark any individual panel as
+  half-width or half-height for non-rectangular walls and stepped layouts.
+    - Drag-select panels in Pixel Map view → sidebar shows action
+      buttons: Set Blank, Restore, Set Half-tile (auto), Force
+      Half-Width, Force Half-Height, Restore Full. Selection count
+      badge in the canvas corner.
+    - Right-click a panel (or selection) → context menu with the same
+      actions.
+    - Alt + click toggles blank on a single panel (existing) — when a
+      multi-selection is active, applies to the entire selection.
+    - Alt + Shift + click toggles half-tile (auto direction) on a single
+      panel — when a multi-selection is active, applies to the entire
+      selection. Auto direction picks 'height' for top/bottom-edge panels
+      and 'width' for left/right-edge panels.
+    - Plain click on a panel resets selection to that single panel;
+      Cmd/Ctrl + click adds/removes from selection. Esc clears the
+      selection.
+    - Half-tile cabinets render anchored to their visible neighbor so
+      the missing half sits on the wall's outer edge (matching how
+      half cabinets are physically installed at wall edges).
+    - Math: half-tiles count as 0.5 panels for data/port mapping,
+      0.65 panels for power/weight (existing helpers already do this
+      via pixel area + load factor).
+    - Legacy halfFirstColumn / halfLastColumn / halfFirstRow / halfLastRow
+      flags are migrated to per-panel halfTile values on first load,
+      then dropped from the schema. Existing projects keep their look.
+- FIX: NovaStar 1G/Armor port load calculation now uses the actual
+  pixel bounding rect (panel x/y/width/height) instead of the cabinet-
+  cell shortcut. Half-tile cabinets correctly contribute half their
+  full-cell pixel footprint to the port reservation rectangle.
+- FIX: Pre-existing bug — hidden ("blank") panels in the middle of a
+  wall would scatter to other positions when columns or rows were
+  resized. Panel state was preserved by sequential id, so the same id
+  pointed to a different (row, col) cell after a grid resize. State
+  is now keyed by (row, col) so blanks and half-tiles stay anchored
+  to their original positions across resizes (within the new bounds).
+
 v0.7.4.35 - April 29, 2026
 ----------------------------
 - FIX: Ports Required count and the port-rename editor showed too few

--- a/src/app.py
+++ b/src/app.py
@@ -95,63 +95,149 @@ def rotate_logs():
     except Exception:
         pass
 
-def _panel_width(layer, col):
-    width = layer.get('cabinet_width', 0)
-    cols = int(layer.get('columns', 0) or 0)
-    if cols <= 0:
-        return width
-    if col == 0 and layer.get('halfFirstColumn', False):
-        return width / 2
-    if col == cols - 1 and layer.get('halfLastColumn', False):
-        return width / 2
-    return width
+def _migrate_screen_half_flags_to_panel_states(layer, panel_states):
+    """Convert legacy screen-level halfFirstColumn/halfLastColumn/halfFirstRow/
+    halfLastRow flags into per-panel halfTile values stamped onto panel_states.
 
-def _panel_height(layer, row):
-    height = layer.get('cabinet_height', 0)
+    Called from _build_panels so the legacy flags continue to render correctly
+    after migration. Panels in the affected first/last column get halfTile='width';
+    panels in the affected first/last row get halfTile='height'.
+
+    Mutates panel_states in place and returns it.
+    """
     rows = int(layer.get('rows', 0) or 0)
-    if rows <= 0:
-        return height
-    if row == 0 and layer.get('halfFirstRow', False):
-        return height / 2
-    if row == rows - 1 and layer.get('halfLastRow', False):
-        return height / 2
-    return height
+    cols = int(layer.get('columns', 0) or 0)
+    if rows <= 0 or cols <= 0:
+        return panel_states
+    if panel_states is None:
+        panel_states = {}
+    half_first_col = bool(layer.get('halfFirstColumn', False))
+    half_last_col = bool(layer.get('halfLastColumn', False))
+    half_first_row = bool(layer.get('halfFirstRow', False))
+    half_last_row = bool(layer.get('halfLastRow', False))
+    if not (half_first_col or half_last_col or half_first_row or half_last_row):
+        return panel_states
+    for r in range(rows):
+        for c in range(cols):
+            panel_num = r * cols + c + 1
+            state = panel_states.setdefault(panel_num, {})
+            if state.get('halfTile') in ('width', 'height'):
+                continue
+            if (half_first_row and r == 0) or (half_last_row and r == rows - 1):
+                state['halfTile'] = 'height'
+            elif (half_first_col and c == 0) or (half_last_col and c == cols - 1):
+                state['halfTile'] = 'width'
+    # Clear the legacy flags so they don't double-apply on subsequent rebuilds
+    layer['halfFirstColumn'] = False
+    layer['halfLastColumn'] = False
+    layer['halfFirstRow'] = False
+    layer['halfLastRow'] = False
+    return panel_states
+
 
 def _build_panels(layer, panel_states=None):
     rows = int(layer.get('rows', 0) or 0)
     cols = int(layer.get('columns', 0) or 0)
     offset_x = float(layer.get('offset_x', 0) or 0)
     offset_y = float(layer.get('offset_y', 0) or 0)
+    cabinet_width = float(layer.get('cabinet_width', 0) or 0)
+    cabinet_height = float(layer.get('cabinet_height', 0) or 0)
+
+    # One-time migration of legacy screen-level half flags into per-panel state.
+    panel_states = _migrate_screen_half_flags_to_panel_states(layer, panel_states or {})
+
+    def _half_at(r, c):
+        ps = panel_states.get(r * cols + c + 1, {}) if panel_states else {}
+        return ps.get('halfTile', 'none')
+
+    # Per-panel width/height — half-tiles render at half cabinet size.
+    def panel_w(r, c):
+        return cabinet_width / 2 if _half_at(r, c) == 'width' else cabinet_width
+
+    def panel_h(r, c):
+        return cabinet_height / 2 if _half_at(r, c) == 'height' else cabinet_height
+
+    # Column width = max width across all panels in that column. Row height = max
+    # across the row. So a row where every panel is half-height collapses to
+    # half-height (matching the legacy halfFirstRow behavior); a mixed row stays
+    # full-height with the half panels rendering shorter inside their slot.
+    col_widths = []
+    for c in range(cols):
+        widths = [panel_w(r, c) for r in range(rows)] or [cabinet_width]
+        col_widths.append(max(widths))
+    row_heights = []
+    for r in range(rows):
+        heights = [panel_h(r, c) for c in range(cols)] or [cabinet_height]
+        row_heights.append(max(heights))
 
     col_x = []
     x_cursor = offset_x
-    for col in range(cols):
+    for c in range(cols):
         col_x.append(x_cursor)
-        x_cursor += _panel_width(layer, col)
+        x_cursor += col_widths[c]
 
     row_y = []
     y_cursor = offset_y
-    for row in range(rows):
+    for r in range(rows):
         row_y.append(y_cursor)
-        y_cursor += _panel_height(layer, row)
+        y_cursor += row_heights[r]
+
+    # Helper: is the panel at (r, c) a visible (non-hidden) cabinet?
+    def _has_visible_neighbor(r, c):
+        if r < 0 or r >= rows or c < 0 or c >= cols:
+            return False
+        ps = panel_states.get(r * cols + c + 1, {}) if panel_states else {}
+        return not ps.get('hidden', False)
 
     panels = []
     panel_num = 1
-    for row in range(rows):
-        for col in range(cols):
+    for r in range(rows):
+        for c in range(cols):
             state = panel_states.get(panel_num, {}) if panel_states else {}
+            half_tile = state.get('halfTile', 'none')
+            if half_tile not in ('width', 'height'):
+                half_tile = 'none'
+
+            pw = panel_w(r, c)
+            ph = panel_h(r, c)
+            slot_w = col_widths[c]
+            slot_h = row_heights[r]
+            x = col_x[c]
+            y = row_y[r]
+
+            # Anchor half-tiles to their neighbor side so the visible cabinet
+            # connects to the rest of the wall — the "missing" half sits on
+            # the wall's outer edge (no neighbor side), not between this
+            # cabinet and its neighbor.
+            if half_tile == 'height' and ph < slot_h:
+                has_above = _has_visible_neighbor(r - 1, c)
+                has_below = _has_visible_neighbor(r + 1, c)
+                if not has_above and has_below:
+                    # Missing half on top — anchor to bottom of slot.
+                    y = row_y[r] + (slot_h - ph)
+                # else: anchor to top (default; covers top-anchored top edges
+                # and the interior/all-neighbors fallback).
+            elif half_tile == 'width' and pw < slot_w:
+                has_left = _has_visible_neighbor(r, c - 1)
+                has_right = _has_visible_neighbor(r, c + 1)
+                if not has_left and has_right:
+                    # Missing half on left — anchor to right of slot.
+                    x = col_x[c] + (slot_w - pw)
+                # else: anchor to left (default).
+
             panel = {
                 'id': panel_num,
                 'number': panel_num,
-                'row': row,
-                'col': col,
-                'x': col_x[col],
-                'y': row_y[row],
-                'width': _panel_width(layer, col),
-                'height': _panel_height(layer, row),
+                'row': r,
+                'col': c,
+                'x': x,
+                'y': y,
+                'width': pw,
+                'height': ph,
                 'blank': state.get('blank', False),
                 'hidden': state.get('hidden', False),
-                'is_color1': (row + col) % 2 == 0
+                'halfTile': half_tile,
+                'is_color1': (r + c) % 2 == 0
             }
             panels.append(panel)
             panel_num += 1
@@ -932,13 +1018,14 @@ def update_layer(layer_id):
         'columns' in data or 'rows' in data or 'cabinet_width' in data or 'cabinet_height' in data
             or 'halfFirstColumn' in data or 'halfLastColumn' in data
             or 'halfFirstRow' in data or 'halfLastRow' in data):
-        # Save existing panel states (hidden, blank) before regenerating
+        # Save existing panel states (hidden, blank, halfTile) before regenerating
         old_panel_states = {}
         if 'panels' in layer:
             for p in layer['panels']:
                 old_panel_states[p['id']] = {
                     'hidden': p.get('hidden', False),
-                    'blank': p.get('blank', False)
+                    'blank': p.get('blank', False),
+                    'halfTile': p.get('halfTile', 'none'),
                 }
         layer['panels'] = _build_panels(layer, old_panel_states)
     elif layer.get('type') != 'image' and ('offset_x' in data or 'offset_y' in data):
@@ -1019,6 +1106,74 @@ def set_panels_hidden(layer_id):
     log_event('bulk_set_panels_hidden', {'layer_id': layer_id, 'count': len(updated)})
     socketio.emit('layer_updated', layer)
     return jsonify({'updated': len(updated)})
+
+
+def _rebuild_layer_geometry_from_panel_states(layer):
+    """Re-run _build_panels using the layer's current panel states so per-panel
+    halfTile changes propagate into x/y/width/height (column widths and row
+    heights may collapse when an entire row/column becomes half).
+    """
+    states = {}
+    for p in layer.get('panels', []):
+        states[p['id']] = {
+            'hidden': p.get('hidden', False),
+            'blank': p.get('blank', False),
+            'halfTile': p.get('halfTile', 'none'),
+        }
+    layer['panels'] = _build_panels(layer, states)
+
+
+@app.route('/api/layer/<int:layer_id>/panel/<int:panel_id>/set_half_tile', methods=['POST'])
+def set_panel_half_tile(layer_id, panel_id):
+    """Set a single panel's halfTile value ('none' | 'width' | 'height')."""
+    layer = next((l for l in current_project['layers'] if l['id'] == layer_id), None)
+    if not layer:
+        return jsonify({'error': 'Layer not found'}), 404
+
+    panel = next((p for p in layer['panels'] if p['id'] == panel_id), None)
+    if not panel:
+        return jsonify({'error': 'Panel not found'}), 404
+
+    data = request.json or {}
+    value = data.get('halfTile', 'none')
+    if value not in ('none', 'width', 'height'):
+        value = 'none'
+    panel['halfTile'] = value
+
+    _rebuild_layer_geometry_from_panel_states(layer)
+    log_event('set_panel_half_tile', {'layer_id': layer_id, 'panel_id': panel_id, 'halfTile': value})
+    socketio.emit('layer_updated', layer)
+    return jsonify(layer)
+
+
+@app.route('/api/layer/<int:layer_id>/panels/set_half_tile', methods=['POST'])
+def set_panels_half_tile(layer_id):
+    """Bulk set halfTile state for multiple panels.
+
+    Body: { panels: [{ id, halfTile: 'none' | 'width' | 'height' }, ...] }
+    """
+    layer = next((l for l in current_project['layers'] if l['id'] == layer_id), None)
+    if not layer:
+        return jsonify({'error': 'Layer not found'}), 404
+
+    data = request.json or {}
+    panel_states = data.get('panels', [])
+
+    updated = 0
+    for ps in panel_states:
+        panel = next((p for p in layer['panels'] if p['id'] == ps.get('id')), None)
+        if not panel:
+            continue
+        value = ps.get('halfTile', 'none')
+        if value not in ('none', 'width', 'height'):
+            value = 'none'
+        panel['halfTile'] = value
+        updated += 1
+
+    _rebuild_layer_geometry_from_panel_states(layer)
+    log_event('bulk_set_panels_half_tile', {'layer_id': layer_id, 'count': updated})
+    socketio.emit('layer_updated', layer)
+    return jsonify({'updated': updated})
 
 
 @app.route('/api/log', methods=['POST'])

--- a/src/app.py
+++ b/src/app.py
@@ -99,9 +99,7 @@ def _migrate_screen_half_flags_to_panel_states(layer, panel_states):
     """Convert legacy screen-level halfFirstColumn/halfLastColumn/halfFirstRow/
     halfLastRow flags into per-panel halfTile values stamped onto panel_states.
 
-    Called from _build_panels so the legacy flags continue to render correctly
-    after migration. Panels in the affected first/last column get halfTile='width';
-    panels in the affected first/last row get halfTile='height'.
+    panel_states is keyed by (row, col) tuples so state survives grid resizes.
 
     Mutates panel_states in place and returns it.
     """
@@ -119,8 +117,8 @@ def _migrate_screen_half_flags_to_panel_states(layer, panel_states):
         return panel_states
     for r in range(rows):
         for c in range(cols):
-            panel_num = r * cols + c + 1
-            state = panel_states.setdefault(panel_num, {})
+            key = (r, c)
+            state = panel_states.setdefault(key, {})
             if state.get('halfTile') in ('width', 'height'):
                 continue
             if (half_first_row and r == 0) or (half_last_row and r == rows - 1):
@@ -147,7 +145,7 @@ def _build_panels(layer, panel_states=None):
     panel_states = _migrate_screen_half_flags_to_panel_states(layer, panel_states or {})
 
     def _half_at(r, c):
-        ps = panel_states.get(r * cols + c + 1, {}) if panel_states else {}
+        ps = panel_states.get((r, c), {}) if panel_states else {}
         return ps.get('halfTile', 'none')
 
     # Per-panel width/height — half-tiles render at half cabinet size.
@@ -186,14 +184,14 @@ def _build_panels(layer, panel_states=None):
     def _has_visible_neighbor(r, c):
         if r < 0 or r >= rows or c < 0 or c >= cols:
             return False
-        ps = panel_states.get(r * cols + c + 1, {}) if panel_states else {}
+        ps = panel_states.get((r, c), {}) if panel_states else {}
         return not ps.get('hidden', False)
 
     panels = []
     panel_num = 1
     for r in range(rows):
         for c in range(cols):
-            state = panel_states.get(panel_num, {}) if panel_states else {}
+            state = panel_states.get((r, c), {}) if panel_states else {}
             half_tile = state.get('halfTile', 'none')
             if half_tile not in ('width', 'height'):
                 half_tile = 'none'
@@ -1018,11 +1016,14 @@ def update_layer(layer_id):
         'columns' in data or 'rows' in data or 'cabinet_width' in data or 'cabinet_height' in data
             or 'halfFirstColumn' in data or 'halfLastColumn' in data
             or 'halfFirstRow' in data or 'halfLastRow' in data):
-        # Save existing panel states (hidden, blank, halfTile) before regenerating
+        # Save existing panel states (hidden, blank, halfTile) before regenerating.
+        # Key by (row, col) so state stays anchored to its grid cell when columns
+        # or rows change — keying by sequential id meant a column resize would
+        # shuffle blanks/half-tiles across the wall.
         old_panel_states = {}
         if 'panels' in layer:
             for p in layer['panels']:
-                old_panel_states[p['id']] = {
+                old_panel_states[(p.get('row', 0), p.get('col', 0))] = {
                     'hidden': p.get('hidden', False),
                     'blank': p.get('blank', False),
                     'halfTile': p.get('halfTile', 'none'),
@@ -1115,7 +1116,7 @@ def _rebuild_layer_geometry_from_panel_states(layer):
     """
     states = {}
     for p in layer.get('panels', []):
-        states[p['id']] = {
+        states[(p.get('row', 0), p.get('col', 0))] = {
             'hidden': p.get('hidden', False),
             'blank': p.get('blank', False),
             'halfTile': p.get('halfTile', 'none'),

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.4.35',
-            'CFBundleVersion': '0.7.4.35',
+            'CFBundleShortVersionString': '0.7.5.0',
+            'CFBundleVersion': '0.7.5.0',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -919,6 +919,9 @@ class LEDRasterApp {
         this.customDebug = false;
         this.powerCustomSelection = new Set();
         this.powerCustomDebug = false;
+        // Pixel Map bulk-select: drag-select panels of the current layer to
+        // bulk-toggle blank or half-tile state. Set of "row,col" strings.
+        this.pixelMapSelection = new Set();
         
         // Undo/Redo system
         this.history = [];
@@ -2107,16 +2110,8 @@ class LEDRasterApp {
             });
         }
 
-        ['half-first-column', 'half-last-column', 'half-first-row', 'half-last-row'].forEach(id => {
-            const checkbox = document.getElementById(id);
-            if (checkbox) {
-                checkbox.addEventListener('change', () => {
-                    if (this.currentLayer) {
-                        this.updateLayerFromInputs();
-                    }
-                });
-            }
-        });
+        // (legacy half-* checkboxes removed; per-panel halfTile editing
+        // replaces them via Alt+Shift+Click and the bulk action sidebar.)
         
         // Cabinet ID style radio buttons
         const cabinetIdStyleRadios = document.querySelectorAll('input[name="cabinet-id-style"]');
@@ -5600,14 +5595,14 @@ class LEDRasterApp {
         const columnsVal = readNumber('screen-columns').value;
         const rowsVal = readNumber('screen-rows').value;
         const numberSizeVal = readNumber('number-size').value;
-        const halfFirstColumnEl = document.getElementById('half-first-column');
-        const halfLastColumnEl = document.getElementById('half-last-column');
-        const halfFirstRowEl = document.getElementById('half-first-row');
-        const halfLastRowEl = document.getElementById('half-last-row');
-        const halfFirstColumnVal = halfFirstColumnEl && !halfFirstColumnEl.indeterminate ? halfFirstColumnEl.checked : null;
-        const halfLastColumnVal = halfLastColumnEl && !halfLastColumnEl.indeterminate ? halfLastColumnEl.checked : null;
-        const halfFirstRowVal = halfFirstRowEl && !halfFirstRowEl.indeterminate ? halfFirstRowEl.checked : null;
-        const halfLastRowVal = halfLastRowEl && !halfLastRowEl.indeterminate ? halfLastRowEl.checked : null;
+        // The four screen-level half-tile flags were replaced by per-panel
+        // halfTile state. The variables below remain (always null) so the
+        // existing "if halfXxxVal !== null" assignment block stays a no-op
+        // without further changes elsewhere.
+        const halfFirstColumnVal = null;
+        const halfLastColumnVal = null;
+        const halfFirstRowVal = null;
+        const halfLastRowVal = null;
         
         // Panel physical dimensions
         const panelWidthMMVal = readNumber('panel-width-mm').value;
@@ -5853,10 +5848,9 @@ class LEDRasterApp {
         setTextInput('cabinet-height', getCommon(l => l.cabinet_height));
         setTextInput('screen-columns', getCommon(l => l.columns));
         setTextInput('screen-rows', getCommon(l => l.rows));
-        setCheckbox('half-first-column', getCommon(l => !!l.halfFirstColumn));
-        setCheckbox('half-last-column', getCommon(l => !!l.halfLastColumn));
-        setCheckbox('half-first-row', getCommon(l => !!l.halfFirstRow));
-        setCheckbox('half-last-row', getCommon(l => !!l.halfLastRow));
+        // (legacy half-* checkboxes were removed when half-tile state moved
+        // to per-panel; the four screen-level flags are migrated to per-panel
+        // halfTile values on first load.)
         setCheckbox('show-numbers', getCommon(l => l.show_numbers !== false));
         setTextInput('number-size', getCommon(l => l.number_size || 24));
         
@@ -8850,6 +8844,149 @@ class LEDRasterApp {
         });
         this.updateCustomFlowUI();
         window.canvasRenderer.render();
+    }
+
+    // ---------- Pixel Map bulk-select (panel selection on the Pixel Map tab) ----------
+
+    selectPixelMapPanelsInRect(layer, rect) {
+        if (!layer || !rect) return;
+        this.pixelMapSelection.clear();
+        const minX = Math.min(rect.x1, rect.x2);
+        const maxX = Math.max(rect.x1, rect.x2);
+        const minY = Math.min(rect.y1, rect.y2);
+        const maxY = Math.max(rect.y1, rect.y2);
+        (layer.panels || []).forEach(panel => {
+            if (panel.hidden) return;
+            const intersects = panel.x <= maxX && (panel.x + panel.width) >= minX &&
+                panel.y <= maxY && (panel.y + panel.height) >= minY;
+            if (intersects) this.pixelMapSelection.add(this.getPanelKey(panel));
+        });
+        this.updatePixelMapBulkActionUI();
+        window.canvasRenderer.render();
+    }
+
+    togglePixelMapPanelSelection(panel) {
+        if (!panel) return;
+        const key = this.getPanelKey(panel);
+        if (this.pixelMapSelection.has(key)) {
+            this.pixelMapSelection.delete(key);
+        } else {
+            this.pixelMapSelection.add(key);
+        }
+        this.updatePixelMapBulkActionUI();
+        window.canvasRenderer.render();
+    }
+
+    clearPixelMapSelection() {
+        if (!this.pixelMapSelection || this.pixelMapSelection.size === 0) return;
+        this.pixelMapSelection.clear();
+        this.updatePixelMapBulkActionUI();
+        if (window.canvasRenderer) window.canvasRenderer.render();
+    }
+
+    getPixelMapSelectedPanels() {
+        if (!this.currentLayer || !this.currentLayer.panels) return [];
+        return this.currentLayer.panels.filter(p => this.pixelMapSelection.has(this.getPanelKey(p)));
+    }
+
+    /**
+     * Auto-detect half-tile direction for a panel based on its visible neighbors:
+     *  - top/bottom edge (no neighbor above or below): 'height'
+     *  - left/right edge (no neighbor left or right): 'width'
+     *  - corner (two missing): default 'height' (top/bottom is the common case)
+     *  - interior (all four neighbors visible): 'height' (rare; user can force-W via UI)
+     */
+    autoDetectHalfDirection(layer, panel) {
+        if (!layer || !panel) return 'height';
+        const get = (r, c) => (layer.panels || []).find(p => p.row === r && p.col === c);
+        const neighborVisible = (r, c) => {
+            const n = get(r, c);
+            return !!(n && !n.hidden);
+        };
+        const hasAbove = neighborVisible(panel.row - 1, panel.col);
+        const hasBelow = neighborVisible(panel.row + 1, panel.col);
+        const hasLeft = neighborVisible(panel.row, panel.col - 1);
+        const hasRight = neighborVisible(panel.row, panel.col + 1);
+        const verticalEdge = !hasAbove || !hasBelow;
+        const horizontalEdge = !hasLeft || !hasRight;
+        if (verticalEdge && !horizontalEdge) return 'height';
+        if (horizontalEdge && !verticalEdge) return 'width';
+        // Corner or interior — default to 'height' (top/bottom edges are the common case).
+        return 'height';
+    }
+
+    async setPanelsHalfTileBulk(panels, halfTile) {
+        if (!this.currentLayer || !panels || panels.length === 0) return;
+        const layerId = this.currentLayer.id;
+        const body = {
+            panels: panels.map(p => ({
+                id: p.id,
+                halfTile: (halfTile === 'auto' ? this.autoDetectHalfDirection(this.currentLayer, p) : halfTile),
+            })),
+        };
+        try {
+            const res = await fetch(`/api/layer/${layerId}/panels/set_half_tile`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            await res.json();
+        } catch (err) {
+            console.error('setPanelsHalfTileBulk failed', err);
+            return;
+        }
+        this.saveState('Bulk Set Half-tile');
+        sendClientLog && sendClientLog('bulk_set_half_tile', {
+            layer_id: layerId,
+            count: panels.length,
+            mode: halfTile,
+        });
+    }
+
+    async setPanelsBlankBulk(panels, blank) {
+        if (!this.currentLayer || !panels || panels.length === 0) return;
+        const layerId = this.currentLayer.id;
+        // No bulk endpoint for blank — toggle each. Using set_hidden bulk
+        // would conflict; instead call the per-panel toggle. Optimize later
+        // if needed (not on the hot path).
+        const requests = panels.map(p => fetch(`/api/layer/${layerId}/panel/${p.id}/toggle`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+        }));
+        // The single-panel toggle flips state — to *set* a specific value we
+        // only toggle panels whose current state mismatches the target.
+        const toToggle = panels.filter(p => !!p.blank !== !!blank);
+        if (toToggle.length > 0) {
+            await Promise.all(toToggle.map(p => fetch(`/api/layer/${layerId}/panel/${p.id}/toggle`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+            })));
+        }
+        this.saveState('Bulk Set Blank');
+        sendClientLog && sendClientLog('bulk_set_blank', {
+            layer_id: layerId,
+            count: toToggle.length,
+            blank,
+        });
+        if (window.canvasRenderer) window.canvasRenderer.render();
+    }
+
+    /**
+     * Update the sidebar bulk-action panel based on current selection.
+     * Shows count + action buttons when at least one panel is selected,
+     * hides when empty.
+     */
+    updatePixelMapBulkActionUI() {
+        const panel = document.getElementById('pixel-map-bulk-actions');
+        if (!panel) return;
+        const count = this.pixelMapSelection ? this.pixelMapSelection.size : 0;
+        const countEl = document.getElementById('pixel-map-bulk-count');
+        if (count > 0) {
+            panel.style.display = 'block';
+            if (countEl) countEl.textContent = count.toLocaleString();
+        } else {
+            panel.style.display = 'none';
+        }
     }
 
     selectPowerPanelsInRect(layer, rect) {

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1836,7 +1836,40 @@ class LEDRasterApp {
         }
     }
     
+    setupPixelMapBulkActions() {
+        const wireBtn = (id, fn) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.addEventListener('click', () => {
+                const panels = this.getPixelMapSelectedPanels();
+                if (panels.length === 0) return;
+                fn(panels);
+            });
+        };
+        wireBtn('bulk-set-blank',       (panels) => this.setPanelsBlankBulk(panels, true));
+        wireBtn('bulk-unset-blank',     (panels) => this.setPanelsBlankBulk(panels, false));
+        wireBtn('bulk-set-half-auto',   (panels) => this.setPanelsHalfTileBulk(panels, 'auto'));
+        wireBtn('bulk-set-half-width',  (panels) => this.setPanelsHalfTileBulk(panels, 'width'));
+        wireBtn('bulk-set-half-height', (panels) => this.setPanelsHalfTileBulk(panels, 'height'));
+        wireBtn('bulk-clear-half',      (panels) => this.setPanelsHalfTileBulk(panels, 'none'));
+
+        // Esc clears the pixel-map selection. Only react when no input is focused
+        // and the pixel-map view is active.
+        document.addEventListener('keydown', (e) => {
+            if (e.key !== 'Escape') return;
+            const tag = (document.activeElement && document.activeElement.tagName) || '';
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+            if (window.canvasRenderer && window.canvasRenderer.viewMode === 'pixel-map'
+                    && this.pixelMapSelection && this.pixelMapSelection.size > 0) {
+                this.clearPixelMapSelection();
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        }, true);
+    }
+
     setupEventListeners() {
+        this.setupPixelMapBulkActions();
         // Project name editing
         const projectNameInput = document.getElementById('project-name');
         const projectNameWarning = document.getElementById('project-name-warning');
@@ -6503,22 +6536,30 @@ class LEDRasterApp {
                         return total + panels.reduce((sum, p) => sum + this.getPanelPixelArea(p), 0);
                     }, 0);
                 }
-                // Rectangle constraint: bounding rect based on visible panel extent
-                // Find the overall min and max positions across all units in this port
-                let overallMin = Infinity, overallMax = -Infinity;
+                // Rectangle constraint (NovaStar Armor / 1G): the processor reserves
+                // a pixel rectangle that encloses every visible cabinet in the port.
+                // Compute that bounding rect from each panel's actual x/y/width/height
+                // so half-tiles correctly contribute their reduced footprint instead
+                // of the full cabinet cell.
+                let minX = Infinity, maxX = -Infinity;
+                let minY = Infinity, maxY = -Infinity;
                 let hasVisible = false;
                 unitIdxList.forEach(idx => {
-                    const range = getUnitVisibleRange(idx);
-                    if (range.span > 0) {
+                    const visible = orderedForCapacity.filter(p => (isHorizontalFirst ? p.row === idx : p.col === idx) && !p.hidden);
+                    visible.forEach(p => {
                         hasVisible = true;
-                        if (range.min < overallMin) overallMin = range.min;
-                        if (range.max > overallMax) overallMax = range.max;
-                    }
+                        const x1 = Number(p.x) || 0;
+                        const y1 = Number(p.y) || 0;
+                        const x2 = x1 + (Number(p.width) || 0);
+                        const y2 = y1 + (Number(p.height) || 0);
+                        if (x1 < minX) minX = x1;
+                        if (y1 < minY) minY = y1;
+                        if (x2 > maxX) maxX = x2;
+                        if (y2 > maxY) maxY = y2;
+                    });
                 });
                 if (!hasVisible) return 0;
-                const rectWidth = overallMax - overallMin + 1; // columns spanned
-                const rectHeight = unitIdxList.length;          // rows in port
-                return rectWidth * rectHeight * fullPanelPixels;
+                return (maxX - minX) * (maxY - minY);
             };
 
             let current = { unitIndices: [], load: 0 };
@@ -6530,9 +6571,23 @@ class LEDRasterApp {
                 const visibleInUnit = unitPanelsAll.filter(p => !p.hidden);
                 if (visibleInUnit.length === 0) return;
 
-                // Check if this single unit exceeds port capacity
+                // Check if this single unit exceeds port capacity. For
+                // rectangle-constraint processors, use the pixel-extent of the
+                // visible panels in the unit (so half-tiles count as half).
                 const singleUnitLoad = usesRectangle
-                    ? getUnitVisibleRange(unitIdx).span * fullPanelPixels
+                    ? (() => {
+                        const visible = unitPanelsAll.filter(p => !p.hidden);
+                        if (visible.length === 0) return 0;
+                        let mnX = Infinity, mxX = -Infinity, mnY = Infinity, mxY = -Infinity;
+                        visible.forEach(p => {
+                            const x1 = Number(p.x) || 0, y1 = Number(p.y) || 0;
+                            const x2 = x1 + (Number(p.width) || 0);
+                            const y2 = y1 + (Number(p.height) || 0);
+                            if (x1 < mnX) mnX = x1; if (y1 < mnY) mnY = y1;
+                            if (x2 > mxX) mxX = x2; if (y2 > mxY) mxY = y2;
+                        });
+                        return (mxX - mnX) * (mxY - mnY);
+                    })()
                     : unitPanelsAll.reduce((sum, p) => sum + this.getPanelPixelArea(p), 0);
                 if (singleUnitLoad > portCapacity) {
                     layer._capacityError = {
@@ -7578,6 +7633,24 @@ class LEDRasterApp {
             case 'prev-port':
                 this.stepCustomPort(-1);
                 break;
+            case 'bulk-set-blank':
+                this.setPanelsBlankBulk(this.getPixelMapSelectedPanels(), true);
+                break;
+            case 'bulk-unset-blank':
+                this.setPanelsBlankBulk(this.getPixelMapSelectedPanels(), false);
+                break;
+            case 'bulk-set-half-auto':
+                this.setPanelsHalfTileBulk(this.getPixelMapSelectedPanels(), 'auto');
+                break;
+            case 'bulk-set-half-width':
+                this.setPanelsHalfTileBulk(this.getPixelMapSelectedPanels(), 'width');
+                break;
+            case 'bulk-set-half-height':
+                this.setPanelsHalfTileBulk(this.getPixelMapSelectedPanels(), 'height');
+                break;
+            case 'bulk-clear-half':
+                this.setPanelsHalfTileBulk(this.getPixelMapSelectedPanels(), 'none');
+                break;
             case 'fit':
                 if (window.canvasRenderer) window.canvasRenderer.fitToView();
                 break;
@@ -8075,6 +8148,13 @@ class LEDRasterApp {
     showContextMenu(x, y) {
         const menu = document.getElementById('context-menu');
         if (!menu) return;
+        // Show/hide pixel-map-only menu group based on view + selection.
+        const inPixelMap = window.canvasRenderer && window.canvasRenderer.viewMode === 'pixel-map';
+        const haveSelection = this.pixelMapSelection && this.pixelMapSelection.size > 0;
+        const showPixelMapItems = inPixelMap && haveSelection;
+        menu.querySelectorAll('.pixel-map-only').forEach(el => {
+            el.style.display = showPixelMapItems ? '' : 'none';
+        });
         menu.style.visibility = 'hidden';
         menu.style.display = 'block';
         const menuRect = menu.getBoundingClientRect();
@@ -8943,32 +9023,35 @@ class LEDRasterApp {
         });
     }
 
+    /**
+     * Bulk hide/show panels — what the UI calls "Set Blank" (matching the
+     * Alt+click behaviour, which toggles the per-panel `hidden` flag so the
+     * cabinet disappears from the wall layout).
+     */
     async setPanelsBlankBulk(panels, blank) {
         if (!this.currentLayer || !panels || panels.length === 0) return;
         const layerId = this.currentLayer.id;
-        // No bulk endpoint for blank — toggle each. Using set_hidden bulk
-        // would conflict; instead call the per-panel toggle. Optimize later
-        // if needed (not on the hot path).
-        const requests = panels.map(p => fetch(`/api/layer/${layerId}/panel/${p.id}/toggle`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-        }));
-        // The single-panel toggle flips state — to *set* a specific value we
-        // only toggle panels whose current state mismatches the target.
-        const toToggle = panels.filter(p => !!p.blank !== !!blank);
-        if (toToggle.length > 0) {
-            await Promise.all(toToggle.map(p => fetch(`/api/layer/${layerId}/panel/${p.id}/toggle`, {
+        const targetHidden = !!blank;
+        const toChange = panels.filter(p => !!p.hidden !== targetHidden);
+        if (toChange.length === 0) return;
+        // Apply locally so the canvas updates immediately while the server PUT is in flight.
+        toChange.forEach(p => { p.hidden = targetHidden; });
+        if (window.canvasRenderer) window.canvasRenderer.render();
+        try {
+            await fetch(`/api/layer/${layerId}/panels/set_hidden`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-            })));
+                body: JSON.stringify({ panels: toChange.map(p => ({ id: p.id, hidden: targetHidden })) }),
+            });
+        } catch (err) {
+            console.error('setPanelsBlankBulk failed', err);
         }
         this.saveState('Bulk Set Blank');
         sendClientLog && sendClientLog('bulk_set_blank', {
             layer_id: layerId,
-            count: toToggle.length,
-            blank,
+            count: toChange.length,
+            hidden: targetHidden,
         });
-        if (window.canvasRenderer) window.canvasRenderer.render();
     }
 
     /**
@@ -8981,9 +9064,12 @@ class LEDRasterApp {
         if (!panel) return;
         const count = this.pixelMapSelection ? this.pixelMapSelection.size : 0;
         const countEl = document.getElementById('pixel-map-bulk-count');
+        // Wrap label too so we can fix pluralization without rebuilding markup.
+        const labelEl = document.getElementById('pixel-map-bulk-label');
         if (count > 0) {
             panel.style.display = 'block';
             if (countEl) countEl.textContent = count.toLocaleString();
+            if (labelEl) labelEl.textContent = count === 1 ? 'panel' : 'panels';
         } else {
             panel.style.display = 'none';
         }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -215,7 +215,35 @@ class CanvasRenderer {
             }
         }
 
+        // Pixel Map: drag-select panels of the current layer for bulk
+        // Set-Blank / Set-Half-tile actions. Falls through to layer selection
+        // when the drag starts in empty space (so layer multi-select still works).
+        if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey
+                && this.viewMode === 'pixel-map'
+                && window.app && window.app.currentLayer) {
+            const startPanel = this.getPanelAt(worldX, worldY);
+            const onCurrentLayer = startPanel
+                && startPanel.layerId === window.app.currentLayer.id
+                && !startPanel.panel.hidden;
+            if (onCurrentLayer) {
+                this.isSelectingPixelMapPanels = true;
+                this.selectionRect = { x1: worldX, y1: worldY, x2: worldX, y2: worldY };
+                if (typeof sendClientLog === 'function') {
+                    sendClientLog('panel_selection_start', { viewMode: this.viewMode, layerId: window.app.currentLayer.id });
+                }
+                return;
+            }
+        }
+
         if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
+            // Falling through to layer-select means the user clicked outside any
+            // panel in pixel-map (or in another view). Drop any stale pixel-map
+            // panel selection so it doesn't sit around — fresh layer-drag should
+            // start without panel-state lingering.
+            if (this.viewMode === 'pixel-map' && window.app && window.app.pixelMapSelection
+                    && window.app.pixelMapSelection.size > 0) {
+                window.app.clearPixelMapSelection();
+            }
             this.isSelectingLayers = true;
             this.layerSelectionRect = { x1: worldX, y1: worldY, x2: worldX, y2: worldY };
             if (typeof sendClientLog === 'function') {
@@ -300,12 +328,48 @@ class CanvasRenderer {
                     };
                 }
             }
+        } else if (e.button === 0 && e.altKey && e.shiftKey) {
+            // Alt+Shift+click toggles per-panel half-tile (auto direction).
+            // When a multi-selection is active, apply to the entire selection
+            // instead of just the clicked panel.
+            if (this.viewMode === 'pixel-map') {
+                const clickedPanel = this.getPanelAt(worldX, worldY);
+                if (clickedPanel && window.app && window.app.currentLayer
+                        && clickedPanel.layerId === window.app.currentLayer.id
+                        && !clickedPanel.panel.hidden) {
+                    e.preventDefault();
+                    const layer = window.app.currentLayer;
+                    const p = clickedPanel.panel;
+                    const selected = window.app.getPixelMapSelectedPanels
+                        ? window.app.getPixelMapSelectedPanels()
+                        : [];
+                    const targets = selected.length > 0 ? selected : [p];
+                    // Toggle: if any target panel currently has a halfTile, clear all;
+                    // otherwise auto-detect per panel and apply.
+                    const anyOn = targets.some(t => t.halfTile && t.halfTile !== 'none');
+                    const targetMode = anyOn ? 'none' : 'auto';
+                    window.app.setPanelsHalfTileBulk(targets, targetMode);
+                }
+            }
         } else if (e.button === 0 && e.altKey) {
-            // Alt+click/drag to hide/show panels on pixel-map
+            // Alt+click/drag toggles "blank" (hidden) on the panel.
+            // When a multi-selection is active, apply to the entire selection
+            // in one shot (no drag-painting in that mode — the selection is
+            // already explicit).
             if (this.viewMode === 'pixel-map') {
                 const clickedPanel = this.getPanelAt(worldX, worldY);
                 if (clickedPanel && window.app) {
                     e.preventDefault();
+                    const selected = (window.app.getPixelMapSelectedPanels
+                        ? window.app.getPixelMapSelectedPanels()
+                        : []);
+                    if (selected.length > 0) {
+                        // Toggle direction: if any selected panel is currently
+                        // visible, hide all; otherwise show all.
+                        const anyVisible = selected.some(p => !p.hidden);
+                        window.app.setPanelsBlankBulk(selected, anyVisible);
+                        return;
+                    }
                     this.isAltPainting = true;
                     this.altPaintLayerId = clickedPanel.layerId;
                     this.altPaintMode = clickedPanel.panel.hidden ? 'show' : 'hide';
@@ -370,6 +434,16 @@ class CanvasRenderer {
                 window.app.selectPanelsInRect(window.app.currentLayer, this.selectionRect);
             } else if (window.app && window.app.currentLayer && this.viewMode === 'power' && window.app.isCustomPower(window.app.currentLayer)) {
                 window.app.selectPowerPanelsInRect(window.app.currentLayer, this.selectionRect);
+            }
+            this.render();
+            return;
+        }
+
+        if (this.isSelectingPixelMapPanels && this.selectionRect) {
+            this.selectionRect.x2 = worldX;
+            this.selectionRect.y2 = worldY;
+            if (window.app && window.app.currentLayer) {
+                window.app.selectPixelMapPanelsInRect(window.app.currentLayer, this.selectionRect);
             }
             this.render();
             return;
@@ -596,6 +670,43 @@ class CanvasRenderer {
             this.render();
             return;
         }
+
+        if (this.isSelectingPixelMapPanels) {
+            this.isSelectingPixelMapPanels = false;
+            if (this.selectionRect && window.app && window.app.currentLayer) {
+                const w = Math.abs(this.selectionRect.x2 - this.selectionRect.x1);
+                const h = Math.abs(this.selectionRect.y2 - this.selectionRect.y1);
+                if (w < 0.5 && h < 0.5) {
+                    // Click without drag.
+                    //  - Plain click on a panel: replace the selection with just that panel
+                    //    (resets multi-select instead of confusingly toggling one panel out).
+                    //  - Cmd/Ctrl+click: additive — toggle that panel in/out of the selection.
+                    //  - Plain click on empty space: clear the selection.
+                    const clickedPanel = this.getPanelAt(this.selectionRect.x1, this.selectionRect.y1);
+                    const additive = e.metaKey || e.ctrlKey;
+                    if (clickedPanel && clickedPanel.layerId === window.app.currentLayer.id && !clickedPanel.panel.hidden) {
+                        if (additive) {
+                            window.app.togglePixelMapPanelSelection(clickedPanel.panel);
+                        } else {
+                            window.app.pixelMapSelection.clear();
+                            window.app.pixelMapSelection.add(window.app.getPanelKey(clickedPanel.panel));
+                            window.app.updatePixelMapBulkActionUI();
+                            this.render();
+                        }
+                    } else if (!additive) {
+                        window.app.clearPixelMapSelection();
+                    }
+                } else {
+                    window.app.selectPixelMapPanelsInRect(window.app.currentLayer, this.selectionRect);
+                }
+            }
+            this.selectionRect = null;
+            if (typeof sendClientLog === 'function') {
+                sendClientLog('panel_selection_end', { viewMode: this.viewMode });
+            }
+            this.render();
+            return;
+        }
         if (this.isSelectingLayers) {
             this.isSelectingLayers = false;
             if (this.layerSelectionRect && window.app) {
@@ -756,9 +867,26 @@ class CanvasRenderer {
     handleContextMenu(e) {
         e.preventDefault();
         e.stopPropagation();
-        if (window.app) {
-            window.app.showContextMenu(e.clientX, e.clientY);
+        if (!window.app) return;
+        // In Pixel Map view: if right-click lands on a panel of currentLayer
+        // and the panel is not already in the selection, treat it as a
+        // single-panel selection so the menu actions target it.
+        if (this.viewMode === 'pixel-map' && window.app.currentLayer) {
+            const rect = this.canvas.getBoundingClientRect();
+            const worldX = ((e.clientX - rect.left) - this.panX) / this.zoom;
+            const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
+            const clicked = this.getPanelAt(worldX, worldY);
+            if (clicked && clicked.layerId === window.app.currentLayer.id && !clicked.panel.hidden) {
+                const key = window.app.getPanelKey(clicked.panel);
+                if (!window.app.pixelMapSelection.has(key)) {
+                    window.app.pixelMapSelection.clear();
+                    window.app.pixelMapSelection.add(key);
+                    window.app.updatePixelMapBulkActionUI();
+                    this.render();
+                }
+            }
         }
+        window.app.showContextMenu(e.clientX, e.clientY);
     }
     
     handleKeyDown(e) {
@@ -1234,6 +1362,10 @@ class CanvasRenderer {
             if (!this.exportMode && this.viewMode === 'power') {
                 this.renderPowerSelectionOverlay();
                 this.renderPowerActiveCircuitBadge();
+            }
+            if (!this.exportMode && this.viewMode === 'pixel-map') {
+                this.renderPixelMapSelectionOverlay();
+                this.renderPixelMapSelectionBadge();
             }
             
             // Third pass: render capacity error overlays ON TOP of labels (Data Flow mode only)
@@ -3038,6 +3170,58 @@ class CanvasRenderer {
             });
         }
 
+        this.ctx.restore();
+    }
+
+    renderPixelMapSelectionOverlay() {
+        if (!window.app || !window.app.currentLayer) return;
+        const selection = window.app.pixelMapSelection;
+        if (!selection || selection.size === 0) return;
+        const layer = window.app.currentLayer;
+        this.ctx.save();
+        this.ctx.beginPath();
+        this.ctx.rect(0, 0, this.rasterWidth, this.rasterHeight);
+        this.ctx.clip();
+        this.ctx.fillStyle = 'rgba(74, 144, 226, 0.35)';
+        this.ctx.strokeStyle = 'rgba(74, 144, 226, 1.0)';
+        this.ctx.lineWidth = 2 / this.zoom;
+        selection.forEach(key => {
+            const [row, col] = key.split(',').map(n => parseInt(n, 10));
+            const panel = window.app.getPanelByRowCol(layer, row, col);
+            if (!panel) return;
+            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+            this.ctx.strokeRect(panel.x, panel.y, panel.width, panel.height);
+        });
+        this.ctx.restore();
+    }
+
+    renderPixelMapSelectionBadge() {
+        if (!window.app || !window.app.currentLayer) return;
+        const selection = window.app.pixelMapSelection;
+        if (!selection || selection.size === 0) return;
+        const count = selection.size;
+        const label = `${count.toLocaleString()} panel${count === 1 ? '' : 's'} selected`;
+
+        // Draw in screen-space (above the world transform) so size doesn't depend on zoom.
+        this.ctx.save();
+        this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+        const padX = 14;
+        const padY = 8;
+        const fontPx = 13;
+        this.ctx.font = `600 ${fontPx}px -apple-system, "Segoe UI", sans-serif`;
+        const textWidth = this.ctx.measureText(label).width;
+        const boxW = textWidth + padX * 2;
+        const boxH = fontPx + padY * 2;
+        const x = 20;
+        const y = 20;
+        this.ctx.fillStyle = 'rgba(74, 144, 226, 0.95)';
+        this.ctx.beginPath();
+        if (this.ctx.roundRect) this.ctx.roundRect(x, y, boxW, boxH, 6);
+        else this.ctx.rect(x, y, boxW, boxH);
+        this.ctx.fill();
+        this.ctx.fillStyle = '#fff';
+        this.ctx.textBaseline = 'middle';
+        this.ctx.fillText(label, x + padX, y + boxH / 2);
         this.ctx.restore();
     }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -129,22 +129,11 @@
                                 <label>Rows</label>
                                 <input type="text" id="screen-rows" value="5">
                             </div>
-                            <div class="info-row checkbox-row" data-tooltip="Half First Column — Use a half-width cabinet for the first column.">
-                                <input type="checkbox" id="half-first-column">
-                                <label for="half-first-column">Half First Column</label>
-                            </div>
-                            <div class="info-row checkbox-row" data-tooltip="Half Last Column — Use a half-width cabinet for the last column.">
-                                <input type="checkbox" id="half-last-column">
-                                <label for="half-last-column">Half Last Column</label>
-                            </div>
-                            <div class="info-row checkbox-row" data-tooltip="Half First Row — Use a half-height cabinet for the first row.">
-                                <input type="checkbox" id="half-first-row">
-                                <label for="half-first-row">Half First Row</label>
-                            </div>
-                            <div class="info-row checkbox-row" data-tooltip="Half Last Row — Use a half-height cabinet for the last row.">
-                                <input type="checkbox" id="half-last-row">
-                                <label for="half-last-row">Half Last Row</label>
-                            </div>
+                            <!-- Per-panel half-tile editing has replaced the four
+                                 screen-level Half checkboxes. Use Alt+Shift+Click
+                                 on a panel, or drag-select panels and use the
+                                 sidebar / right-click actions. -->
+
                             <div class="info-row" data-tooltip="Panel Width — Physical width of each cabinet in millimeters, used for real-world size labels.">
                                 <label>Panel Width (mm)</label>
                                 <input type="number" id="panel-width-mm" value="500" step="0.1" autocomplete="off" style="width: 70px;">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.4.35</title>
+    <title>LED Raster Designer v0.7.5.0</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -60,6 +60,16 @@
         </div>
 
         <div id="context-menu" class="context-menu">
+            <!-- Pixel-map panel-selection group (hidden by default; shown when a panel
+                 is right-clicked or a panel selection is active in Pixel Map view). -->
+            <div class="menu-option pixel-map-only" data-action="bulk-set-blank" data-label="Set Blank" data-shortcut-mac="Alt+Click" data-shortcut-win="Alt+Click"></div>
+            <div class="menu-option pixel-map-only" data-action="bulk-unset-blank" data-label="Restore From Blank"></div>
+            <div class="menu-divider pixel-map-only"></div>
+            <div class="menu-option pixel-map-only" data-action="bulk-set-half-auto" data-label="Set Half-tile" data-shortcut-mac="Alt+Shift+Click" data-shortcut-win="Alt+Shift+Click"></div>
+            <div class="menu-option pixel-map-only" data-action="bulk-set-half-width" data-label="Force Half-Width"></div>
+            <div class="menu-option pixel-map-only" data-action="bulk-set-half-height" data-label="Force Half-Height"></div>
+            <div class="menu-option pixel-map-only" data-action="bulk-clear-half" data-label="Restore Full"></div>
+            <div class="menu-divider pixel-map-only"></div>
             <div class="menu-option" data-action="undo" data-label="Undo" data-shortcut-mac="Cmd+Z" data-shortcut-win="Ctrl+Z"></div>
             <div class="menu-option" data-action="redo" data-label="Redo" data-shortcut-mac="Cmd+Shift+Z" data-shortcut-win="Ctrl+Shift+Z"></div>
             <div class="menu-divider"></div>
@@ -74,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.4.35</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.5.0</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -133,6 +143,21 @@
                                  screen-level Half checkboxes. Use Alt+Shift+Click
                                  on a panel, or drag-select panels and use the
                                  sidebar / right-click actions. -->
+                            <div id="pixel-map-bulk-actions" style="display:none; margin: 8px 0; padding: 10px 12px; background: rgba(74,144,226,0.10); border: 1px solid rgba(74,144,226,0.55); border-radius: 6px;">
+                                <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom: 8px;">
+                                    <span style="font-size:11px; color:#aac4ee; text-transform:uppercase; letter-spacing:0.5px;">Selection</span>
+                                    <span style="font-size:11px; color:#fff;"><span id="pixel-map-bulk-count">0</span> <span id="pixel-map-bulk-label">panels</span></span>
+                                </div>
+                                <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px;">
+                                    <button id="bulk-set-blank" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Set Blank — Hide the selected panels (same as Alt+click).">🚫 Set Blank</button>
+                                    <button id="bulk-unset-blank" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Restore — Bring the selected panels back to visible.">↺ Restore</button>
+                                    <button id="bulk-set-half-auto" class="btn btn-secondary" style="font-size:11px; padding:6px 8px; grid-column: 1 / -1;" data-tooltip="Set Half-tile (auto) — Auto-detect width vs height per panel from its wall-edge position.">◐ Set Half-tile (auto)</button>
+                                    <button id="bulk-set-half-width" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Force half-width on all selected panels.">◧ Half-Width</button>
+                                    <button id="bulk-set-half-height" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Force half-height on all selected panels.">⬓ Half-Height</button>
+                                    <button id="bulk-clear-half" class="btn btn-secondary" style="font-size:11px; padding:6px 8px; grid-column: 1 / -1;" data-tooltip="Clear half-tile — Restore selected panels to full size.">◯ Restore Full</button>
+                                </div>
+                                <div style="margin-top:8px; font-size:10px; color:#888; line-height:1.4;">Esc to clear selection. Alt+Shift+click toggles half-tile on a single panel.</div>
+                            </div>
 
                             <div class="info-row" data-tooltip="Panel Width — Physical width of each cabinet in millimeters, used for real-world size labels.">
                                 <label>Panel Width (mm)</label>


### PR DESCRIPTION
## Summary

Headline feature: per-panel half-tile editing (replaces the four screen-level Half First/Last Column/Row checkboxes).

### Feature
- Drag-select panels in Pixel Map → sidebar action buttons + canvas count badge
- Right-click context menu with the same actions
- **Alt+Click** toggles blank (existing); now applies to whole selection when multi-selected
- **Alt+Shift+Click** toggles half-tile (auto direction from edge); applies to whole selection
- Plain click resets selection; Cmd/Ctrl+click is additive; Esc clears
- Half-tile cabinets anchor toward visible neighbor (missing half on wall's outer edge)
- Math: half-tiles count as 0.5 for data/ports, 0.65 for power/weight
- Legacy screen-level half flags migrated to per-panel on first build

### Fixes
- **NovaStar 1G/Armor**: rect-constraint port load now uses actual pixel bounding rect (so half-tiles contribute half the cell footprint instead of full).
- **Pre-existing bug**: blanks/hidden panels scattered when resizing columns/rows. Panel state was keyed by sequential id; now keyed by (row, col) so state stays anchored.

## Test plan
- [ ] Drag-select panels in Pixel Map → sidebar buttons appear, count badge on canvas
- [ ] Set Half-tile (auto) on bottom row → row collapses to half-height
- [ ] Set Half-tile (auto) on left edge column → column collapses to half-width
- [ ] Half-tiles visually connect to neighbor (gap on wall's outer edge)
- [ ] Alt+click on a single panel toggles blank; on a selection toggles whole selection
- [ ] Alt+Shift+click on a single panel auto-half; on a selection applies to whole selection
- [ ] Plain click on a panel: replaces selection with that panel
- [ ] Cmd/Ctrl+click: adds/removes from selection
- [ ] Esc clears selection
- [ ] Right-click panel → context menu shows half-tile / blank actions in pixel-map view; hides in other views
- [ ] Hide a panel in mid-screen, resize columns 8→12: blank stays at original (row, col)
- [ ] Open a saved project that had halfFirstRow=true: bottom/top row migrates to per-panel halfTile='height'
- [ ] NovaStar Armor with half-tile bottom row: ports-required reflects reduced load
- [ ] Power calc shows 0.65 weight for half-tiles