### PR TITLE
v0.7.6.3 — collapsible sidebars + show-look render/auto-link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.6.2
+# LED Raster Designer v0.7.6.3
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,31 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.6.3 - May 1, 2026
+----------------------------
+- FEATURE: Collapsible side panels. A small chevron tab on the inner
+  edge of each sidebar collapses/expands the panel independently. The
+  toggle anchors to the sidebar's actual edge via ResizeObserver so it
+  stays in place at any window/sidebar size. Collapsed state persists
+  in localStorage per side.
+- FIX: Editing or dragging a layer's Pixel Map offset now mirrors the
+  change to the Show Look offset while the two are still equal
+  (linked). Without this, moving a layer in Pixel Map left Show Look /
+  Data / Power rendering at the old position. Once you set a different
+  Show Look offset, the two stay independent — Pixel Map edits no
+  longer touch Show Look.
+- FIX: Screen name labels and other per-layer labels were rendered
+  off-center in Show Look / Data / Power because the per-layer ctx
+  translate AND the bounds-calculation both added the show-offset,
+  double-shifting label positions. Bounds returned by getLayerBounds
+  are now in raw processor coords; new getLayerBoundsInActiveView
+  helper is used for the few callers that operate outside the
+  per-layer translate (selection bounding box, hit-test, magnetic
+  snap, screen-name drag, zoom-to-fit).
+- FIX: "Reset to Pixel Map Position" appeared to put screens in the
+  wrong spot — same root cause as the label bug above. Now resets
+  cleanly with screens visually matching their pixel-map positions.
+
 v0.7.6.2 - April 30, 2026
 ----------------------------
 - FIX: Opening a project file (recent or via the file picker) didn't

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.6.2',
-            'CFBundleVersion': '0.7.6.2',
+            'CFBundleShortVersionString': '0.7.6.3',
+            'CFBundleVersion': '0.7.6.3',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -27,9 +27,48 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 .btn-primary { background: #4A90E2; border-color: #4A90E2; color: white; }
 .btn-primary:hover { background: #357ABD; }
 .full-width { width: 100%; }
-#main-container { display: flex; flex: 1; overflow: hidden; }
-#left-sidebar, #right-sidebar { background: #252525; width: 260px; overflow-y: auto; overflow-x: hidden; scrollbar-gutter: stable; padding: 10px; border-right: 1px solid #3a3a3a; box-sizing: border-box; }
+#main-container { display: flex; flex: 1; overflow: hidden; position: relative; }
+#left-sidebar, #right-sidebar { background: #252525; width: 260px; overflow-y: auto; overflow-x: hidden; scrollbar-gutter: stable; padding: 10px; border-right: 1px solid #3a3a3a; box-sizing: border-box; transition: width 0.18s ease, padding 0.18s ease, border-color 0.18s ease; }
 #right-sidebar { border-right: none; border-left: 1px solid #3a3a3a; display: flex; flex-direction: column; overflow: hidden; padding: 0; }
+
+/* ── Collapsible side panels ─────────────────────────────────────────── */
+/* Each toggle button hugs the inner edge of its sidebar. Click to hide
+   the entire panel; click again to bring it back. The two sides are
+   independent and the state persists across reloads (localStorage —
+   see app.js initSidebarToggles). */
+.sidebar-toggle {
+    position: fixed;
+    z-index: 50;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 18px;
+    height: 56px;
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #aaa;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0;
+    transition: background 0.15s, color 0.15s, left 0.18s ease, right 0.18s ease;
+}
+.sidebar-toggle:hover { background: #3a3a3a; color: #fff; }
+/* The actual left/right pixel positions are set in JS (initSidebarToggles)
+   based on the sidebar's live geometry — this lets the toggle hug the
+   sidebar's inner edge regardless of monitor size, window resize, or any
+   future change to sidebar width. */
+#left-sidebar-toggle { border-left: none; border-radius: 0 4px 4px 0; }
+#right-sidebar-toggle { border-right: none; border-radius: 4px 0 0 4px; }
+/* Collapsed: shrink the sidebar to nothing but keep it in the DOM so
+   layout/interactions stay intact. */
+#left-sidebar.collapsed,
+#right-sidebar.collapsed {
+    width: 0;
+    min-width: 0;
+    padding: 0;
+    border-right: none;
+    border-left: none;
+}
 #right-sidebar > .panel { margin: 0 10px 0 10px; flex: 1; overflow-y: auto; min-height: 0; }
 .panel { background: #2a2a2a; border: 1px solid #3a3a3a; border-radius: 6px; margin-bottom: 10px; }
 .panel-header { padding: 12px; border-bottom: 1px solid #3a3a3a; }

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -946,13 +946,87 @@ class LEDRasterApp {
     
     init() {
         window.canvasRenderer = new CanvasRenderer('main-canvas');
-        
+
+        // Restore collapsed sidebar state before anything paints so there's
+        // no flash of the open panel.
+        this.initSidebarToggles();
+
         // Check server session FIRST - if server restarted, clear localStorage
         this.checkServerSession().then(() => {
             this.connectWebSocket();
             this.loadProject();
             this.setupEventListeners();
             sendClientLog('app_init', { ua: navigator.userAgent });
+        });
+    }
+
+    /**
+     * Wire the left/right sidebar collapse toggles. Each side is independent
+     * and the collapsed state persists in localStorage so the panel stays
+     * the way the user left it across reloads. The toggle button is
+     * positioned dynamically against the sidebar's actual geometry (via
+     * getBoundingClientRect), so it always sits flush with the sidebar's
+     * inner edge regardless of monitor size, sidebar width, or window
+     * resize. ResizeObserver keeps it pinned in place if the sidebar's
+     * dimensions ever change at runtime.
+     */
+    initSidebarToggles() {
+        const sides = [
+            { key: 'left', sidebarId: 'left-sidebar', toggleId: 'left-sidebar-toggle', expandSym: '›', collapseSym: '‹' },
+            { key: 'right', sidebarId: 'right-sidebar', toggleId: 'right-sidebar-toggle', expandSym: '‹', collapseSym: '›' },
+        ];
+        sides.forEach(({ key, sidebarId, toggleId, expandSym, collapseSym }) => {
+            const sidebar = document.getElementById(sidebarId);
+            const btn = document.getElementById(toggleId);
+            if (!sidebar || !btn) return;
+            const storageKey = `ledRasterSidebarCollapsed_${key}`;
+            const positionToggle = () => {
+                const rect = sidebar.getBoundingClientRect();
+                if (key === 'left') {
+                    btn.style.left = `${Math.round(rect.right)}px`;
+                    btn.style.right = '';
+                } else {
+                    btn.style.right = `${Math.round(window.innerWidth - rect.left)}px`;
+                    btn.style.left = '';
+                }
+            };
+            const apply = (collapsed) => {
+                sidebar.classList.toggle('collapsed', collapsed);
+                document.body.classList.toggle(`${key}-sidebar-collapsed`, collapsed);
+                btn.textContent = collapsed ? expandSym : collapseSym;
+                btn.title = collapsed
+                    ? `Expand ${key} panel`
+                    : `Collapse ${key} panel`;
+                // The width transition runs ~180ms; reposition while it
+                // animates and again at the end so the toggle hugs the
+                // edge throughout (and at the final position).
+                requestAnimationFrame(positionToggle);
+                setTimeout(positionToggle, 60);
+                setTimeout(positionToggle, 220);
+                // Canvas width changes when the sidebar shrinks; trigger a
+                // re-render so the canvas + raster boundary repaint at the
+                // new size.
+                if (window.canvasRenderer) {
+                    if (window.canvasRenderer.setupCanvas) window.canvasRenderer.setupCanvas();
+                    window.canvasRenderer.render();
+                }
+            };
+            const saved = localStorage.getItem(storageKey) === '1';
+            apply(saved);
+            btn.addEventListener('click', () => {
+                const nowCollapsed = !sidebar.classList.contains('collapsed');
+                localStorage.setItem(storageKey, nowCollapsed ? '1' : '0');
+                apply(nowCollapsed);
+                if (typeof sendClientLog === 'function') {
+                    sendClientLog('sidebar_toggle', { side: key, collapsed: nowCollapsed });
+                }
+            });
+            // Keep the toggle pinned to the sidebar edge whenever the
+            // sidebar resizes (window resize, scrollbar appearance, etc.).
+            if (typeof ResizeObserver === 'function') {
+                new ResizeObserver(positionToggle).observe(sidebar);
+            }
+            window.addEventListener('resize', positionToggle);
         });
     }
     
@@ -5714,8 +5788,13 @@ class LEDRasterApp {
         const lastChanged = this._lastChangedInputId || null;
         const applyOffsetX = offsetXVal !== null && (!multiSelected || lastChanged === 'offset-x');
         const applyOffsetY = offsetYVal !== null && (!multiSelected || lastChanged === 'offset-y');
-        const applyShowOffsetX = showOffsetXVal !== null && (!multiSelected || lastChanged === 'show-offset-x');
-        const applyShowOffsetY = showOffsetYVal !== null && (!multiSelected || lastChanged === 'show-offset-y');
+        // Show-offset writes are gated strictly on lastChanged so that editing
+        // the pixel-map offset doesn't fight the auto-link logic below (which
+        // mirrors the new offset_x to showOffsetX while they're equal). The
+        // show-offset inputs only set their fields when the user actually
+        // edits them (single-select OR multi-select).
+        const applyShowOffsetX = showOffsetXVal !== null && lastChanged === 'show-offset-x';
+        const applyShowOffsetY = showOffsetYVal !== null && lastChanged === 'show-offset-y';
         const cabinetWidthVal = readNumber('cabinet-width').value;
         const cabinetHeightVal = readNumber('cabinet-height').value;
         const columnsVal = readNumber('screen-columns').value;
@@ -5809,8 +5888,22 @@ class LEDRasterApp {
         targetLayers.forEach(layer => {
             const isImage = (layer.type || 'screen') === 'image';
             if (!layer.locked) {
-                if (applyOffsetX) layer.offset_x = offsetXVal;
-                if (applyOffsetY) layer.offset_y = offsetYVal;
+                // Capture whether the show offset is currently linked to the
+                // processor offset (i.e. equal). If so, editing the pixel-map
+                // offset should also update showOffset so Show Look / Data /
+                // Power follow the move. Once they diverge (because the user
+                // explicitly set a different show offset), pixel-map edits
+                // stop touching showOffset.
+                const linkedX = Number(layer.showOffsetX ?? layer.offset_x ?? 0) === Number(layer.offset_x ?? 0);
+                const linkedY = Number(layer.showOffsetY ?? layer.offset_y ?? 0) === Number(layer.offset_y ?? 0);
+                if (applyOffsetX) {
+                    layer.offset_x = offsetXVal;
+                    if (linkedX) layer.showOffsetX = offsetXVal;
+                }
+                if (applyOffsetY) {
+                    layer.offset_y = offsetYVal;
+                    if (linkedY) layer.showOffsetY = offsetYVal;
+                }
                 if (applyShowOffsetX) layer.showOffsetX = showOffsetXVal;
                 if (applyShowOffsetY) layer.showOffsetY = showOffsetYVal;
             }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -117,6 +117,19 @@ class CanvasRenderer {
     }
 
     /**
+     * Layer bounds in the *currently active view's* coordinate space.
+     * For pixel-map / cabinet-id this matches getLayerBounds (processor
+     * coords). For show-look / data-flow / power it shifts by the layer's
+     * showOffset - offset_x/y delta so selection rects, hit-tests, and
+     * magnetic snap line up with the rendered position.
+     */
+    getLayerBoundsInActiveView(layer) {
+        const b = this.getLayerBounds(layer);
+        const { dx, dy } = this.getLayerRenderOffset(layer);
+        return { x: b.x + dx, y: b.y + dy, width: b.width, height: b.height };
+    }
+
+    /**
      * Render-time translation to apply to a layer's geometry so it appears
      * at its show position in show-look / data-flow / power. Returns
      * {dx: 0, dy: 0} for pixel-map / cabinet-id (no shift).
@@ -133,11 +146,17 @@ class CanvasRenderer {
     }
 
     getLayerBounds(layer) {
-        const { dx, dy } = this.getLayerRenderOffset(layer);
+        // NOTE: returns RAW processor-coords bounds (not shifted by Show Look
+        // offset). Most callers use this for things drawn INSIDE the per-layer
+        // ctx.translate(dx, dy) block in render(), so adding dx here would
+        // double-shift them. Callers that operate OUTSIDE the per-layer
+        // translate (selection bounding box, hit-test, magnetic snap, layer
+        // drag overlay) should use getLayerBoundsInActiveView(layer) instead,
+        // which adds the active view's render offset.
         if (layer && (layer.type || 'screen') === 'text') {
             return {
-                x: (Number(layer.offset_x) || 0) + dx,
-                y: (Number(layer.offset_y) || 0) + dy,
+                x: Number(layer.offset_x) || 0,
+                y: Number(layer.offset_y) || 0,
                 width: Number(layer.textWidth) || 400,
                 height: Number(layer.textHeight) || 100
             };
@@ -147,8 +166,8 @@ class CanvasRenderer {
             const width = (Number(layer.imageWidth) || 0) * scale;
             const height = (Number(layer.imageHeight) || 0) * scale;
             return {
-                x: (Number(layer.offset_x) || 0) + dx,
-                y: (Number(layer.offset_y) || 0) + dy,
+                x: Number(layer.offset_x) || 0,
+                y: Number(layer.offset_y) || 0,
                 width,
                 height
             };
@@ -169,8 +188,8 @@ class CanvasRenderer {
                 if (y2 > maxY) maxY = y2;
             });
             return {
-                x: minX + dx,
-                y: minY + dy,
+                x: minX,
+                y: minY,
                 width: maxX - minX,
                 height: maxY - minY
             };
@@ -178,8 +197,8 @@ class CanvasRenderer {
         const width = (Number(layer.columns) || 0) * (Number(layer.cabinet_width) || 0);
         const height = (Number(layer.rows) || 0) * (Number(layer.cabinet_height) || 0);
         return {
-            x: (Number(layer.offset_x) || 0) + dx,
-            y: (Number(layer.offset_y) || 0) + dy,
+            x: Number(layer.offset_x) || 0,
+            y: Number(layer.offset_y) || 0,
             width,
             height
         };
@@ -343,6 +362,15 @@ class CanvasRenderer {
                         startY: useShow
                             ? (layer.showOffsetY ?? layer.offset_y ?? 0)
                             : (layer.offset_y ?? 0),
+                        // Capture whether this layer's show position was
+                        // linked to its processor position at drag-start
+                        // (i.e. equal). If so, dragging in pixel-map should
+                        // also update showOffset so Show Look / Data / Power
+                        // track the new position. Once they diverge (because
+                        // the user moved the layer in Show Look), pixel-map
+                        // drags stop touching showOffset.
+                        showLinkedX: !useShow && (Number(layer.showOffsetX ?? layer.offset_x ?? 0) === Number(layer.offset_x ?? 0)),
+                        showLinkedY: !useShow && (Number(layer.showOffsetY ?? layer.offset_y ?? 0) === Number(layer.offset_y ?? 0)),
                         // Only the processor-position drag mutates panel.x/y
                         // (panels live in processor coords). Show-position
                         // drag is rendered via ctx.translate so panels stay
@@ -565,6 +593,11 @@ class CanvasRenderer {
                     } else {
                         layer.offset_x = nextX;
                         layer.offset_y = nextY;
+                        // While show position was linked to processor position,
+                        // keep them in sync so Show Look / Data / Power follow
+                        // the pixel-map move.
+                        if (item.showLinkedX) layer.showOffsetX = nextX;
+                        if (item.showLinkedY) layer.showOffsetY = nextY;
                         const startMap = new Map((item.panelStarts || []).map(p => [p.id, p]));
                         layer.panels.forEach(panel => {
                             const start = startMap.get(panel.id);
@@ -581,7 +614,8 @@ class CanvasRenderer {
             // Screen name dragging with snap positions - tab-specific
             if (window.app && window.app.currentLayer) {
                 const layer = window.app.currentLayer;
-                const bounds = this.getLayerBounds(layer);
+                // Screen-name drag — bounds in the active view for snap calc.
+                const bounds = this.getLayerBoundsInActiveView(layer);
                 const layerWidth = bounds.width;
                 const layerHeight = bounds.height;
                 
@@ -1178,7 +1212,10 @@ class CanvasRenderer {
         for (let i = window.app.project.layers.length - 1; i >= 0; i--) {
             const layer = window.app.project.layers[i];
             if (!layer.visible) continue;
-            const bounds = this.getLayerBounds(layer);
+            // Hit-test against the layer's bounds in the *active view*, since
+            // worldX/worldY are in the view's coord space (Show Look / Data /
+            // Power render at the show position).
+            const bounds = this.getLayerBoundsInActiveView(layer);
             if (worldX >= bounds.x && worldX <= bounds.x + bounds.width &&
                 worldY >= bounds.y && worldY <= bounds.y + bounds.height) {
                 return layer;
@@ -1484,12 +1521,14 @@ class CanvasRenderer {
             }
             
             // Draw bounding boxes around selected layers (skip during export)
+            // These render OUTSIDE the per-layer ctx.translate, so use the
+            // active-view bounds.
             if (!this.exportMode && window.app && window.app.selectedLayerIds && window.app.selectedLayerIds.size > 0) {
                 const selectedIds = window.app.selectedLayerIds;
                 window.app.project.layers.forEach(layer => {
                     if (!layer.visible) return;
                     if (!selectedIds.has(layer.id)) return;
-                    const bounds = this.getLayerBounds(layer);
+                    const bounds = this.getLayerBoundsInActiveView(layer);
                     const layerWidth = bounds.width;
                     const layerHeight = bounds.height;
                     this.ctx.strokeStyle = (window.app.currentLayer && window.app.currentLayer.id === layer.id) ? '#00ccff' : '#4A90E2';
@@ -1504,10 +1543,10 @@ class CanvasRenderer {
             if (!this.exportMode && this.isDraggingLayer && window.app && window.app.currentLayer) {
                 const selectedLayer = window.app.currentLayer;
                 if (selectedLayer.visible) {
-                    const bounds = this.getLayerBounds(selectedLayer);
+                    const bounds = this.getLayerBoundsInActiveView(selectedLayer);
                     const layerWidth = bounds.width;
                     const layerHeight = bounds.height;
-                    
+
                     this.ctx.strokeStyle = '#4A90E2';  // Blue highlight color
                     this.ctx.lineWidth = 3 / this.zoom;  // Scale with zoom
                     this.ctx.setLineDash([10 / this.zoom, 5 / this.zoom]);
@@ -1533,7 +1572,9 @@ class CanvasRenderer {
                 if (window.app && window.app.project) {
                     window.app.project.layers.forEach(layer => {
                         if (!layer.visible) return;
-                        const bounds = this.getLayerBounds(layer);
+                        // Active-view bounds — selection rect is in world coords
+                        // matching the rendered (possibly show-shifted) layout.
+                        const bounds = this.getLayerBoundsInActiveView(layer);
                         const layerWidth = bounds.width;
                         const layerHeight = bounds.height;
                         const x1 = bounds.x;
@@ -1643,7 +1684,8 @@ class CanvasRenderer {
             this.panY = 100;
         } else {
             const layer = window.app.currentLayer;
-            const bounds = this.getLayerBounds(layer);
+            // Zoom-to-layer in the active view, so it matches what's rendered.
+            const bounds = this.getLayerBoundsInActiveView(layer);
             const layerWidth = bounds.width;
             const layerHeight = bounds.height;
             const zoomX = (this.canvas.width * 0.9) / layerWidth;
@@ -1662,7 +1704,8 @@ class CanvasRenderer {
         const snapDistance = 20; // Snap within 20 pixels - feels natural
         let snappedX = offsetX;
         let snappedY = offsetY;
-        
+
+        // Width/height are the same regardless of view; use raw bounds.
         const currentBounds = this.getLayerBounds(currentLayer);
         const layerWidth = currentBounds.width;
         const layerHeight = currentBounds.height;
@@ -1692,11 +1735,14 @@ class CanvasRenderer {
         }
         
         // Snap to other layers - HARD EDGES ONLY
+        // Other layers' bounds are compared against the dragged layer's
+        // proposed offset (offsetX/Y), which is in the active view's
+        // coords — so use active-view bounds for the comparison.
         if (window.app && window.app.project) {
             window.app.project.layers.forEach(layer => {
                 if (layer.id === currentLayer.id || !layer.visible) return;
-                
-                const otherBounds = this.getLayerBounds(layer);
+
+                const otherBounds = this.getLayerBoundsInActiveView(layer);
                 const otherLeft = otherBounds.x;
                 const otherRight = otherBounds.x + otherBounds.width;
                 const otherTop = otherBounds.y;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.6.2</title>
+    <title>LED Raster Designer v0.7.6.3</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.2</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.3</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -108,6 +108,7 @@
         </div>
 
         <div id="main-container">
+            <button id="left-sidebar-toggle" class="sidebar-toggle" data-side="left" title="Collapse left panel" aria-label="Toggle left panel">‹</button>
             <div id="left-sidebar">
                 <!-- Pixel Map Controls -->
                 <div class="panel tab-panel" data-tab="pixel-map">
@@ -1228,6 +1229,7 @@
             </div>
         </div>
 
+        <button id="right-sidebar-toggle" class="sidebar-toggle" data-side="right" title="Collapse right panel" aria-label="Toggle right panel">›</button>
         <div id="right-sidebar">
             <div class="panel">
                 <div class="panel-header" data-tooltip="Screens — Manage screen and image layers: reorder, lock, add, or remove layers in the design.">


### PR DESCRIPTION
## Summary
- **Feature:** Collapsible left/right sidebars (independent, persisted, dynamically positioned toggle).
- **Fix:** Pixel-map layer drag/edit now mirrors to Show Look while linked (same UX as the raster auto-link from v0.7.6.1).
- **Fix:** Labels and other per-layer renders were double-shifted in Show Look/Data/Power. Split bounds API: raw processor coords for in-translate callers, view-shifted coords for outside-translate callers (selection rect, hit-test, snap, screen-name drag, zoom-to-fit).
- **Fix:** "Reset to Pixel Map Position" now visually matches the pixel-map layout (same root cause as the label bug).

## Test plan
- [ ] Click left/right toggle chevrons → sidebar collapses; click again → expands. State persists across reload.
- [ ] Drag a layer in Pixel Map → Show Look follows. Open a layer in Show Look, drag it; pixel-map drag after that doesn't touch show.
- [ ] Edit Offset X/Y in Pixel Map sidebar → same auto-link behavior.
- [ ] Switch to Show Look → screen-name labels are centered on each screen.
- [ ] Reset to Pixel Map Position → layouts match Pixel Map exactly.