### PR TITLE
v0.7.6.0 — Show Look tab + per-view raster + hidden-panel selection fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.5.3
+# LED Raster Designer v0.7.6.0
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,35 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.6.0 - April 30, 2026
+----------------------------
+- FEATURE: Show Look tab. New tab between Cabinet ID and Data that lets
+  you rearrange screen layers to match the real-world stage layout
+  without affecting the processor's expected layout.
+    - Pixel Map and Cabinet ID continue to use each layer's processor
+      position (offset_x / offset_y) — what the processor sends out.
+    - Show Look has its own per-layer position (showOffsetX / Y), which
+      also drives the Data and Power views so the wiring/power maps
+      match how the show is actually built on stage.
+    - Pixel Map and Show Look each have an independent raster size.
+      The toolbar Raster width/height edits the active view's raster:
+      pixel-map / cabinet-id edits the processor raster, show-look /
+      data / power edits the show raster.
+    - Shift-drag a screen on the canvas in Show Look (or Pixel Map) to
+      reposition it. Pixel Map drag writes to the processor position;
+      Show Look drag writes to the show position. The two can differ.
+    - Sidebar in Show Look exposes Show Offset X / Y inputs and a
+      "Reset to Pixel Map Position" button to re-sync.
+    - Show Look added to the export dialog with its own filename suffix.
+    - Existing projects open with show position = pixel position and
+      show raster = pixel raster, so nothing visually changes until you
+      start moving things in Show Look.
+- FIX: Hidden ("blank") panels in a Pixel Map drag-selection now render
+  a stronger blue tint than visible panels so you can clearly see which
+  blank cells are part of the selection. Without this, the normal
+  35%-alpha overlay was barely visible against the dark background of
+  an empty hidden cell.
+
 v0.7.5.3 - April 30, 2026
 ----------------------------
 - FIX: Hidden ("blank") panels could not be selected via drag-select,

--- a/src/app.py
+++ b/src/app.py
@@ -328,6 +328,12 @@ current_project = {
     'name': 'Untitled Project',
     'raster_width': 1920,
     'raster_height': 1080,
+    # Show Look has its own raster size — defaults to the same as the
+    # processor raster so existing projects open identically. The Show Look
+    # raster is used as the export canvas size for the Show Look / Data /
+    # Power views (which all render at the show position).
+    'show_raster_width': 1920,
+    'show_raster_height': 1080,
     'layers': [],
     'is_pristine': True
 }
@@ -374,6 +380,14 @@ def create_layer(name, columns, rows, cabinet_width, cabinet_height, offset_x=0,
         'cabinet_height': cabinet_height,
         'offset_x': offset_x,
         'offset_y': offset_y,
+        # Show Look position — used by the Show Look / Data / Power tabs.
+        # Defaults to the same values as offset_x/offset_y until the user
+        # rearranges the layer in the Show Look view, at which point the
+        # two positions diverge: pixel-map / cabinet-id keep using
+        # offset_x/y (the processor's expected layout) while show-look /
+        # data / power use showOffsetX/Y (the real-world stage layout).
+        'showOffsetX': offset_x,
+        'showOffsetY': offset_y,
         'panel_width_mm': 500.0,
         'panel_height_mm': 500.0,
         'panel_weight': 20.0,
@@ -794,6 +808,8 @@ def new_project():
         'name': 'Untitled Project',
         'raster_width': 1920,
         'raster_height': 1080,
+        'show_raster_width': 1920,
+        'show_raster_height': 1080,
         'layers': [],
         'is_pristine': True
     }
@@ -819,6 +835,20 @@ def restore_project():
     data = request.json
     current_project = data
     current_project['is_pristine'] = False
