### PR TITLE
v0.7.7.0 — Front/Back view perspective toggle (Issue #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.6.4
+# LED Raster Designer v0.7.7.0
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.7.0 - May 1, 2026
+----------------------------
+- FEATURE: Front/Back view perspective toggle for Data Flow and Power
+  tabs (Issue #31). Each tab has its own independent Front/Back toggle
+  in the sidebar. Back view horizontally mirrors the canvas geometry
+  (so wiring matches what you actually see standing behind the wall)
+  while keeping every text label readable. A "BACK VIEW" badge shows
+  in the top-right corner of the canvas whenever Back is active. On
+  export, the filename suffix for that view auto-appends "_back" when
+  in Back perspective so front/back artwork doesn't collide.
+
 v0.7.6.4 - May 1, 2026
 ----------------------------
 - FIX: Collapsing a sidebar left a black strip on the canvas where the

--- a/src/app.py
+++ b/src/app.py
@@ -334,6 +334,13 @@ current_project = {
     # Power views (which all render at the show position).
     'show_raster_width': 1920,
     'show_raster_height': 1080,
+    # Wiring view perspective per tab. 'front' shows the layout as the
+    # audience sees it (matching Show Look). 'back' horizontally mirrors
+    # the geometry so the techs working behind the wall see it from their
+    # perspective. Labels stay readable in either view. Per-tab so a Data
+    # tech and a Power tech can configure independently.
+    'data_flow_perspective': 'front',
+    'power_perspective': 'front',
     'layers': [],
     'is_pristine': True
 }
@@ -810,6 +817,8 @@ def new_project():
         'raster_height': 1080,
         'show_raster_width': 1920,
         'show_raster_height': 1080,
+        'data_flow_perspective': 'front',
+        'power_perspective': 'front',
         'layers': [],
         'is_pristine': True
     }
@@ -849,6 +858,12 @@ def restore_project():
         current_project['show_raster_width'] = current_project.get('raster_width', 1920)
     if current_project.get('show_raster_height') is None:
         current_project['show_raster_height'] = current_project.get('raster_height', 1080)
+    # Wiring perspective defaults: older projects render front-facing,
+    # matching how they appeared before the perspective toggle existed.
+    if current_project.get('data_flow_perspective') not in ('front', 'back'):
+        current_project['data_flow_perspective'] = 'front'
+    if current_project.get('power_perspective') not in ('front', 'back'):
+        current_project['power_perspective'] = 'front'
     sync_next_layer_id()
     log_event('restore_project', {
         'name': current_project.get('name', '?'),

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.6.4',
-            'CFBundleVersion': '0.7.6.4',
+            'CFBundleShortVersionString': '0.7.7.0',
+            'CFBundleVersion': '0.7.7.0',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -31,6 +31,11 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 #left-sidebar, #right-sidebar { background: #252525; width: 260px; overflow-y: auto; overflow-x: hidden; scrollbar-gutter: stable; padding: 10px; border-right: 1px solid #3a3a3a; box-sizing: border-box; transition: width 0.18s ease, padding 0.18s ease, border-color 0.18s ease; }
 #right-sidebar { border-right: none; border-left: 1px solid #3a3a3a; display: flex; flex-direction: column; overflow: hidden; padding: 0; }
 
+/* ── Perspective toggle (Front / Back) ────────────────────────────────── */
+.perspective-btn { background: #2a2a2a; border: 1px solid #3a3a3a; color: #aaa; }
+.perspective-btn:hover { background: #3a3a3a; color: #fff; }
+.perspective-btn.active { background: #4A90E2; border-color: #4A90E2; color: #fff; }
+
 /* ── Collapsible side panels ─────────────────────────────────────────── */
 /* Each toggle button hugs the inner edge of its sidebar. Click to hide
    the entire panel; click again to bring it back. The two sides are

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1925,6 +1925,9 @@ class LEDRasterApp {
         // Refresh illegal-character warning whenever the project name changes
         // programmatically (e.g. on project load).
         projectNameEl.dispatchEvent(new Event('input'));
+        // Sync the Front/Back perspective toggle buttons to the loaded
+        // project's saved values.
+        if (this.refreshPerspectiveButtons) this.refreshPerspectiveButtons();
 
         // Load project notes
         const notesEl = document.getElementById('project-notes');
@@ -1979,8 +1982,52 @@ class LEDRasterApp {
         }, true);
     }
 
+    /**
+     * Wire the Front / Back perspective toggles in the Data Flow and Power
+     * sidebars. Each tab has its own perspective stored on the project
+     * (project.data_flow_perspective, project.power_perspective). 'back'
+     * horizontally mirrors the wiring view so techs working behind the wall
+     * see things from their perspective; labels stay readable (un-mirrored
+     * inside the canvas mirror transform during render).
+     */
+    setupPerspectiveToggles() {
+        document.querySelectorAll('.perspective-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const target = btn.getAttribute('data-target');
+                const value = btn.getAttribute('data-perspective');
+                if (!target || !value || !this.project) return;
+                if (this.project[target] === value) return;
+                this.project[target] = value;
+                this.refreshPerspectiveButtons();
+                this.saveProject();
+                if (window.canvasRenderer) window.canvasRenderer.render();
+                if (typeof sendClientLog === 'function') {
+                    sendClientLog('perspective_change', { target, value });
+                }
+            });
+        });
+        this.refreshPerspectiveButtons();
+    }
+
+    /**
+     * Reflect the project's current perspective values on the toggle
+     * buttons (active state). Called after the project loads or the user
+     * toggles.
+     */
+    refreshPerspectiveButtons() {
+        if (!this.project) return;
+        document.querySelectorAll('.perspective-btn').forEach(btn => {
+            const target = btn.getAttribute('data-target');
+            const value = btn.getAttribute('data-perspective');
+            if (!target || !value) return;
+            const current = this.project[target] || 'front';
+            btn.classList.toggle('active', current === value);
+        });
+    }
+
     setupEventListeners() {
         this.setupPixelMapBulkActions();
+        this.setupPerspectiveToggles();
         // Project name editing
         const projectNameInput = document.getElementById('project-name');
         const projectNameWarning = document.getElementById('project-name-warning');
@@ -6969,7 +7016,17 @@ class LEDRasterApp {
 
     getExportSuffixForView(view, suffixes, viewNames) {
         const raw = (suffixes && typeof suffixes[view] === 'string') ? suffixes[view].trim() : '';
-        return raw || viewNames[view];
+        let suffix = raw || viewNames[view];
+        // Append _back when this view is in back perspective
+        if (this.project) {
+            const perspectiveKey = view === 'data-flow' ? 'data_flow_perspective'
+                : view === 'power' ? 'power_perspective'
+                : null;
+            if (perspectiveKey && this.project[perspectiveKey] === 'back') {
+                if (!/_back$/i.test(suffix)) suffix = `${suffix}_back`;
+            }
+        }
+        return suffix;
     }
     
     // Export Resolume Arena Advanced Output XML

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -117,6 +117,63 @@ class CanvasRenderer {
     }
 
     /**
+     * True when the active view is one of the wiring views (Data Flow /
+     * Power) AND the project's perspective for that view is 'back'. In that
+     * case render() horizontally mirrors the canvas around the right edge
+     * of the raster so techs working behind the wall see the layout from
+     * their perspective. Labels are un-mirrored at draw time via _fillText
+     * / _strokeText so they stay readable.
+     */
+    isMirroredView() {
+        if (!window.app || !window.app.project) return false;
+        if (this.viewMode === 'data-flow') {
+            return window.app.project.data_flow_perspective === 'back';
+        }
+        if (this.viewMode === 'power') {
+            return window.app.project.power_perspective === 'back';
+        }
+        return false;
+    }
+
+    /**
+     * fillText that auto-un-mirrors when the canvas is in a mirrored
+     * (back-view) render so label glyphs stay right-side-up. Anchor
+     * position is the same as ctx.fillText — pass the position you would
+     * have used in normal rendering. Text alignment ('center' is the most
+     * common in this codebase) keeps its visual centering. Edge-aligned
+     * text ('left'/'right') will flip its anchor side, which is the right
+     * behavior for a back view (the cabinet's left edge becomes its right
+     * in the tech's view).
+     */
+    _fillText(text, x, y, maxWidth) {
+        if (this._mirror) {
+            this.ctx.save();
+            this.ctx.translate(x, y);
+            this.ctx.scale(-1, 1);
+            if (maxWidth !== undefined) this.ctx.fillText(text, 0, 0, maxWidth);
+            else this.ctx.fillText(text, 0, 0);
+            this.ctx.restore();
+        } else {
+            if (maxWidth !== undefined) this.ctx.fillText(text, x, y, maxWidth);
+            else this.ctx.fillText(text, x, y);
+        }
+    }
+
+    _strokeText(text, x, y, maxWidth) {
+        if (this._mirror) {
+            this.ctx.save();
+            this.ctx.translate(x, y);
+            this.ctx.scale(-1, 1);
+            if (maxWidth !== undefined) this.ctx.strokeText(text, 0, 0, maxWidth);
+            else this.ctx.strokeText(text, 0, 0);
+            this.ctx.restore();
+        } else {
+            if (maxWidth !== undefined) this.ctx.strokeText(text, x, y, maxWidth);
+            else this.ctx.strokeText(text, x, y);
+        }
+    }
+
+    /**
      * Layer bounds in the *currently active view's* coordinate space.
      * For pixel-map / cabinet-id this matches getLayerBounds (processor
      * coords). For show-look / data-flow / power it shifts by the layer's
@@ -204,11 +261,19 @@ class CanvasRenderer {
         };
     }
     
+    // When the active view is mirrored (Back perspective), the canvas is
+    // flipped horizontally for display only. Mouse coordinates are still in
+    // un-mirrored screen space, so we have to flip them back into layer
+    // coordinates before any hit-testing / drag math.
+    _unmirrorWorldX(worldX) {
+        return this.isMirroredView() ? (this.rasterWidth - worldX) : worldX;
+    }
+
     handleMouseDown(e) {
         const rect = this.canvas.getBoundingClientRect();
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
-        const worldX = (mouseX - this.panX) / this.zoom;
+        const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
         
         if (e.button === 0 && this.spacePressed) {
@@ -500,7 +565,7 @@ class CanvasRenderer {
         const rect = this.canvas.getBoundingClientRect();
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
-        const worldX = (mouseX - this.panX) / this.zoom;
+        const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
 
         if (this.isAltPainting) {
@@ -858,7 +923,7 @@ class CanvasRenderer {
             this.isDraggingLayer = false;
             
             if (window.app && window.app.currentLayer) {
-                const dx = Math.round(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom - this.dragLayerStartX);
+                const dx = Math.round(this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom) - this.dragLayerStartX);
                 const dy = Math.round(((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom - this.dragLayerStartY);
                 
                 let snapDx = dx;
@@ -982,7 +1047,7 @@ class CanvasRenderer {
         // single-panel selection so the menu actions target it.
         if (this.viewMode === 'pixel-map' && window.app.currentLayer) {
             const rect = this.canvas.getBoundingClientRect();
-            const worldX = ((e.clientX - rect.left) - this.panX) / this.zoom;
+            const worldX = this._unmirrorWorldX(((e.clientX - rect.left) - this.panX) / this.zoom);
             const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
             const clicked = this.getPanelAt(worldX, worldY);
             // Right-click works on hidden panels too — the menu shows
@@ -1350,7 +1415,7 @@ class CanvasRenderer {
             lines.forEach((line, i) => {
                 const ty = y + padding + i * lineHeight;
                 if (ty + lineHeight <= y + h + lineHeight) {
-                    this.ctx.fillText(line, textX, ty);
+                    this._fillText(line, textX, ty);
                     // Underline
                     if (layer.fontUnderline && line.length > 0) {
                         const metrics = this.ctx.measureText(line);
@@ -1408,7 +1473,19 @@ class CanvasRenderer {
         this.ctx.save();
         // Round pan values to prevent sub-pixel anti-aliasing seams between panels
         this.ctx.setTransform(this.zoom, 0, 0, this.zoom, Math.round(this.panX), Math.round(this.panY));
-        
+
+        // Wiring view perspective: in 'back' view, mirror the entire
+        // geometry around the right edge of the raster so techs working
+        // behind the wall see things from their perspective. _fillText /
+        // _strokeText un-mirror text glyphs so labels stay readable. The
+        // _mirror flag drives both the canvas transform and the text
+        // helpers below.
+        this._mirror = this.isMirroredView();
+        if (this._mirror) {
+            this.ctx.translate(this.rasterWidth, 0);
+            this.ctx.scale(-1, 1);
+        }
+
         // Disable image smoothing to prevent anti-aliasing artifacts (seams between panels)
         this.ctx.imageSmoothingEnabled = false;
         
@@ -1502,6 +1579,12 @@ class CanvasRenderer {
             if (!this.exportMode && this.viewMode === 'pixel-map') {
                 this.renderPixelMapSelectionOverlay();
                 this.renderPixelMapSelectionBadge();
+            }
+            // Always show the perspective badge (BACK VIEW) in wiring views
+            // when in back perspective. Renders in both interactive view and
+            // export so the printed map is unambiguous.
+            if (this.viewMode === 'data-flow' || this.viewMode === 'power') {
+                this.renderPerspectiveBadge();
             }
             
             // Third pass: render capacity error overlays ON TOP of labels (Data Flow mode only)
@@ -2044,13 +2127,13 @@ class CanvasRenderer {
         this.ctx.textAlign = 'center';
         this.ctx.textBaseline = 'middle';
         
-        this.ctx.fillText(titleText, layerCenterX, layerCenterY - 35);
+        this._fillText(titleText, layerCenterX, layerCenterY - 35);
         this.ctx.fillStyle = '#FFFFFF';
         this.ctx.font = '28px Arial';
-        this.ctx.fillText(detailText, layerCenterX, layerCenterY + 10);
+        this._fillText(detailText, layerCenterX, layerCenterY + 10);
         this.ctx.font = '24px Arial';
         this.ctx.fillStyle = '#AAAAAA';
-        this.ctx.fillText(infoText, layerCenterX, layerCenterY + 45);
+        this._fillText(infoText, layerCenterX, layerCenterY + 45);
     }
     
     renderDataFlowArrows(layer) {
@@ -2167,28 +2250,28 @@ class CanvasRenderer {
                 this.ctx.font = `bold ${labelSize}px Arial`;
                 this.ctx.textAlign = 'center';
                 this.ctx.textBaseline = 'middle';
-                this.ctx.fillText(returnLabel, rx, ry);
+                this._fillText(returnLabel, rx, ry);
             }
-            
+
             this.ctx.fillStyle = primaryColor;
             this.ctx.beginPath();
             this.ctx.arc(px, py, circleRadius, 0, Math.PI * 2);
             this.ctx.fill();
-            
+
             this.ctx.fillStyle = primaryTextColor;
             this.ctx.font = `bold ${labelSize}px Arial`;
             this.ctx.textAlign = 'center';
             this.ctx.textBaseline = 'middle';
-            this.ctx.fillText(primaryLabel, px, py);
-            
+            this._fillText(primaryLabel, px, py);
+
             if (portPanels.length > 1) {
                 this.ctx.fillStyle = backupColor;
                 this.ctx.beginPath();
                 this.ctx.arc(rx, ry, circleRadius, 0, Math.PI * 2);
                 this.ctx.fill();
-                
+
                 this.ctx.fillStyle = backupTextColor;
-                this.ctx.fillText(returnLabel, rx, ry);
+                this._fillText(returnLabel, rx, ry);
             }
         };
 
@@ -2361,7 +2444,7 @@ class CanvasRenderer {
             this.ctx.fillStyle = powerLabelTextColor;
             this.ctx.textAlign = 'center';
             this.ctx.textBaseline = 'middle';
-            this.ctx.fillText(label, px, py);
+            this._fillText(label, px, py);
         };
 
         if (useColorCodedView) {
@@ -2507,7 +2590,7 @@ class CanvasRenderer {
         this.ctx.font = 'bold 42px Arial';
         this.ctx.textAlign = 'center';
         this.ctx.textBaseline = 'middle';
-        this.ctx.fillText(titleText, layerCenterX, layerCenterY);
+        this._fillText(titleText, layerCenterX, layerCenterY);
     }
     
     // Get panel flow order for a specific range of rows (for horizontal-first patterns)
@@ -2786,9 +2869,9 @@ class CanvasRenderer {
                 textY = panel.y + 5;
             }
             
-            this.ctx.fillText(label, this.snap(textX), this.snap(textY));
+            this._fillText(label, this.snap(textX), this.snap(textY));
         });
-        
+
         this.ctx.restore();
     }
     
@@ -3101,7 +3184,7 @@ class CanvasRenderer {
 
             // Draw BLACK text
             this.ctx.fillStyle = '#000000';
-            this.ctx.fillText(screenName, this.snap(screenNameX), this.snap(screenNameY));
+            this._fillText(screenName, this.snap(screenNameX), this.snap(screenNameY));
 
             this.ctx.restore();
             
@@ -3149,7 +3232,7 @@ class CanvasRenderer {
             this.ctx.fillStyle = layer.labelsColor || '#ffffff';
             let yPos = bgY + padding + lineHeight / 2;
             centerLines.forEach(line => {
-                this.ctx.fillText(line, this.snap(centerX), this.snap(yPos));
+                this._fillText(line, this.snap(centerX), this.snap(yPos));
                 yPos += lineHeight;
             });
 
@@ -3184,7 +3267,7 @@ class CanvasRenderer {
             this.ctx.fillStyle = layer.labelsColor || '#ffffff';
             let yPos = bgY + padding + infoLineHeight;
             infoLines.forEach(line => {
-                this.ctx.fillText(line, this.snap(centerX), this.snap(yPos));
+                this._fillText(line, this.snap(centerX), this.snap(yPos));
                 yPos += infoLineHeight;
             });
         }
@@ -3283,8 +3366,8 @@ class CanvasRenderer {
             
             const textX = corner.align === 'left' ? worldX + padding : worldX - padding;
             const textY = corner.baseline === 'top' ? worldY + padding : worldY - padding;
-            
-            this.ctx.fillText(corner.text, this.snap(textX), this.snap(textY));
+
+            this._fillText(corner.text, this.snap(textX), this.snap(textY));
         });
         
         this.ctx.restore();
@@ -3396,6 +3479,39 @@ class CanvasRenderer {
         this.ctx.fill();
         this.ctx.fillStyle = '#fff';
         this.ctx.textBaseline = 'middle';
+        this.ctx.fillText(label, x + padX, y + boxH / 2);
+        this.ctx.restore();
+    }
+
+    /**
+     * Wiring perspective badge — "BACK VIEW" in screen-space corner when
+     * Data Flow / Power are rendering in back perspective. Shown in both
+     * interactive view and export so the printed map is unambiguous.
+     * Front view shows nothing (clutter-free default; Front is implied).
+     */
+    renderPerspectiveBadge() {
+        if (!this.isMirroredView()) return;
+        const label = 'BACK VIEW';
+        this.ctx.save();
+        this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+        const padX = 18;
+        const padY = 10;
+        const fontPx = 16;
+        this.ctx.font = `700 ${fontPx}px -apple-system, "Segoe UI", sans-serif`;
+        const textWidth = this.ctx.measureText(label).width;
+        const boxW = textWidth + padX * 2;
+        const boxH = fontPx + padY * 2;
+        // Top-right corner so it doesn't overlap the selection badge.
+        const x = this.canvas.width - boxW - 20;
+        const y = 20;
+        this.ctx.fillStyle = 'rgba(217, 80, 0, 0.95)';
+        this.ctx.beginPath();
+        if (this.ctx.roundRect) this.ctx.roundRect(x, y, boxW, boxH, 6);
+        else this.ctx.rect(x, y, boxW, boxH);
+        this.ctx.fill();
+        this.ctx.fillStyle = '#fff';
+        this.ctx.textBaseline = 'middle';
+        this.ctx.textAlign = 'left';
         this.ctx.fillText(label, x + padX, y + boxH / 2);
         this.ctx.restore();
     }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.6.4</title>
+    <title>LED Raster Designer v0.7.7.0</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.6.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.7.0</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -410,6 +410,15 @@
                         <h2>Data Settings</h2>
                     </div>
                     <div class="panel-content">
+                        <!-- Wiring view perspective: front (audience) or back (techs behind the wall). -->
+                        <div class="info-row" data-tooltip="View perspective for the Data Flow tab. Front shows the layout the audience sees (matches Show Look). Back horizontally mirrors the wall so techs working behind it see things from their perspective. Labels stay readable in either view.">
+                            <label>View</label>
+                            <div style="display: flex; gap: 4px;">
+                                <button type="button" id="data-flow-perspective-front" class="btn btn-secondary perspective-btn" data-perspective="front" data-target="data_flow_perspective" style="flex: 1; padding: 4px 10px; font-size: 12px;">Front</button>
+                                <button type="button" id="data-flow-perspective-back" class="btn btn-secondary perspective-btn" data-perspective="back" data-target="data_flow_perspective" style="flex: 1; padding: 4px 10px; font-size: 12px;">Back</button>
+                            </div>
+                        </div>
+
                         <div class="info-row checkbox-row" data-tooltip="Screen Name — Show or hide the screen layer name on the canvas in Data Flow view.">
                             <input type="checkbox" id="show-label-name-data" checked>
                             <label for="show-label-name-data">Screen Name</label>
@@ -780,6 +789,14 @@
                         <h2>Power Settings</h2>
                     </div>
                     <div class="panel-content">
+                        <div class="info-row" data-tooltip="View perspective for the Power tab. Front shows the layout the audience sees (matches Show Look). Back horizontally mirrors the wall so techs working behind it see things from their perspective. Labels stay readable in either view.">
+                            <label>View</label>
+                            <div style="display: flex; gap: 4px;">
+                                <button type="button" id="power-perspective-front" class="btn btn-secondary perspective-btn" data-perspective="front" data-target="power_perspective" style="flex: 1; padding: 4px 10px; font-size: 12px;">Front</button>
+                                <button type="button" id="power-perspective-back" class="btn btn-secondary perspective-btn" data-perspective="back" data-target="power_perspective" style="flex: 1; padding: 4px 10px; font-size: 12px;">Back</button>
+                            </div>
+                        </div>
+
                         <div class="info-row checkbox-row" data-tooltip="Screen Name — Show or hide the screen layer name on the canvas in Power view.">
                             <input type="checkbox" id="show-label-name-power" checked>
                             <label for="show-label-name-power">Screen Name</label>


### PR DESCRIPTION
## Summary
- Independent Front/Back perspective toggle per tab (Data Flow + Power)
- Back view horizontally mirrors canvas geometry; labels stay readable; "BACK VIEW" badge in top-right corner
- Export filename suffix auto-appends `_back` when in Back perspective
- Mouse hit-testing/drag math flipped back into layer space so clicks and drags match the visible mirrored canvas

Closes #31

## Test plan
- [x] Toggle Back in Data Flow → canvas mirrors, labels readable, badge shows
- [x] Toggle Back in Power → independent of Data Flow
- [x] Click & drag a layer in Back view → correct layer selected/moved
- [x] Export filename includes `_back` when in Back perspective
- [x] Show Look / Pixel Map / Cabinet ID unaffected