### PR TITLE
v0.7.6.2 — Show Look raster sync on file open

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.6.1
+# LED Raster Designer v0.7.6.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.6.2 - April 30, 2026
+----------------------------
+- FIX: Opening a project file (recent or via the file picker) didn't
+  sync the renderer's pixel/show raster backing fields, so Show Look
+  showed the wrong raster size after a file open even though the
+  project's data was correct. Added a single syncRasterFromProject()
+  helper that all project-load paths now call (initial socket connect,
+  HTTP /api/project, file-picker open, recent files, new project) so
+  Show Look picks up the file's saved show raster, falling back to
+  the pixel raster when the file pre-dates the Show Look feature.
+
 v0.7.6.1 - April 30, 2026
 ----------------------------
 - FIX: Show Look raster now tracks the Pixel Map raster by default.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.6.1',
-            'CFBundleVersion': '0.7.6.1',
+            'CFBundleShortVersionString': '0.7.6.2',
+            'CFBundleVersion': '0.7.6.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1043,23 +1043,7 @@ class LEDRasterApp {
             this.project = data;
             this.dedupeProjectLayers('socket_project_data');
             if (data && data.raster_width && data.raster_height) {
-                const r = window.canvasRenderer;
-                r.pixelRasterWidth = data.raster_width;
-                r.pixelRasterHeight = data.raster_height;
-                r.showRasterWidth = data.show_raster_width || data.raster_width;
-                r.showRasterHeight = data.show_raster_height || data.raster_height;
-                // Match the active fields to the current view.
-                if (r.isShowLookView()) {
-                    r.rasterWidth = r.showRasterWidth;
-                    r.rasterHeight = r.showRasterHeight;
-                } else {
-                    r.rasterWidth = r.pixelRasterWidth;
-                    r.rasterHeight = r.pixelRasterHeight;
-                }
-                const rw = document.getElementById('toolbar-raster-width');
-                const rh = document.getElementById('toolbar-raster-height');
-                if (rw) rw.value = r.rasterWidth;
-                if (rh) rh.value = r.rasterHeight;
+                this.syncRasterFromProject();
                 this.saveRasterSize();
             }
 
@@ -1245,22 +1229,7 @@ class LEDRasterApp {
                 this.project = data;
                 this.dedupeProjectLayers('load_project');
                 if (data && data.raster_width && data.raster_height) {
-                    const r = window.canvasRenderer;
-                    r.pixelRasterWidth = data.raster_width;
-                    r.pixelRasterHeight = data.raster_height;
-                    r.showRasterWidth = data.show_raster_width || data.raster_width;
-                    r.showRasterHeight = data.show_raster_height || data.raster_height;
-                    if (r.isShowLookView()) {
-                        r.rasterWidth = r.showRasterWidth;
-                        r.rasterHeight = r.showRasterHeight;
-                    } else {
-                        r.rasterWidth = r.pixelRasterWidth;
-                        r.rasterHeight = r.pixelRasterHeight;
-                    }
-                    const rw = document.getElementById('toolbar-raster-width');
-                    const rh = document.getElementById('toolbar-raster-height');
-                    if (rw) rw.value = r.rasterWidth;
-                    if (rh) rh.value = r.rasterHeight;
+                    this.syncRasterFromProject();
                     this.saveRasterSize();
                 }
                 sendClientLog('load_project', { name: data.name, layers: data.layers ? data.layers.length : 0 });
@@ -1653,6 +1622,43 @@ class LEDRasterApp {
         };
         localStorage.setItem('ledRasterSize', JSON.stringify(rasterSize));
     }
