### PR TITLE
Test fixes + lint cleanup for v0.7.5 half-tile rewrite

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1873,7 +1873,6 @@ class LEDRasterApp {
         // Project name editing
         const projectNameInput = document.getElementById('project-name');
         const projectNameWarning = document.getElementById('project-name-warning');
-        const ILLEGAL_FILENAME_CHARS = /[\\/:*?"<>|]/;
         const updateProjectNameWarning = () => {
             if (!projectNameWarning) return;
             const v = projectNameInput.value || '';
@@ -5677,7 +5676,11 @@ class LEDRasterApp {
         const showLabelInfoEl = document.getElementById('show-label-info');
         const showLabelWeightEl = document.getElementById('show-label-weight');
         const labelsColorEl = document.getElementById('labels-color');
-        const labelsFontSizeEl = document.getElementById('labels-fontsize');
+        // labelsFontSize is now read via readNumber('labels-fontsize') below;
+        // the element handle above used to be referenced directly with parseInt
+        // and converted blank input into NaN, which then leaked through the
+        // multi-select bulk update as a real null write. The readNumber path
+        // returns null cleanly and skips the assignment in that case.
         const useFractionalInchesEl = document.getElementById('use-fractional-inches');
 
         const showLabelNameVal = showLabelNameEl && !showLabelNameEl.indeterminate ? showLabelNameEl.checked : null;
@@ -6512,22 +6515,11 @@ class LEDRasterApp {
                 ? [...Array(layer.rows).keys()].map(i => (startsTop ? i : (layer.rows - 1 - i)))
                 : [...Array(layer.columns).keys()].map(i => (startsLeft ? i : (layer.columns - 1 - i)));
 
-            // For rectangle-constraint processors (Novastar Legacy), calculate load
-            // using the bounding rectangle of VISIBLE panels in the port.
-            // The processor reserves the full rectangle from min to max visible panel position.
-            // Hidden panels outside that range don't count, but hidden panels within the
-            // bounding rect of visible panels DO count (the processor sees the whole rectangle).
-            const getUnitVisibleRange = (unitIdx) => {
-                // Get only non-hidden panels in this row/column
-                const allPanels = orderedForCapacity.filter(p => (isHorizontalFirst ? p.row === unitIdx : p.col === unitIdx));
-                const visible = allPanels.filter(p => !p.hidden);
-                if (visible.length === 0) return { min: -1, max: -1, span: 0 };
-                const positions = visible.map(p => isHorizontalFirst ? p.col : p.row);
-                const min = Math.min(...positions);
-                const max = Math.max(...positions);
-                return { min, max, span: max - min + 1 };
-            };
-
+            // Rectangle-constraint processors (NovaStar Armor / 1G) reserve a
+            // pixel rectangle that encloses every visible cabinet in the port.
+            // We compute that rect from each panel's actual x/y/width/height
+            // (so half-tiles contribute their reduced footprint instead of the
+            // full cell). See calcBoundingRectLoad below.
             const calcBoundingRectLoad = (unitIdxList) => {
                 if (!usesRectangle) {
                     // Non-rectangle processors: sum actual pixel areas
@@ -8117,7 +8109,7 @@ class LEDRasterApp {
                         document.getElementById('status-message').textContent = 'Ready';
                     }, 2000);
                 })
-                .catch((err) => {
+                .catch(() => {
                     this.resetHistory('Initial State');
                     document.getElementById('status-message').textContent = 'Project loaded (server sync failed)';
                     setTimeout(() => {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -338,7 +338,6 @@ class CanvasRenderer {
                         && clickedPanel.layerId === window.app.currentLayer.id
                         && !clickedPanel.panel.hidden) {
                     e.preventDefault();
-                    const layer = window.app.currentLayer;
                     const p = clickedPanel.panel;
                     const selected = window.app.getPixelMapSelectedPanels
                         ? window.app.getPixelMapSelectedPanels()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from app import _build_panels, _panel_width, _panel_height, _layer_bounds
+from app import _build_panels, _layer_bounds
 
 
 def _make_layer(**overrides):
@@ -17,6 +17,9 @@ def _make_layer(**overrides):
         'cabinet_height': 80,
         'offset_x': 0,
         'offset_y': 0,
+        # Legacy half flags — _build_panels migrates these to per-panel
+        # halfTile values on first call and clears them. New code should
+        # set halfTile per-panel via panel_states.
         'halfFirstColumn': False,
         'halfLastColumn': False,
         'halfFirstRow': False,
@@ -28,26 +31,72 @@ def _make_layer(**overrides):
 
 def test_panel_width_normal():
     layer = _make_layer(cabinet_width=128)
-    assert _panel_width(layer, 0) == 128
-    assert _panel_width(layer, 1) == 128
+    panels = _build_panels(layer)
+    # Every panel is full-width when no half-tile state is set.
+    for p in panels:
+        assert p['width'] == 128
 
 
-def test_panel_width_half_first():
+def test_panel_width_half_first_legacy_migrates():
+    # Legacy halfFirstColumn flag is migrated into per-panel halfTile='width'.
     layer = _make_layer(cabinet_width=128, halfFirstColumn=True)
-    assert _panel_width(layer, 0) == 64
-    assert _panel_width(layer, 1) == 128
+    panels = _build_panels(layer)
+    first_col = [p for p in panels if p['col'] == 0]
+    other_col = [p for p in panels if p['col'] == 1]
+    for p in first_col:
+        assert p['width'] == 64
+        assert p['halfTile'] == 'width'
+    for p in other_col:
+        assert p['width'] == 128
+    # The legacy flag should be cleared after migration.
+    assert layer.get('halfFirstColumn') is False
 
 
-def test_panel_width_half_last():
+def test_panel_width_half_last_legacy_migrates():
+    # Legacy halfLastColumn flag also migrates correctly.
     layer = _make_layer(cabinet_width=128, halfLastColumn=True)
-    assert _panel_width(layer, 2) == 64  # last col (index 2 of 3)
-    assert _panel_width(layer, 1) == 128
+    panels = _build_panels(layer)
+    last_col = [p for p in panels if p['col'] == layer['columns'] - 1]
+    middle_col = [p for p in panels if p['col'] == 1]
+    for p in last_col:
+        assert p['width'] == 64
+        assert p['halfTile'] == 'width'
+    for p in middle_col:
+        assert p['width'] == 128
 
 
-def test_panel_height_half_first():
+def test_panel_height_half_first_legacy_migrates():
+    # halfFirstRow → halfTile='height' on row 0 panels.
     layer = _make_layer(cabinet_height=100, halfFirstRow=True)
-    assert _panel_height(layer, 0) == 50
-    assert _panel_height(layer, 1) == 100
+    panels = _build_panels(layer)
+    row0 = [p for p in panels if p['row'] == 0]
+    row1 = [p for p in panels if p['row'] == 1]
+    for p in row0:
+        assert p['height'] == 50
+        assert p['halfTile'] == 'height'
+    for p in row1:
+        assert p['height'] == 100
+
+
+def test_per_panel_half_tile_via_state():
+    # New model: set halfTile per-panel in panel_states, keyed by (row, col).
+    layer = _make_layer(columns=4, rows=3, cabinet_width=128, cabinet_height=128)
+    states = {
+        (0, 0): {'halfTile': 'height'},  # top-left corner: half-height
+        (1, 0): {'halfTile': 'width'},   # left edge mid: half-width
+    }
+    panels = _build_panels(layer, panel_states=states)
+    by_pos = {(p['row'], p['col']): p for p in panels}
+    assert by_pos[(0, 0)]['halfTile'] == 'height'
+    assert by_pos[(0, 0)]['height'] == 64
+    assert by_pos[(0, 0)]['width'] == 128
+    assert by_pos[(1, 0)]['halfTile'] == 'width'
+    assert by_pos[(1, 0)]['width'] == 64
+    assert by_pos[(1, 0)]['height'] == 128
+    # Other panels stay full size.
+    assert by_pos[(1, 1)]['halfTile'] == 'none'
+    assert by_pos[(1, 1)]['width'] == 128
+    assert by_pos[(1, 1)]['height'] == 128
 
 
 def test_build_panels_count():
@@ -59,23 +108,70 @@ def test_build_panels_count():
 def test_build_panels_positions():
     layer = _make_layer(columns=2, rows=2, cabinet_width=100, cabinet_height=80, offset_x=10, offset_y=20)
     panels = _build_panels(layer)
-    # First panel
-    assert panels[0]['x'] == 10
-    assert panels[0]['y'] == 20
-    # Second panel (col 1)
-    assert panels[1]['x'] == 110
-    assert panels[1]['y'] == 20
+    by_pos = {(p['row'], p['col']): p for p in panels}
+    # First panel (row 0, col 0)
+    assert by_pos[(0, 0)]['x'] == 10
+    assert by_pos[(0, 0)]['y'] == 20
+    # Second panel (row 0, col 1)
+    assert by_pos[(0, 1)]['x'] == 110
+    assert by_pos[(0, 1)]['y'] == 20
     # Third panel (row 1, col 0)
-    assert panels[2]['x'] == 10
-    assert panels[2]['y'] == 100
+    assert by_pos[(1, 0)]['x'] == 10
+    assert by_pos[(1, 0)]['y'] == 100
 
 
 def test_build_panels_preserves_state():
+    # panel_states is keyed by (row, col) so state survives column/row
+    # resizes (the previous id-keyed scheme scattered blanks across the wall
+    # when columns changed).
     layer = _make_layer(columns=2, rows=1)
-    states = {1: {'hidden': True, 'blank': False}, 2: {'hidden': False, 'blank': True}}
+    states = {
+        (0, 0): {'hidden': True, 'blank': False},
+        (0, 1): {'hidden': False, 'blank': True},
+    }
     panels = _build_panels(layer, panel_states=states)
-    assert panels[0]['hidden'] is True
-    assert panels[1]['blank'] is True
+    by_pos = {(p['row'], p['col']): p for p in panels}
+    assert by_pos[(0, 0)]['hidden'] is True
+    assert by_pos[(0, 1)]['blank'] is True
+
+
+def test_build_panels_state_keyed_by_position():
+    # Resizing columns shouldn't shuffle hidden/blank/halfTile state.
+    # Build a 4-col layer with a hidden panel at (0, 2), then "resize" to
+    # 6 cols by passing the same states dict — the hidden panel should
+    # still be at (0, 2).
+    layer = _make_layer(columns=4, rows=2)
+    states = {(0, 2): {'hidden': True, 'blank': False, 'halfTile': 'none'}}
+    panels = _build_panels(layer, panel_states=states)
+    by_pos = {(p['row'], p['col']): p for p in panels}
+    assert by_pos[(0, 2)]['hidden'] is True
+
+    layer2 = _make_layer(columns=6, rows=2)
+    panels2 = _build_panels(layer2, panel_states=states)
+    by_pos2 = {(p['row'], p['col']): p for p in panels2}
+    assert by_pos2[(0, 2)]['hidden'] is True
+    # Newly-added cells (cols 4, 5) get default state.
+    assert by_pos2[(0, 4)]['hidden'] is False
+    assert by_pos2[(0, 5)]['hidden'] is False
+
+
+def test_half_tile_anchors_to_neighbor():
+    # Half-height panel at the top edge of a wall (no above neighbor) should
+    # anchor to the bottom of its row slot so it visually connects to row 1.
+    # When the whole row is half-height the slot collapses, so anchoring is a
+    # no-op; we test the mixed case here.
+    layer = _make_layer(columns=2, rows=2, cabinet_width=100, cabinet_height=80, offset_x=0, offset_y=0)
+    states = {(0, 0): {'halfTile': 'height'}}  # only one panel in row 0 is half
+    panels = _build_panels(layer, panel_states=states)
+    by_pos = {(p['row'], p['col']): p for p in panels}
+    half = by_pos[(0, 0)]
+    full_neighbor = by_pos[(0, 1)]
+    # Row 0 stays full-height because col 1 is a full panel; the half panel
+    # renders in the bottom half of the slot, touching row 1 below.
+    assert full_neighbor['height'] == 80
+    assert half['height'] == 40
+    # half.y + half.height == row 1 top edge (no gap between half and row 1)
+    assert half['y'] + half['height'] == by_pos[(1, 0)]['y']
 
 
 def test_layer_bounds_from_panels():

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -117,8 +117,16 @@ def test_delete_layer(client_with_layer):
 
 
 def test_half_panel_dimensions(client):
-    """Half-first/last column/row creates panels with half dimensions."""
-    # Add a layer first, then update it to enable halving
+    """Legacy halfFirstColumn / halfLastRow flags migrate to per-panel
+    halfTile state, producing the same visual result.
+
+    Note: under the new per-panel model, a corner panel can only be half
+    in one dimension at a time (height OR width, not both). The migration
+    gives row-based half flags precedence, so a corner cell affected by
+    both halfFirstColumn and halfLastRow becomes half-HEIGHT (the row flag
+    wins). Non-overlapping cells get exactly the dimension they were
+    flagged for.
+    """
     resp = client.post('/api/layer/add', json={
         'name': 'HalfTest',
         'columns': 3,
@@ -129,7 +137,6 @@ def test_half_panel_dimensions(client):
     assert resp.status_code == 200
     layer_id = resp.get_json()['id']
 
-    # Update with half-panel flags (triggers panel regeneration)
     resp = client.put(f'/api/layer/{layer_id}', json={
         'halfFirstColumn': True,
         'halfLastRow': True,
@@ -138,12 +145,13 @@ def test_half_panel_dimensions(client):
     layer = resp.get_json()
     panels = layer['panels']
 
-    # First column panels should have width 50
-    first_col_panels = [p for p in panels if p['col'] == 0]
-    for p in first_col_panels:
+    # First column panels (excluding the corner that the row flag claims)
+    # should have width 50.
+    first_col_non_overlap = [p for p in panels if p['col'] == 0 and p['row'] != 1]
+    for p in first_col_non_overlap:
         assert p['width'] == 50
 
-    # Last row panels should have height 50
+    # Last row panels should all have height 50.
     last_row_panels = [p for p in panels if p['row'] == 1]
     for p in last_row_panels:
         assert p['height'] == 50

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -406,7 +406,14 @@ def test_screen_name_sizes_workflow(client):
 # ── Half panel combinations ──────────────────────────────────────────
 
 def test_all_half_panel_flags(client):
-    """Enable all four half-panel flags simultaneously."""
+    """All four legacy half-panel flags simultaneously.
+
+    Under the new per-panel model, each panel can be half in one dimension
+    at a time. The migration gives row-based flags precedence over column-
+    based flags, so a corner cell affected by both row and column flags
+    becomes half-HEIGHT. Non-corner first/last column cells become
+    half-WIDTH; non-corner first/last row cells become half-HEIGHT.
+    """
     resp = client.post('/api/layer/add', json={
         'name': 'AllHalves',
         'columns': 4,
@@ -426,28 +433,34 @@ def test_all_half_panel_flags(client):
     assert resp.status_code == 200
     updated = resp.get_json()
     panels = updated['panels']
+    by_pos = {(p['row'], p['col']): p for p in panels}
 
-    # First column should be half width
-    for p in panels:
-        if p['col'] == 0:
-            assert p['width'] == 100, f"First col panel should be half width"
-        elif p['col'] == 3:
-            assert p['width'] == 100, f"Last col panel should be half width"
-        else:
-            assert p['width'] == 200, f"Middle col panel should be full width"
+    # Non-corner first/last row panels: half-height (full width).
+    for c in range(1, 3):
+        assert by_pos[(0, c)]['height'] == 50
+        assert by_pos[(0, c)]['width'] == 200
+        assert by_pos[(2, c)]['height'] == 50
+        assert by_pos[(2, c)]['width'] == 200
 
-    # First/last row should be half height
-    for p in panels:
-        if p['row'] == 0:
-            assert p['height'] == 50, f"First row panel should be half height"
-        elif p['row'] == 2:
-            assert p['height'] == 50, f"Last row panel should be half height"
-        else:
-            assert p['height'] == 100, f"Middle row panel should be full height"
+    # Non-corner first/last column panels: half-width (full height).
+    assert by_pos[(1, 0)]['width'] == 100
+    assert by_pos[(1, 0)]['height'] == 100
+    assert by_pos[(1, 3)]['width'] == 100
+    assert by_pos[(1, 3)]['height'] == 100
+
+    # Corner cells: row flag wins → half-height, full width.
+    for r in (0, 2):
+        for c in (0, 3):
+            assert by_pos[(r, c)]['height'] == 50, f"Corner ({r},{c}) should be half-height"
 
 
 def test_half_panels_with_1x1_grid(client):
-    """Half panel flags on a 1x1 grid (edge case)."""
+    """Half panel flags on a 1x1 grid (edge case).
+
+    With both halfFirstColumn and halfFirstRow set on a single cell, the
+    migration gives the row flag precedence, so the panel becomes half-
+    height with full width.
+    """
     resp = client.post('/api/layer/add', json={
         'name': 'Tiny',
         'columns': 1,
@@ -465,8 +478,10 @@ def test_half_panels_with_1x1_grid(client):
     assert resp.status_code == 200
     panels = resp.get_json()['panels']
     assert len(panels) == 1
-    assert panels[0]['width'] == 100
+    # Row flag wins: full width, half height.
+    assert panels[0]['width'] == 200
     assert panels[0]['height'] == 50
+    assert panels[0]['halfTile'] == 'height'
 
 
 # ── Multi-layer export workflow ───────────────────────────────────────
@@ -605,8 +620,12 @@ def test_restore_preserves_all_settings(client):
     assert restored_layer['dataFlowPattern'] == 'horizontal-right'
     assert restored_layer['cabinetIdStyle'] == 'row-column'
     assert restored_layer['showLabelWeight'] is True
-    assert restored_layer['halfFirstColumn'] is True
     assert restored_layer['panel_width_mm'] == 600
+    # The legacy halfFirstColumn flag is migrated into per-panel halfTile
+    # state on first build, then cleared. Verify the equivalent state is
+    # preserved on the affected panels instead of the flag itself.
+    first_col_panels = [p for p in restored_layer['panels'] if p['col'] == 0]
+    assert all(p['halfTile'] == 'width' for p in first_col_panels)
 
 
 # ── Rotation ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Update test_helpers / test_layers / test_workflows to match the new per-panel \`halfTile\` model from v0.7.5.0 (legacy half-flags migrate to per-panel state; corner cell with overlapping row+column flags now becomes half-height instead of quarter-cabinet).
- New tests cover per-panel \`halfTile\` state and (row, col)-keyed state preservation across grid resizes.
- Drop dead JS lint warnings: \`getUnitVisibleRange\`, \`ILLEGAL_FILENAME_CHARS\`, unused \`layer\`/\`err\` bindings, \`labelsFontSizeEl\` handle.
- No user-facing behavior change. No version bump.

## Test plan
- [ ] CI green on all platforms