+    # Backfill showOffsetX/Y on layers from older projects that pre-date the
+    # Show Look feature — default them to the layer's processor offset so
+    # existing projects open with the show layout = pixel layout.
+    for layer in current_project.get('layers', []):
+        if layer.get('showOffsetX') is None:
+            layer['showOffsetX'] = layer.get('offset_x', 0)
+        if layer.get('showOffsetY') is None:
+            layer['showOffsetY'] = layer.get('offset_y', 0)
+    # Backfill the Show Look raster size to match the processor raster for
+    # projects saved before the Show Look feature.
+    if current_project.get('show_raster_width') is None:
+        current_project['show_raster_width'] = current_project.get('raster_width', 1920)
+    if current_project.get('show_raster_height') is None:
+        current_project['show_raster_height'] = current_project.get('raster_height', 1080)
     sync_next_layer_id()
     log_event('restore_project', {
         'name': current_project.get('name', '?'),
@@ -865,7 +895,8 @@ def add_layer():
         'portLabelTemplatePrimary', 'portLabelTemplateReturn',
         'portLabelOverridesPrimary', 'portLabelOverridesReturn',
         'customPortPaths', 'customPortIndex',
-        'randomDataColors'
+        'randomDataColors',
+        'showOffsetX', 'showOffsetY',
     ]
     
     half_fields = {'halfFirstColumn', 'halfLastColumn', 'halfFirstRow', 'halfLastRow'}
@@ -991,6 +1022,8 @@ def update_layer(layer_id):
                 'screenNameOffsetXDataFlow', 'screenNameOffsetYDataFlow',
                 'screenNameOffsetXPower', 'screenNameOffsetYPower',
                 'screenNameSize',
+                # Show Look position (separate from offset_x/y).
+                'showOffsetX', 'showOffsetY',
                 'showDataFlowPortInfo', 'showPowerCircuitInfo']:
         if key in data:
             layer[key] = data[key]

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.5.3',
-            'CFBundleVersion': '0.7.5.3',
+            'CFBundleShortVersionString': '0.7.6.0',
+            'CFBundleVersion': '0.7.6.0',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1043,12 +1043,23 @@ class LEDRasterApp {
             this.project = data;
             this.dedupeProjectLayers('socket_project_data');
             if (data && data.raster_width && data.raster_height) {
-                window.canvasRenderer.rasterWidth = data.raster_width;
-                window.canvasRenderer.rasterHeight = data.raster_height;
+                const r = window.canvasRenderer;
+                r.pixelRasterWidth = data.raster_width;
+                r.pixelRasterHeight = data.raster_height;
+                r.showRasterWidth = data.show_raster_width || data.raster_width;
+                r.showRasterHeight = data.show_raster_height || data.raster_height;
+                // Match the active fields to the current view.
+                if (r.isShowLookView()) {
+                    r.rasterWidth = r.showRasterWidth;
+                    r.rasterHeight = r.showRasterHeight;
+                } else {
+                    r.rasterWidth = r.pixelRasterWidth;
+                    r.rasterHeight = r.pixelRasterHeight;
+                }
                 const rw = document.getElementById('toolbar-raster-width');
                 const rh = document.getElementById('toolbar-raster-height');
-                if (rw) rw.value = data.raster_width;
-                if (rh) rh.value = data.raster_height;
+                if (rw) rw.value = r.rasterWidth;
+                if (rh) rh.value = r.rasterHeight;
                 this.saveRasterSize();
             }
 
@@ -1234,12 +1245,22 @@ class LEDRasterApp {
                 this.project = data;
                 this.dedupeProjectLayers('load_project');
                 if (data && data.raster_width && data.raster_height) {
-                    window.canvasRenderer.rasterWidth = data.raster_width;
-                    window.canvasRenderer.rasterHeight = data.raster_height;
+                    const r = window.canvasRenderer;
+                    r.pixelRasterWidth = data.raster_width;
+                    r.pixelRasterHeight = data.raster_height;
+                    r.showRasterWidth = data.show_raster_width || data.raster_width;
+                    r.showRasterHeight = data.show_raster_height || data.raster_height;
+                    if (r.isShowLookView()) {
+                        r.rasterWidth = r.showRasterWidth;
+                        r.rasterHeight = r.showRasterHeight;
+                    } else {
+                        r.rasterWidth = r.pixelRasterWidth;
+                        r.rasterHeight = r.pixelRasterHeight;
+                    }
                     const rw = document.getElementById('toolbar-raster-width');
                     const rh = document.getElementById('toolbar-raster-height');
-                    if (rw) rw.value = data.raster_width;
-                    if (rh) rh.value = data.raster_height;
+                    if (rw) rw.value = r.rasterWidth;
+                    if (rh) rh.value = r.rasterHeight;
                     this.saveRasterSize();
                 }
                 sendClientLog('load_project', { name: data.name, layers: data.layers ? data.layers.length : 0 });
@@ -1437,6 +1458,14 @@ class LEDRasterApp {
             if (layer.infoLabelSize === undefined) layer.infoLabelSize = 14;
             if (layer.showDataFlowPortInfo === undefined) layer.showDataFlowPortInfo = false;
             if (layer.showPowerCircuitInfo === undefined) layer.showPowerCircuitInfo = false;
+            // Show Look position — default to processor offset for older
+            // projects so they open looking identical to before.
+            if (layer.showOffsetX === undefined || layer.showOffsetX === null) {
+                layer.showOffsetX = layer.offset_x || 0;
+            }
+            if (layer.showOffsetY === undefined || layer.showOffsetY === null) {
+                layer.showOffsetY = layer.offset_y || 0;
+            }
         });
 
         // For startup factory-default project only, enforce saved preference defaults.
@@ -2066,8 +2095,9 @@ class LEDRasterApp {
             window.canvasRenderer.magneticSnap = e.target.checked;
         });
         
