### PR TITLE
v0.7.5.1 — auto half-tile direction uses majority vote across selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.5.0
+# LED Raster Designer v0.7.5.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,15 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.5.1 - April 30, 2026
+----------------------------
+- UX: "Set Half-tile (auto)" on a multi-selection now picks one
+  direction (width vs. height) by majority vote across the selected
+  panels, then applies that direction uniformly. Previously each panel
+  resolved its own direction, which could split a selected row into
+  some half-height and some half-width panels when one of them was an
+  interior or corner cell.
+
 v0.7.5.0 - April 30, 2026
 ----------------------------
 - FEATURE: Per-panel half-tile editing replaces the four screen-level

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.5.0',
-            'CFBundleVersion': '0.7.5.0',
+            'CFBundleShortVersionString': '0.7.5.1',
+            'CFBundleVersion': '0.7.5.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -8998,10 +8998,26 @@ class LEDRasterApp {
     async setPanelsHalfTileBulk(panels, halfTile) {
         if (!this.currentLayer || !panels || panels.length === 0) return;
         const layerId = this.currentLayer.id;
+        // For 'auto', vote across the selection: pick the direction the
+        // majority of panels would auto-detect to, then apply that uniformly.
+        // Avoids a row of selected panels splitting into different directions
+        // when one happens to be an interior panel.
+        let resolved = halfTile;
+        if (halfTile === 'auto') {
+            let widthVotes = 0;
+            let heightVotes = 0;
+            panels.forEach(p => {
+                const d = this.autoDetectHalfDirection(this.currentLayer, p);
+                if (d === 'width') widthVotes++;
+                else heightVotes++;
+            });
+            // Tie goes to 'height' (top/bottom is the more common case).
+            resolved = widthVotes > heightVotes ? 'width' : 'height';
+        }
         const body = {
             panels: panels.map(p => ({
                 id: p.id,
-                halfTile: (halfTile === 'auto' ? this.autoDetectHalfDirection(this.currentLayer, p) : halfTile),
+                halfTile: resolved,
             })),
         };
         try {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.5.0</title>
+    <title>LED Raster Designer v0.7.5.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.5.0</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.5.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
\"Set Half-tile (auto)\" on a multi-selection now picks one direction (width or height) by majority vote across the selected panels and applies it uniformly. Previously each panel auto-detected independently, so a corner panel could split off from the rest of its row.

## Test plan
- [ ] Select an entire top row (including corners) → all panels become half-height
- [ ] Select an entire left column (including corners) → all panels become half-width
- [ ] Single panel on left edge → still resolves to half-width
- [ ] Single panel on top edge → still resolves to half-height