### PR TITLE
v0.7.6.1 — Show Look raster tracks Pixel Map by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.6.0
+# LED Raster Designer v0.7.6.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,14 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.6.1 - April 30, 2026
+----------------------------
+- FIX: Show Look raster now tracks the Pixel Map raster by default.
+  Changing the Pixel Map raster size also updates the Show Look raster
+  while they're equal (which is the case for new projects and any
+  project where Show Look hasn't been explicitly resized). Once you
+  set a different raster size in Show Look, the two stay independent.
+
 v0.7.6.0 - April 30, 2026
 ----------------------------
 - FEATURE: Show Look tab. New tab between Cabinet ID and Data that lets

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.6.0',
-            'CFBundleVersion': '0.7.6.0',
+            'CFBundleShortVersionString': '0.7.6.1',
+            'CFBundleVersion': '0.7.6.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -3452,25 +3452,30 @@ class LEDRasterApp {
                 // The toolbar edits the raster for the *current* view: pixel-map
                 // / cabinet-id edit the processor raster, show-look / data /
                 // power edit the show raster.
+                //
+                // While show raster equals pixel raster ("linked"), changing
+                // the pixel raster also updates the show raster — Show Look
+                // tracks Pixel Map by default. Once they're set to different
+                // values they stay independent.
                 const renderer = window.canvasRenderer;
                 const isShow = renderer.isShowLookView();
+                const wasLinked = renderer.pixelRasterWidth === renderer.showRasterWidth;
                 if (isShow) {
                     renderer.showRasterWidth = width;
+                    if (this.project) this.project.show_raster_width = width;
                 } else {
                     renderer.pixelRasterWidth = width;
+                    if (this.project) this.project.raster_width = width;
+                    if (wasLinked) {
+                        renderer.showRasterWidth = width;
+                        if (this.project) this.project.show_raster_width = width;
+                    }
                 }
                 renderer.rasterWidth = width;
-                if (this.project) {
-                    if (isShow) {
-                        this.project.show_raster_width = width;
-                    } else {
-                        this.project.raster_width = width;
-                    }
-                    this.saveProject();
-                }
+                if (this.project) this.saveProject();
                 this.saveRasterSize();
                 if (typeof sendClientLog === 'function') {
-                    sendClientLog('raster_change', { width, height: renderer.rasterHeight, source: 'toolbar-width', view: renderer.viewMode });
+                    sendClientLog('raster_change', { width, height: renderer.rasterHeight, source: 'toolbar-width', view: renderer.viewMode, autoSyncedShow: !isShow && wasLinked });
                 }
                 renderer.render();
             });
@@ -3482,23 +3487,23 @@ class LEDRasterApp {
                 rasterHeightInput.value = height;
                 const renderer = window.canvasRenderer;
                 const isShow = renderer.isShowLookView();
+                const wasLinked = renderer.pixelRasterHeight === renderer.showRasterHeight;
                 if (isShow) {
                     renderer.showRasterHeight = height;
+                    if (this.project) this.project.show_raster_height = height;
                 } else {
                     renderer.pixelRasterHeight = height;
+                    if (this.project) this.project.raster_height = height;
+                    if (wasLinked) {
+                        renderer.showRasterHeight = height;
+                        if (this.project) this.project.show_raster_height = height;
+                    }
                 }
                 renderer.rasterHeight = height;
-                if (this.project) {
-                    if (isShow) {
-                        this.project.show_raster_height = height;
-                    } else {
-                        this.project.raster_height = height;
-                    }
-                    this.saveProject();
-                }
+                if (this.project) this.saveProject();
                 this.saveRasterSize();
                 if (typeof sendClientLog === 'function') {
-                    sendClientLog('raster_change', { width: renderer.rasterWidth, height, source: 'toolbar-height', view: renderer.viewMode });
+                    sendClientLog('raster_change', { width: renderer.rasterWidth, height, source: 'toolbar-height', view: renderer.viewMode, autoSyncedShow: !isShow && wasLinked });
                 }
                 renderer.render();
             });

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.6.0</title>
+    <title>LED Raster Designer v0.7.6.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.0</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
Show Look raster now defaults to (and tracks) the Pixel Map raster size while they're equal. Set Show Look to a different size and they diverge — Pixel Map changes after that no longer touch Show Look.

## Test plan
- [ ] New project, change Pixel Map raster from 1920×1080 → 3840×2160; switch to Show Look → raster shows 3840×2160
- [ ] In Show Look, change raster to 5120×1440; switch back to Pixel Map → raster still 3840×2160
- [ ] In Pixel Map, change raster to 4096×2304; switch to Show Look → raster still 5120×1440 (no longer linked)