### PR TITLE
v0.7.5.3 — let hidden panels be drag-selected for bulk restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.5.2
+# LED Raster Designer v0.7.5.3
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,14 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.5.3 - April 30, 2026
+----------------------------
+- FIX: Hidden ("blank") panels could not be selected via drag-select,
+  plain click, or right-click in Pixel Map view, so there was no way to
+  bulk-restore them via the sidebar buttons. Hidden panels can now be
+  selected for bulk Restore. (Alt+Shift+click for half-tile still skips
+  hidden panels — half-tiling a hidden cell would have no visible effect.)
+
 v0.7.5.2 - April 30, 2026
 ----------------------------
 - Internal: tests and lint cleanup for the v0.7.5 half-tile rewrite.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.5.2',
-            'CFBundleVersion': '0.7.5.2',
+            'CFBundleShortVersionString': '0.7.5.3',
+            'CFBundleVersion': '0.7.5.3',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -8927,8 +8927,9 @@ class LEDRasterApp {
         const maxX = Math.max(rect.x1, rect.x2);
         const minY = Math.min(rect.y1, rect.y2);
         const maxY = Math.max(rect.y1, rect.y2);
+        // Include hidden ("blank") panels so they can be selected for bulk
+        // restore via the sidebar / Alt+click action.
         (layer.panels || []).forEach(panel => {
-            if (panel.hidden) return;
             const intersects = panel.x <= maxX && (panel.x + panel.width) >= minX &&
                 panel.y <= maxY && (panel.y + panel.height) >= minY;
             if (intersects) this.pixelMapSelection.add(this.getPanelKey(panel));

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -222,9 +222,10 @@ class CanvasRenderer {
                 && this.viewMode === 'pixel-map'
                 && window.app && window.app.currentLayer) {
             const startPanel = this.getPanelAt(worldX, worldY);
+            // Allow drag-start on hidden ("blank") panels too — selecting them
+            // is the only way to bulk-restore via the sidebar buttons.
             const onCurrentLayer = startPanel
-                && startPanel.layerId === window.app.currentLayer.id
-                && !startPanel.panel.hidden;
+                && startPanel.layerId === window.app.currentLayer.id;
             if (onCurrentLayer) {
                 this.isSelectingPixelMapPanels = true;
                 this.selectionRect = { x1: worldX, y1: worldY, x2: worldX, y2: worldY };
@@ -683,7 +684,9 @@ class CanvasRenderer {
                     //  - Plain click on empty space: clear the selection.
                     const clickedPanel = this.getPanelAt(this.selectionRect.x1, this.selectionRect.y1);
                     const additive = e.metaKey || e.ctrlKey;
-                    if (clickedPanel && clickedPanel.layerId === window.app.currentLayer.id && !clickedPanel.panel.hidden) {
+                    // Allow click-select on hidden panels so they can be
+                    // bulk-restored via the sidebar.
+                    if (clickedPanel && clickedPanel.layerId === window.app.currentLayer.id) {
                         if (additive) {
                             window.app.togglePixelMapPanelSelection(clickedPanel.panel);
                         } else {
@@ -875,7 +878,9 @@ class CanvasRenderer {
             const worldX = ((e.clientX - rect.left) - this.panX) / this.zoom;
             const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
             const clicked = this.getPanelAt(worldX, worldY);
-            if (clicked && clicked.layerId === window.app.currentLayer.id && !clicked.panel.hidden) {
+            // Right-click works on hidden panels too — the menu shows
+            // "Restore From Blank" so they can be brought back.
+            if (clicked && clicked.layerId === window.app.currentLayer.id) {
                 const key = window.app.getPanelKey(clicked.panel);
                 if (!window.app.pixelMapSelection.has(key)) {
                     window.app.pixelMapSelection.clear();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.5.2</title>
+    <title>LED Raster Designer v0.7.5.3</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.5.2</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.5.3</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
Hidden (blank) panels were filtered out of every selection path, so once you blanked a panel there was no way to drag-select it back. Drag-select, plain click, right-click, and Cmd+click now all work on hidden panels. Bulk Restore via sidebar / Alt+click on the multi-selection then un-hides them.

Half-tile modifier (Alt+Shift+click) still skips hidden panels — half-tiling a hidden cell has no visible effect.

## Test plan
- [ ] Hide a 2×2 block via Alt+click drag, then drag-select across that block → all 4 panels in selection
- [ ] Click sidebar Restore (or unset Blank) → block restored
- [ ] Right-click a hidden panel → context menu shows "Restore From Blank"; click it → restored