### PR TITLE
v0.7.6.4 — canvas fills available width after sidebar collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.6.3
+# LED Raster Designer v0.7.6.4
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,16 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.6.4 - May 1, 2026
+----------------------------
+- FIX: Collapsing a sidebar left a black strip on the canvas where the
+  sidebar used to be. The canvas wrapper grew with the freed space but
+  the canvas element kept its pre-collapse pixel dimensions because
+  setupCanvas() ran during the CSS width transition (before the wrapper
+  reached its final size). Canvas resize now fires at multiple points
+  during and after the transition so the canvas always fills the full
+  available width.
+
 v0.7.6.3 - May 1, 2026
 ----------------------------
 - FEATURE: Collapsible side panels. A small chevron tab on the inner

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.6.3',
-            'CFBundleVersion': '0.7.6.3',
+            'CFBundleShortVersionString': '0.7.6.4',
+            'CFBundleVersion': '0.7.6.4',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -990,6 +990,11 @@ class LEDRasterApp {
                     btn.style.left = '';
                 }
             };
+            const resizeCanvas = () => {
+                if (!window.canvasRenderer) return;
+                if (window.canvasRenderer.setupCanvas) window.canvasRenderer.setupCanvas();
+                window.canvasRenderer.render();
+            };
             const apply = (collapsed) => {
                 sidebar.classList.toggle('collapsed', collapsed);
                 document.body.classList.toggle(`${key}-sidebar-collapsed`, collapsed);
@@ -997,19 +1002,15 @@ class LEDRasterApp {
                 btn.title = collapsed
                     ? `Expand ${key} panel`
                     : `Collapse ${key} panel`;
-                // The width transition runs ~180ms; reposition while it
-                // animates and again at the end so the toggle hugs the
-                // edge throughout (and at the final position).
-                requestAnimationFrame(positionToggle);
-                setTimeout(positionToggle, 60);
-                setTimeout(positionToggle, 220);
-                // Canvas width changes when the sidebar shrinks; trigger a
-                // re-render so the canvas + raster boundary repaint at the
-                // new size.
-                if (window.canvasRenderer) {
-                    if (window.canvasRenderer.setupCanvas) window.canvasRenderer.setupCanvas();
-                    window.canvasRenderer.render();
-                }
+                // The CSS width transition runs ~180ms. Reposition the
+                // toggle and resize the canvas at multiple points during /
+                // after the animation so the canvas always fills the
+                // available wrapper width — otherwise the canvas keeps its
+                // pre-collapse pixel dimensions and the user sees a black
+                // strip on the side where the sidebar used to be.
+                requestAnimationFrame(() => { positionToggle(); resizeCanvas(); });
+                setTimeout(() => { positionToggle(); resizeCanvas(); }, 60);
+                setTimeout(() => { positionToggle(); resizeCanvas(); }, 220);
             };
             const saved = localStorage.getItem(storageKey) === '1';
             apply(saved);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.6.3</title>
+    <title>LED Raster Designer v0.7.6.4</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.4</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
Collapsing a sidebar left a black strip where the sidebar used to be — the canvas wrapper grew with the freed space but the canvas element kept its pre-collapse pixel dimensions. Canvas resize now fires alongside the toggle reposition at multiple points during/after the CSS transition so the canvas always fills the available width.

## Test plan
- [ ] Collapse left sidebar → canvas extends to the screen edge, no black strip
- [ ] Collapse right sidebar → same
- [ ] Collapse both → canvas fills the entire viewport between the two chevron tabs