-        ['offset-x', 'offset-y', 'cabinet-width', 'cabinet-height', 
-         'screen-columns', 'screen-rows', 'number-size', 'panel-width-mm', 'panel-height-mm', 'panel-weight-kg', 'image-scale', 'image-scale-range'].forEach(id => {
+        ['offset-x', 'offset-y', 'cabinet-width', 'cabinet-height',
+         'screen-columns', 'screen-rows', 'number-size', 'panel-width-mm', 'panel-height-mm', 'panel-weight-kg', 'image-scale', 'image-scale-range',
+         'show-offset-x', 'show-offset-y'].forEach(id => {
             const input = document.getElementById(id);
             if (input) {
                 input.addEventListener('change', () => {
@@ -2079,6 +2109,23 @@ class LEDRasterApp {
                 });
             }
         });
+
+        // Show Look "Reset to Pixel Map Position" button
+        const showResetBtn = document.getElementById('show-look-reset');
+        if (showResetBtn) {
+            showResetBtn.addEventListener('click', () => {
+                const layers = this.getSelectedLayers ? this.getSelectedLayers() : (this.currentLayer ? [this.currentLayer] : []);
+                if (layers.length === 0) return;
+                this.saveState('Reset Show Look Position');
+                layers.forEach(l => {
+                    l.showOffsetX = l.offset_x;
+                    l.showOffsetY = l.offset_y;
+                });
+                this.updateLayers(layers, false);
+                this.loadLayerToInputs();
+                if (window.canvasRenderer) window.canvasRenderer.render();
+            });
+        }
         const imageScaleInput = document.getElementById('image-scale');
         const imageScaleRange = document.getElementById('image-scale-range');
         if (imageScaleInput && imageScaleRange) {
@@ -3401,34 +3448,59 @@ class LEDRasterApp {
         if (rasterWidthInput) {
             rasterWidthInput.addEventListener('change', () => {
                 const width = evaluateMathExpression(rasterWidthInput.value) || 1920;
-                window.canvasRenderer.rasterWidth = width;
-                rasterWidthInput.value = width; // Update input with evaluated result
+                rasterWidthInput.value = width;
+                // The toolbar edits the raster for the *current* view: pixel-map
+                // / cabinet-id edit the processor raster, show-look / data /
+                // power edit the show raster.
+                const renderer = window.canvasRenderer;
+                const isShow = renderer.isShowLookView();
+                if (isShow) {
+                    renderer.showRasterWidth = width;
+                } else {
+                    renderer.pixelRasterWidth = width;
+                }
+                renderer.rasterWidth = width;
                 if (this.project) {
-                    this.project.raster_width = width;
+                    if (isShow) {
+                        this.project.show_raster_width = width;
+                    } else {
+                        this.project.raster_width = width;
+                    }
                     this.saveProject();
                 }
                 this.saveRasterSize();
                 if (typeof sendClientLog === 'function') {
-                    sendClientLog('raster_change', { width, height: window.canvasRenderer.rasterHeight, source: 'toolbar-width' });
+                    sendClientLog('raster_change', { width, height: renderer.rasterHeight, source: 'toolbar-width', view: renderer.viewMode });
                 }
-                window.canvasRenderer.render();
+                renderer.render();
             });
         }
-        
+
         if (rasterHeightInput) {
             rasterHeightInput.addEventListener('change', () => {
                 const height = evaluateMathExpression(rasterHeightInput.value) || 1080;
-                window.canvasRenderer.rasterHeight = height;
-                rasterHeightInput.value = height; // Update input with evaluated result
+                rasterHeightInput.value = height;
+                const renderer = window.canvasRenderer;
+                const isShow = renderer.isShowLookView();
+                if (isShow) {
+                    renderer.showRasterHeight = height;
+                } else {
+                    renderer.pixelRasterHeight = height;
+                }
+                renderer.rasterHeight = height;
                 if (this.project) {
-                    this.project.raster_height = height;
+                    if (isShow) {
+                        this.project.show_raster_height = height;
+                    } else {
+                        this.project.raster_height = height;
+                    }
                     this.saveProject();
                 }
                 this.saveRasterSize();
                 if (typeof sendClientLog === 'function') {
-                    sendClientLog('raster_change', { width: window.canvasRenderer.rasterWidth, height, source: 'toolbar-height' });
+                    sendClientLog('raster_change', { width: renderer.rasterWidth, height, source: 'toolbar-height', view: renderer.viewMode });
                 }
-                window.canvasRenderer.render();
+                renderer.render();
             });
         }
         
@@ -3463,8 +3535,8 @@ class LEDRasterApp {
         });
         
         // Update preview when options change
-        ['export-name', 'export-format', 'export-pixel-map', 'export-cabinet-id', 'export-data-flow', 'export-power',
-         'export-suffix-pixel-map', 'export-suffix-cabinet-id', 'export-suffix-data-flow', 'export-suffix-power'].forEach(id => {
+        ['export-name', 'export-format', 'export-pixel-map', 'export-cabinet-id', 'export-show-look', 'export-data-flow', 'export-power',
+         'export-suffix-pixel-map', 'export-suffix-cabinet-id', 'export-suffix-show-look', 'export-suffix-data-flow', 'export-suffix-power'].forEach(id => {
             const el = document.getElementById(id);
             if (el) {
                 el.addEventListener('change', () => {
@@ -3511,6 +3583,7 @@ class LEDRasterApp {
             const views = [];
             if (document.getElementById('export-pixel-map').checked) views.push('pixel-map');
             if (document.getElementById('export-cabinet-id').checked) views.push('cabinet-id');
+            if (document.getElementById('export-show-look') && document.getElementById('export-show-look').checked) views.push('show-look');
             if (document.getElementById('export-data-flow').checked) views.push('data-flow');
             if (document.getElementById('export-power').checked) views.push('power');
 
@@ -5480,6 +5553,11 @@ class LEDRasterApp {
 
         const requests = layers.map(layer => {
             const preservedProps = {
+                // Show Look position — keep in sync across the server
+                // round-trip (server whitelists the field, but echoing the
+                // same value is safer than dropping it).
+                showOffsetX: layer.showOffsetX,
+                showOffsetY: layer.showOffsetY,
                 screenNameOffsetX: layer.screenNameOffsetX,
                 screenNameOffsetY: layer.screenNameOffsetY,
                 screenNameOffsetXCabinet: layer.screenNameOffsetXCabinet,
@@ -5615,13 +5693,17 @@ class LEDRasterApp {
 
         const offsetXVal = readNumber('offset-x').value;
         const offsetYVal = readNumber('offset-y').value;
-        
+        const showOffsetXVal = readNumber('show-offset-x').value;
+        const showOffsetYVal = readNumber('show-offset-y').value;
+
         // For multi-select: only apply the offset field that was actually changed by the user.
         // This prevents typing in Y from overwriting all layers' X values (or vice versa).
         const multiSelected = targetLayers.length > 1;
         const lastChanged = this._lastChangedInputId || null;
         const applyOffsetX = offsetXVal !== null && (!multiSelected || lastChanged === 'offset-x');
         const applyOffsetY = offsetYVal !== null && (!multiSelected || lastChanged === 'offset-y');
+        const applyShowOffsetX = showOffsetXVal !== null && (!multiSelected || lastChanged === 'show-offset-x');
+        const applyShowOffsetY = showOffsetYVal !== null && (!multiSelected || lastChanged === 'show-offset-y');
         const cabinetWidthVal = readNumber('cabinet-width').value;
         const cabinetHeightVal = readNumber('cabinet-height').value;
         const columnsVal = readNumber('screen-columns').value;
@@ -5717,6 +5799,8 @@ class LEDRasterApp {
             if (!layer.locked) {
                 if (applyOffsetX) layer.offset_x = offsetXVal;
                 if (applyOffsetY) layer.offset_y = offsetYVal;
+                if (applyShowOffsetX) layer.showOffsetX = showOffsetXVal;
+                if (applyShowOffsetY) layer.showOffsetY = showOffsetYVal;
             }
             if (isImage) {
                 if (imageScaleVal !== null && !Number.isNaN(imageScaleVal)) {
@@ -5849,6 +5933,9 @@ class LEDRasterApp {
 
         setTextInput('offset-x', getCommon(l => l.offset_x));
         setTextInput('offset-y', getCommon(l => l.offset_y));
+        // Show Look offsets — separate from processor offsets (Pixel Map).
+        setTextInput('show-offset-x', getCommon(l => (l.showOffsetX ?? l.offset_x) || 0));
+        setTextInput('show-offset-y', getCommon(l => (l.showOffsetY ?? l.offset_y) || 0));
 
         // Image layer controls
         const imageScaleEl = document.getElementById('image-scale');
@@ -6658,9 +6745,10 @@ class LEDRasterApp {
         const views = [];
         if (document.getElementById('export-pixel-map').checked) views.push('pixel-map');
         if (document.getElementById('export-cabinet-id').checked) views.push('cabinet-id');
+        if (document.getElementById('export-show-look') && document.getElementById('export-show-look').checked) views.push('show-look');
         if (document.getElementById('export-data-flow').checked) views.push('data-flow');
         if (document.getElementById('export-power').checked) views.push('power');
-        
+
         const preview = document.getElementById('export-preview');
 
         // Hide view checkboxes for Resolume XML (geometry only, no rendered views)
@@ -6715,6 +6803,7 @@ class LEDRasterApp {
         return {
             'pixel-map': 'Pixel Map',
             'cabinet-id': 'Cabinet Map',
+            'show-look': 'Show Look',
             'data-flow': 'Data Map',
             'power': 'Power Map'
         };
@@ -6724,6 +6813,7 @@ class LEDRasterApp {
         return {
             'pixel-map': 'Pixel Map',
             'cabinet-id': 'Cabinet Map',
+            'show-look': 'Show Look',
             'data-flow': 'Data Map',
             'power': 'Power Map'
         };
@@ -6745,6 +6835,7 @@ class LEDRasterApp {
         };
         apply('export-suffix-pixel-map', 'pixel-map');
         apply('export-suffix-cabinet-id', 'cabinet-id');
+        apply('export-suffix-show-look', 'show-look');
         apply('export-suffix-data-flow', 'data-flow');
         apply('export-suffix-power', 'power');
     }
@@ -6764,6 +6855,7 @@ class LEDRasterApp {
         return {
             'pixel-map': read('export-suffix-pixel-map', 'pixel-map'),
             'cabinet-id': read('export-suffix-cabinet-id', 'cabinet-id'),
+            'show-look': read('export-suffix-show-look', 'show-look'),
             'data-flow': read('export-suffix-data-flow', 'data-flow'),
             'power': read('export-suffix-power', 'power')
         };

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -15,6 +15,15 @@ class CanvasRenderer {
         this.layerSelectionRect = null;
         this.magneticSnap = true; // Magnetic snapping enabled by default
         this.spacePressed = false;
+        // rasterWidth/Height are the *currently active* view's raster size.
+        // The actual storage lives in pixelRasterWidth/Height and
+        // showRasterWidth/Height; setViewMode() swaps the active fields so
+        // pixel-map/cabinet-id render against the processor raster while
+        // show-look/data-flow/power render against the show raster.
+        this.pixelRasterWidth = 1920;
+        this.pixelRasterHeight = 1080;
+        this.showRasterWidth = 1920;
+        this.showRasterHeight = 1080;
         this.rasterWidth = 1920;
         this.rasterHeight = 1080;
         this.showGrid = true;
@@ -97,11 +106,38 @@ class CanvasRenderer {
         };
     }
 
+    /**
+     * Returns true when the current view uses the Show Look position
+     * (showOffsetX/Y) instead of the processor position (offset_x/y).
+     * Show Look itself, plus Data Flow and Power, all render at the
+     * real-world stage layout per the Show Look feature spec.
+     */
+    isShowLookView(mode = this.viewMode) {
+        return mode === 'show-look' || mode === 'data-flow' || mode === 'power';
+    }
+
+    /**
+     * Render-time translation to apply to a layer's geometry so it appears
+     * at its show position in show-look / data-flow / power. Returns
+     * {dx: 0, dy: 0} for pixel-map / cabinet-id (no shift).
+     */
+    getLayerRenderOffset(layer) {
+        if (!layer || !this.isShowLookView()) return { dx: 0, dy: 0 };
+        const procX = Number(layer.offset_x) || 0;
+        const procY = Number(layer.offset_y) || 0;
+        const showX = (layer.showOffsetX !== null && layer.showOffsetX !== undefined)
+            ? Number(layer.showOffsetX) : procX;
+        const showY = (layer.showOffsetY !== null && layer.showOffsetY !== undefined)
+            ? Number(layer.showOffsetY) : procY;
+        return { dx: showX - procX, dy: showY - procY };
+    }
+
     getLayerBounds(layer) {
+        const { dx, dy } = this.getLayerRenderOffset(layer);
         if (layer && (layer.type || 'screen') === 'text') {
             return {
-                x: Number(layer.offset_x) || 0,
-                y: Number(layer.offset_y) || 0,
+                x: (Number(layer.offset_x) || 0) + dx,
+                y: (Number(layer.offset_y) || 0) + dy,
                 width: Number(layer.textWidth) || 400,
                 height: Number(layer.textHeight) || 100
             };
@@ -111,8 +147,8 @@ class CanvasRenderer {
             const width = (Number(layer.imageWidth) || 0) * scale;
             const height = (Number(layer.imageHeight) || 0) * scale;
             return {
-                x: Number(layer.offset_x) || 0,
-                y: Number(layer.offset_y) || 0,
+                x: (Number(layer.offset_x) || 0) + dx,
+                y: (Number(layer.offset_y) || 0) + dy,
                 width,
                 height
             };
@@ -133,8 +169,8 @@ class CanvasRenderer {
                 if (y2 > maxY) maxY = y2;
             });
             return {
-                x: minX,
-                y: minY,
+                x: minX + dx,
+                y: minY + dy,
                 width: maxX - minX,
                 height: maxY - minY
             };
@@ -142,8 +178,8 @@ class CanvasRenderer {
         const width = (Number(layer.columns) || 0) * (Number(layer.cabinet_width) || 0);
         const height = (Number(layer.rows) || 0) * (Number(layer.cabinet_height) || 0);
         return {
-            x: Number(layer.offset_x) || 0,
-            y: Number(layer.offset_y) || 0,
+            x: (Number(layer.offset_x) || 0) + dx,
+            y: (Number(layer.offset_y) || 0) + dy,
             width,
             height
         };
@@ -165,9 +201,12 @@ class CanvasRenderer {
         }
         
         if (e.button === 0 && e.shiftKey) {
-            // Let shift+drag behavior handle screen name move
+            // Let shift+drag behavior handle screen name move on cabinet-id /
+            // data-flow / power. On pixel-map and show-look, fall through so
+            // shift+drag moves the entire layer (writing to offset_x/y or
+            // showOffsetX/Y respectively).
             if (window.app && window.app.currentLayer) {
-                if (this.viewMode !== 'pixel-map') {
+                if (this.viewMode !== 'pixel-map' && this.viewMode !== 'show-look') {
                     this.isDraggingScreenName = true;
                     this.dragScreenNameStartX = worldX;
                     this.dragScreenNameStartY = worldY;
@@ -260,9 +299,11 @@ class CanvasRenderer {
             this.canvas.style.cursor = 'grabbing';
         } else if (e.button === 0 && e.shiftKey && !e.altKey) {
             if (window.app && window.app.currentLayer) {
-                // On pixel-map: drag entire layer
-                // On other modes: drag screen name label only
-                if (this.viewMode === 'pixel-map') {
+                // On pixel-map / show-look: drag entire layer.
+                //   - pixel-map writes to offset_x/y (the processor position)
+                //   - show-look writes to showOffsetX/Y (the show position)
+                // On data-flow / power / cabinet-id: drag screen name label only.
+                if (this.viewMode === 'pixel-map' || this.viewMode === 'show-look') {
                     const selected = window.app.getSelectedLayers ? window.app.getSelectedLayers() : [window.app.currentLayer];
                     const uniqueSelected = [];
                     const seenIds = new Set();
@@ -279,28 +320,45 @@ class CanvasRenderer {
                         return;
                     }
                     this.isDraggingLayer = true;
+                    this.dragLayerMode = (this.viewMode === 'show-look') ? 'show' : 'processor';
                     // Save state BEFORE the drag starts so undo reverts to pre-move positions
                     if (typeof window.app.saveState === 'function') {
-                        window.app.saveState('Move Layers');
+                        window.app.saveState(this.dragLayerMode === 'show' ? 'Move Layers (Show Look)' : 'Move Layers');
                     }
                     this.dragLayerStartX = worldX;
                     this.dragLayerStartY = worldY;
-                    this.layerStartOffset = {
-                        x: window.app.currentLayer.offset_x,
-                        y: window.app.currentLayer.offset_y
-                    };
+                    const useShow = this.dragLayerMode === 'show';
+                    const startX = useShow
+                        ? (window.app.currentLayer.showOffsetX ?? window.app.currentLayer.offset_x ?? 0)
+                        : (window.app.currentLayer.offset_x ?? 0);
+                    const startY = useShow
+                        ? (window.app.currentLayer.showOffsetY ?? window.app.currentLayer.offset_y ?? 0)
+                        : (window.app.currentLayer.offset_y ?? 0);
+                    this.layerStartOffset = { x: startX, y: startY };
                     this.dragLayerOffsets = movable.map(layer => ({
                         id: layer.id,
-                        startX: layer.offset_x,
-                        startY: layer.offset_y,
-                        panelStarts: (layer.panels || []).map(panel => ({
+                        startX: useShow
+                            ? (layer.showOffsetX ?? layer.offset_x ?? 0)
+                            : (layer.offset_x ?? 0),
+                        startY: useShow
+                            ? (layer.showOffsetY ?? layer.offset_y ?? 0)
+                            : (layer.offset_y ?? 0),
+                        // Only the processor-position drag mutates panel.x/y
+                        // (panels live in processor coords). Show-position
+                        // drag is rendered via ctx.translate so panels stay
+                        // put.
+                        panelStarts: useShow ? null : (layer.panels || []).map(panel => ({
                             id: panel.id,
                             x: panel.x,
                             y: panel.y
                         }))
                     }));
                     if (typeof sendClientLog === 'function') {
-                        sendClientLog('layer_drag_start', { viewMode: this.viewMode, layerIds: movable.map(l => l.id) });
+                        sendClientLog('layer_drag_start', {
+                            viewMode: this.viewMode,
+                            mode: this.dragLayerMode,
+                            layerIds: movable.map(l => l.id),
+                        });
                     }
                 } else {
                     // Dragging screen name on cabinet-id, data-flow, power modes
@@ -493,22 +551,30 @@ class CanvasRenderer {
                 if (movable.length === 0) {
                     return;
                 }
+                const showMode = this.dragLayerMode === 'show';
                 movable.forEach(item => {
                     const layer = window.app.project.layers.find(l => l.id === item.id);
                     if (!layer || layer.locked) return;
                     const nextX = item.startX + snapDx;
                     const nextY = item.startY + snapDy;
-                    layer.offset_x = nextX;
-                    layer.offset_y = nextY;
-                    const startMap = new Map((item.panelStarts || []).map(p => [p.id, p]));
-                    layer.panels.forEach(panel => {
-                        const start = startMap.get(panel.id);
-                        if (!start) return;
-                        panel.x = start.x + snapDx;
-                        panel.y = start.y + snapDy;
-                    });
+                    if (showMode) {
+                        // Show Look drag — only the show position changes;
+                        // panels stay at their processor coords.
+                        layer.showOffsetX = nextX;
+                        layer.showOffsetY = nextY;
+                    } else {
+                        layer.offset_x = nextX;
+                        layer.offset_y = nextY;
+                        const startMap = new Map((item.panelStarts || []).map(p => [p.id, p]));
+                        layer.panels.forEach(panel => {
+                            const start = startMap.get(panel.id);
+                            if (!start) return;
+                            panel.x = start.x + snapDx;
+                            panel.y = start.y + snapDy;
+                        });
+                    }
                 });
-                
+
                 this.render();
             }
         } else if (this.isDraggingScreenName) {
@@ -781,22 +847,28 @@ class CanvasRenderer {
                     const layer = window.app.project.layers.find(l => l.id === item.id);
                     return layer && !layer.locked;
                 });
+                const showMode = this.dragLayerMode === 'show';
                 movable.forEach(item => {
                     const layer = window.app.project.layers.find(l => l.id === item.id);
                     if (!layer || layer.locked) return;
                     const nextX = item.startX + snapDx;
                     const nextY = item.startY + snapDy;
-                    layer.offset_x = nextX;
-                    layer.offset_y = nextY;
-                    const startMap = new Map((item.panelStarts || []).map(p => [p.id, p]));
-                    layer.panels.forEach(panel => {
-                        const start = startMap.get(panel.id);
-                        if (!start) return;
-                        panel.x = start.x + snapDx;
-                        panel.y = start.y + snapDy;
-                    });
+                    if (showMode) {
+                        layer.showOffsetX = nextX;
+                        layer.showOffsetY = nextY;
+                    } else {
+                        layer.offset_x = nextX;
+                        layer.offset_y = nextY;
+                        const startMap = new Map((item.panelStarts || []).map(p => [p.id, p]));
+                        layer.panels.forEach(panel => {
+                            const start = startMap.get(panel.id);
+                            if (!start) return;
+                            panel.x = start.x + snapDx;
+                            panel.y = start.y + snapDy;
+                        });
+                    }
                 });
-                
+
                 // Update Screen Info inputs to reflect current positions (respects mixed values)
                 if (window.app.loadLayerToInputs) {
                     window.app.loadLayerToInputs();
@@ -804,9 +876,10 @@ class CanvasRenderer {
                     document.getElementById('offset-x').value = window.app.currentLayer.offset_x;
                     document.getElementById('offset-y').value = window.app.currentLayer.offset_y;
                 }
-                
+
                 const toUpdate = window.app.getSelectedLayers ? window.app.getSelectedLayers() : [window.app.currentLayer];
                 window.app.updateLayers(toUpdate, false);
+                this.dragLayerMode = null;
             }
         } else if (this.isDraggingScreenName) {
             this.isDraggingScreenName = false;
@@ -1083,10 +1156,16 @@ class CanvasRenderer {
             const layer = window.app.project.layers[i];
             if (!layer.visible) continue;
             if ((layer.type || 'screen') === 'image') continue;
+            // Convert world coords back into the layer's processor space so we
+            // can hit-test against panel.x/y (which are stored at processor
+            // position; show-look just renders with a translate).
+            const { dx, dy } = this.getLayerRenderOffset(layer);
+            const lx = worldX - dx;
+            const ly = worldY - dy;
             for (const panel of layer.panels) {
                 // Don't skip hidden panels - they need to be clickable to toggle back
-                if (worldX >= panel.x && worldX <= panel.x + panel.width &&
-                    worldY >= panel.y && worldY <= panel.y + panel.height) {
+                if (lx >= panel.x && lx <= panel.x + panel.width &&
+                    ly >= panel.y && ly <= panel.y + panel.height) {
                     return { panel, layerId: layer.id };
                 }
             }
@@ -1313,38 +1392,53 @@ class CanvasRenderer {
                     if (this.viewMode === 'power') {
                         this.preparePowerLayerRenderData(layer);
                     }
+                    // Show Look / Data / Power render at the layer's show
+                    // position rather than its processor position. We apply
+                    // that as a per-layer ctx translate so all the existing
+                    // panel.x/y math stays in processor coords.
+                    const { dx, dy } = this.getLayerRenderOffset(layer);
+                    const needsShift = dx !== 0 || dy !== 0;
+                    if (needsShift) {
+                        this.ctx.save();
+                        this.ctx.translate(dx, dy);
+                    }
                     if ((layer.type || 'screen') === 'image') {
                         this.renderImageLayer(layer);
+                        if (needsShift) this.ctx.restore();
                         return;
                     }
                     if ((layer.type || 'screen') === 'text') {
                         this.renderTextLayer(layer);
+                        if (needsShift) this.ctx.restore();
                         return;
                     }
                     // Note: We don't fill the layer background anymore
                     // Each panel fills its own area, and hidden panels show as outlines
                     // This allows hidden panels to be transparent instead of black
-                    
+
                     layer.panels.forEach(panel => {
-                        if (panel.x >= this.rasterWidth || panel.y >= this.rasterHeight) return;
-                        
+                        // Compare against raster bounds in the layer's render
+                        // space so panels that are off-canvas in pixel-map but
+                        // on-canvas in show-look (or vice versa) draw correctly.
+                        if (panel.x + dx >= this.rasterWidth || panel.y + dy >= this.rasterHeight) return;
+
                         // Render all panels - visible and hidden (hidden as ghost outlines)
                         this.renderPanel(panel, layer);
                     });
-                    
+
                     // Render Circle with X test pattern
                     if (layer.show_circle_with_x && this.viewMode === 'pixel-map' && (layer.type || 'screen') !== 'image') {
                         this.renderCircleWithX(layer);
                     }
-                    
+
                     // Render offsets (pixel-map only)
                     this.renderLayerOffsets(layer);
-                    
+
                     // Render Cabinet ID numbers in world space (scales with zoom)
                     if (this.viewMode === 'cabinet-id') {
                         this.renderCabinetIDNumbers(layer);
                     }
-                    
+
                     // Render Data Flow arrows (serpentine path with P1/R1 labels)
                     if (this.viewMode === 'data-flow') {
                         this.renderDataFlowArrows(layer);
@@ -1356,6 +1450,7 @@ class CanvasRenderer {
                     // Render labels as part of each layer so upper layers naturally
                     // paint over lower layers' labels (no bleed-through)
                     this.renderLayerLabels(layer);
+                    if (needsShift) this.ctx.restore();
                 }
             });
 
@@ -1631,6 +1726,22 @@ class CanvasRenderer {
     
     setViewMode(mode) {
         this.viewMode = mode;
+        // Swap the active raster to match the view. Show-look and the
+        // downstream tabs (data-flow, power) render at the show raster;
+        // pixel-map and cabinet-id render at the processor raster.
+        if (this.isShowLookView(mode)) {
+            this.rasterWidth = this.showRasterWidth;
+            this.rasterHeight = this.showRasterHeight;
+        } else {
+            this.rasterWidth = this.pixelRasterWidth;
+            this.rasterHeight = this.pixelRasterHeight;
+        }
+        // Reflect the active raster in the toolbar inputs so the user sees
+        // the right numbers when switching tabs.
+        const rw = document.getElementById('toolbar-raster-width');
+        const rh = document.getElementById('toolbar-raster-height');
+        if (rw) rw.value = this.rasterWidth;
+        if (rh) rh.value = this.rasterHeight;
         this.render();
     }
 
@@ -1662,6 +1773,12 @@ class CanvasRenderer {
                 break;
             case 'cabinet-id':
                 this.renderCabinetID(panel, layer);
+                break;
+            case 'show-look':
+                // Show Look uses the same checkerboard look as Pixel Map so
+                // the user can see the screen arrangement; only the layout
+                // (positions) differs.
+                this.renderPixelMap(panel, layer);
                 break;
             case 'data-flow':
                 this.renderDataFlow(panel, layer);
@@ -3186,13 +3303,21 @@ class CanvasRenderer {
         this.ctx.beginPath();
         this.ctx.rect(0, 0, this.rasterWidth, this.rasterHeight);
         this.ctx.clip();
-        this.ctx.fillStyle = 'rgba(74, 144, 226, 0.35)';
-        this.ctx.strokeStyle = 'rgba(74, 144, 226, 1.0)';
         this.ctx.lineWidth = 2 / this.zoom;
         selection.forEach(key => {
             const [row, col] = key.split(',').map(n => parseInt(n, 10));
             const panel = window.app.getPanelByRowCol(layer, row, col);
             if (!panel) return;
+            // Hidden ("blank") panels render as just a faint dashed outline,
+            // so the normal 0.35-alpha selection tint barely shows against the
+            // dark background. Use a stronger fill on hidden panels so the
+            // user can clearly see which blank cells are part of the selection.
+            if (panel.hidden) {
+                this.ctx.fillStyle = 'rgba(74, 144, 226, 0.55)';
+            } else {
+                this.ctx.fillStyle = 'rgba(74, 144, 226, 0.35)';
+            }
+            this.ctx.strokeStyle = 'rgba(74, 144, 226, 1.0)';
             this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
             this.ctx.strokeRect(panel.x, panel.y, panel.width, panel.height);
         });

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.5.3</title>
+    <title>LED Raster Designer v0.7.6.0</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.5.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.0</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -100,10 +100,11 @@
         </div>
 
         <div id="view-tabs">
-            <button class="view-tab active" data-mode="pixel-map" data-tooltip="Pixel map view — layout and positioning">Pixel Map</button>
-            <button class="view-tab" data-mode="cabinet-id" data-tooltip="Cabinet ID view — label and identify panels">Cabinet ID</button>
-            <button class="view-tab" data-mode="data-flow" data-tooltip="Data flow view — signal routing and ports">Data</button>
-            <button class="view-tab" data-mode="power" data-tooltip="Power view — electrical distribution">Power</button>
+            <button class="view-tab active" data-mode="pixel-map" data-tooltip="Pixel map view — layout and positioning (the layout the processor expects)">Pixel Map</button>
+            <button class="view-tab" data-mode="cabinet-id" data-tooltip="Cabinet ID view — label and identify panels (matches Pixel Map layout)">Cabinet ID</button>
+            <button class="view-tab" data-mode="show-look" data-tooltip="Show Look — rearrange screens to the real-world stage layout. Drives the layout shown in Data and Power views.">Show Look</button>
+            <button class="view-tab" data-mode="data-flow" data-tooltip="Data flow view — signal routing and ports (uses Show Look layout)">Data</button>
+            <button class="view-tab" data-mode="power" data-tooltip="Power view — electrical distribution (uses Show Look layout)">Power</button>
         </div>
 
         <div id="main-container">
@@ -378,7 +379,30 @@
                         </div>
                     </div>
                 </div>
-                
+
+                <!-- Show Look Controls -->
+                <div class="panel tab-panel screen-only" data-tab="show-look" style="display: none;">
+                    <div class="panel-header" data-tooltip="Show Look — Rearrange screens to match the real-world stage layout. Pixel Map and Cabinet ID stay tied to the processor's expected layout; Show Look drives Data and Power.">
+                        <h2>Show Look</h2>
+                    </div>
+                    <div class="panel-content">
+                        <div style="color:#aaa; font-size: 11px; margin-bottom: 10px; line-height: 1.4;">
+                            Shift-drag a screen on the canvas to position it for the real-world stage layout, or set the offsets here. Data and Power views render at this layout.
+                        </div>
+                        <div class="info-row" data-tooltip="Show Offset X — Horizontal position of this screen in the Show Look layout.">
+                            <label>Show Offset X</label>
+                            <input type="text" id="show-offset-x" value="0">
+                        </div>
+                        <div class="info-row" data-tooltip="Show Offset Y — Vertical position of this screen in the Show Look layout.">
+                            <label>Show Offset Y</label>
+                            <input type="text" id="show-offset-y" value="0">
+                        </div>
+                        <div style="margin-top: 12px;">
+                            <button id="show-look-reset" class="btn" style="width:100%;" data-tooltip="Reset this screen's Show Look position to match its Pixel Map position.">Reset to Pixel Map Position</button>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Data Controls -->
                 <div class="panel tab-panel screen-only" data-tab="data-flow" style="display: none;">
                     <div class="panel-header" data-tooltip="Data Settings — Configure data port mapping, flow patterns, port labels, and visual styling for the data flow overlay.">
@@ -1290,6 +1314,13 @@
                             Cabinet Map
                         </label>
                         <input type="text" id="export-suffix-cabinet-id" placeholder="Cabinet Map">
+                    </div>
+                    <div class="export-view-row">
+                        <label class="export-view-label">
+                            <input type="checkbox" id="export-show-look">
+                            Show Look
+                        </label>
+                        <input type="text" id="export-suffix-show-look" placeholder="Show Look">
                     </div>
                     <div class="export-view-row">
                         <label class="export-view-label">


### PR DESCRIPTION
## Summary
**Show Look tab**: new tab between Cabinet ID and Data. Rearrange screens to the real-world stage layout. Pixel Map / Cabinet ID keep the processor layout; Show Look drives Data and Power.

- Per-layer \`showOffsetX/Y\` (separate from \`offset_x/y\`)
- Per-view raster size (\`show_raster_width/height\` separate from \`raster_width/height\`)
- Shift-drag in Show Look writes show position; pixel-map drag writes processor position
- Sidebar Show Offset X/Y inputs + 'Reset to Pixel Map Position' button
- Export checkbox + suffix for Show Look

**Bug fix**: hidden (blank) panels in a Pixel Map drag-selection now render a stronger blue tint so you can see which blank cells are in the selection.

Backwards compatible: older projects open with show position = pixel position and show raster = pixel raster.

## Test plan
- [ ] Add 2 screens, switch to Show Look — both render at processor positions
- [ ] Shift-drag a screen in Show Look — Pixel Map / Cabinet ID unchanged; Data / Power use the new layout
- [ ] Set raster 3840×2160 in Pixel Map; switch to Show Look; set raster 5120×1440 — both persist independently
- [ ] Drag-select across hidden panels — they show blue overlay clearly
- [ ] 'Reset to Pixel Map Position' button syncs show offset back
- [ ] Export with Show Look checkbox → renders show layout at show raster