+
+    /**
+     * Sync the canvas renderer's pixel/show raster backing fields from the
+     * loaded project. Older projects pre-date the show raster, so default
+     * the show fields to the pixel fields when missing. Also refresh the
+     * toolbar input to match the currently active view's raster.
+     */
+    syncRasterFromProject() {
+        if (!this.project) return;
+        const r = window.canvasRenderer;
+        if (!r) return;
+        const pw = Number(this.project.raster_width) || r.pixelRasterWidth || 1920;
+        const ph = Number(this.project.raster_height) || r.pixelRasterHeight || 1080;
+        const sw = Number(this.project.show_raster_width) || pw;
+        const sh = Number(this.project.show_raster_height) || ph;
+        r.pixelRasterWidth = pw;
+        r.pixelRasterHeight = ph;
+        r.showRasterWidth = sw;
+        r.showRasterHeight = sh;
+        // Make sure the project dict carries both — older projects may have
+        // been opened without going through the server migration.
+        this.project.raster_width = pw;
+        this.project.raster_height = ph;
+        this.project.show_raster_width = sw;
+        this.project.show_raster_height = sh;
+        if (r.isShowLookView()) {
+            r.rasterWidth = sw;
+            r.rasterHeight = sh;
+        } else {
+            r.rasterWidth = pw;
+            r.rasterHeight = ph;
+        }
+        const rwIn = document.getElementById('toolbar-raster-width');
+        const rhIn = document.getElementById('toolbar-raster-height');
+        if (rwIn) rwIn.value = r.rasterWidth;
+        if (rhIn) rhIn.value = r.rasterHeight;
+    }
     
     // Load raster size from localStorage (checks version first)
     loadRasterSize() {
@@ -1720,6 +1726,7 @@ class LEDRasterApp {
             .then(data => {
                 this.project = data;
                 this.dedupeProjectLayers('new_project');
+                this.syncRasterFromProject();
                 sendClientLog('new_project');
                 this.updateUI();
 
@@ -8161,11 +8168,10 @@ class LEDRasterApp {
                     this.normalizeLoadedPowerFlowPattern(layer);
                 });
             }
+            // Sync renderer's pixel/show raster fields from the loaded file.
+            // syncRasterFromProject handles view-aware raster + toolbar input.
+            this.syncRasterFromProject();
             if (file.data.raster_width && file.data.raster_height) {
-                window.canvasRenderer.rasterWidth = file.data.raster_width;
-                window.canvasRenderer.rasterHeight = file.data.raster_height;
-                document.getElementById('toolbar-raster-width').value = file.data.raster_width;
-                document.getElementById('toolbar-raster-height').value = file.data.raster_height;
                 this.saveRasterSize();
             }
             this.updateUI();
@@ -8187,6 +8193,7 @@ class LEDRasterApp {
                     }
                     this.project = data;
                     this.dedupeProjectLayers('load_recent_file');
+                    this.syncRasterFromProject();
                     if (this.project.layers) {
                         this.project.layers.forEach(layer => {
                             this.applyMissingLayerDefaults(layer);
@@ -9766,6 +9773,10 @@ class LEDRasterApp {
                                         this.normalizeLoadedPowerFlowPattern(layer);
                                     });
                                 }
+                                // Sync the canvas's pixel/show raster backing fields from the
+                                // loaded project so Show Look picks up the file's values
+                                // (and falls back to the pixel raster when show wasn't saved).
+                                this.syncRasterFromProject();
                                 this.updateUI();
                                 if (this.project.layers && this.project.layers.length > 0) {
                                     this.selectLayer(this.project.layers[0]);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.6.1</title>
+    <title>LED Raster Designer v0.7.6.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
File-open and recent-file paths weren't updating the renderer's pixel/show raster backing fields, so Show Look kept showing 1920×1080 after loading a project. Added \`syncRasterFromProject()\` helper, called from every project-load path. Older files (no \`show_raster_*\` saved) fall back to the pixel raster value.

## Test plan
- [ ] Open an old project file (saved before v0.7.6.0) → Show Look raster matches Pixel Map raster
- [ ] Open a v0.7.6.x project where Show Look was set to a different size → Show Look raster preserves the divergent value
- [ ] Open via 'Recent Files' → same behavior