### PR TITLE
v0.7.7.2 — Live panel catalog refresh + submission flow fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.7.1
+# LED Raster Designer v0.7.7.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,30 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.7.2 - May 1, 2026
+----------------------------
+- FEATURE: Panel catalog can now be refreshed live from GitHub without
+  reinstalling the app. The Add Screen modal has a "↻ Refresh" button
+  in the Panel Catalog header that pulls the latest panel_catalog.json
+  from the repo. The fetch is proxied through the Flask backend so it
+  works regardless of browser CORS or corporate firewall quirks.
+  A small source tag next to the button shows whether the catalog is
+  "Bundled" (shipping default) or "Updated <date>" (refreshed).
+  On boot, the app does a silent background check against upstream;
+  if a newer catalog exists, the source tag turns into a blue
+  "📦 Update available · click to apply" pill that swaps in the new
+  data with a single click. Refreshed catalog persists in localStorage
+  so it survives reloads — per browser, not per project.
+- FIX: Panel correction / new-panel submissions were silently dropping.
+  The "Submit a correction or add a panel" link opens a pre-filled
+  GitHub new-issue page, but users were closing the tab without
+  clicking the green "Submit new issue" button on GitHub itself —
+  so the submission never reached the repo. Added an explicit confirm
+  dialog before opening the tab and an inline note under the link
+  spelling out the extra step. Also created the missing
+  "spec-correction" and "add-panel" GitHub labels server-side so
+  future submissions are filterable on the issues page.
+
 v0.7.7.1 - May 1, 2026
 ----------------------------
 - FEATURE: Favorites for the Add Screen picker. Click the heart icon on

--- a/src/app.py
+++ b/src/app.py
@@ -726,6 +726,91 @@ def delete_preset(name):
     socketio.emit('presets_updated')
     return jsonify({'status': 'success'})
 
+# ── Panel catalog refresh ──
+# The bundled `static/data/panel_catalog.json` is the source of truth shipped
+# with each release. To let users get newer panels between releases, the
+# client can call /api/panel-catalog/refresh and we proxy a fetch of the
+# canonical file from GitHub raw. We do the fetch server-side so we don't
+# depend on browser CORS or a user's corporate firewall, and we cache the
+# response in-process for a few minutes so repeat calls (boot check + manual
+# refresh) don't hammer GitHub.
+import hashlib
+import urllib.request
+import urllib.error
+
+_PANEL_CATALOG_RAW_URL = 'https://raw.githubusercontent.com/kman1898/LED-Raster-Designer/main/src/static/data/panel_catalog.json'
+_panel_catalog_cache = {'fetched_at': 0, 'payload': None}
+_PANEL_CATALOG_CACHE_TTL = 300  # seconds
+
+def _bundled_panel_catalog_path():
+    return os.path.join(os.path.dirname(__file__), 'static', 'data', 'panel_catalog.json')
+
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+def _bundled_panel_catalog_sha():
+    try:
+        with open(_bundled_panel_catalog_path(), 'rb') as f:
+            return _sha256_bytes(f.read())
+    except Exception:
+        return ''
+
+@app.route('/api/panel-catalog/info', methods=['GET'])
+def panel_catalog_info():
+    """Lightweight metadata used on app boot to compare against the upstream
+    catalog without forcing a full GitHub fetch every time."""
+    try:
+        with open(_bundled_panel_catalog_path(), 'rb') as f:
+            data = f.read()
+        catalog = json.loads(data)
+        panel_count = sum(len(v) for v in catalog.values() if isinstance(v, list))
+        return jsonify({
+            'bundledSha': _sha256_bytes(data),
+            'panelCount': panel_count,
+            'mfrCount': len(catalog),
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/panel-catalog/refresh', methods=['GET'])
+def panel_catalog_refresh():
+    """Fetch the canonical panel_catalog.json from GitHub raw and return it
+    along with a SHA the client uses to detect changes. Cached in-process for
+    a few minutes."""
+    now = time.time()
+    cached = _panel_catalog_cache
+    if cached['payload'] and (now - cached['fetched_at']) < _PANEL_CATALOG_CACHE_TTL:
+        payload = dict(cached['payload'])
+        payload['fromCache'] = True
+        return jsonify(payload)
+    try:
+        req = urllib.request.Request(
+            _PANEL_CATALOG_RAW_URL,
+            headers={'User-Agent': 'led-raster-designer'}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = resp.read()
+        catalog = json.loads(data)
+        if not isinstance(catalog, dict):
+            raise ValueError('unexpected catalog shape')
+        sha = _sha256_bytes(data)
+        panel_count = sum(len(v) for v in catalog.values() if isinstance(v, list))
+        payload = {
+            'catalog': catalog,
+            'sha': sha,
+            'panelCount': panel_count,
+            'mfrCount': len(catalog),
+            'fetchedAt': datetime.datetime.utcnow().isoformat() + 'Z',
+            'bundledSha': _bundled_panel_catalog_sha(),
+        }
+        _panel_catalog_cache['payload'] = payload
+        _panel_catalog_cache['fetched_at'] = now
+        return jsonify(dict(payload, fromCache=False))
+    except urllib.error.URLError as e:
+        return jsonify({'error': f'network: {e}'}), 502
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
 # ── Logs (in-app viewer) ──
 @app.route('/api/logs', methods=['GET'])
 def get_logs():

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.7.1',
-            'CFBundleVersion': '0.7.7.1',
+            'CFBundleShortVersionString': '0.7.7.2',
+            'CFBundleVersion': '0.7.7.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -957,6 +957,9 @@ class LEDRasterApp {
             this.loadProject();
             this.setupEventListeners();
             sendClientLog('app_init', { ua: navigator.userAgent });
+            // Background-check upstream panel catalog after the rest of boot
+            // settles so we don't slow first paint. Failure is silent.
+            setTimeout(() => this.checkPanelCatalogUpdate(), 1500);
         });
     }
 
@@ -4190,6 +4193,38 @@ class LEDRasterApp {
         });
     }
 
+    // ── Panel catalog source-of-truth resolution ──
+    // Prefers a cached refresh from GitHub (in localStorage) over the bundled
+    // file shipped with this app version. If the user hits Refresh and a
+    // newer catalog is fetched, we cache it and every subsequent _loadPanelCatalog
+    // call uses the cached copy automatically.
+    _getCachedCatalog() {
+        try {
+            const raw = localStorage.getItem('panelCatalog.cached');
+            if (!raw) return null;
+            return JSON.parse(raw);
+        } catch { return null; }
+    }
+    _setCachedCatalog(catalog, sha, fetchedAt) {
+        try {
+            localStorage.setItem('panelCatalog.cached', JSON.stringify(catalog));
+            if (sha) localStorage.setItem('panelCatalog.cachedSha', sha);
+            if (fetchedAt) localStorage.setItem('panelCatalog.cachedAt', fetchedAt);
+        } catch {}
+    }
+    _getCachedCatalogSha() { return localStorage.getItem('panelCatalog.cachedSha') || ''; }
+    _getCachedCatalogAt()  { return localStorage.getItem('panelCatalog.cachedAt') || ''; }
+
+    _ingestCatalog(catalog) {
+        this._panelCatalog = catalog || {};
+        this._panelCatalogFlat = [];
+        Object.keys(this._panelCatalog).forEach(mfr => {
+            (this._panelCatalog[mfr] || []).forEach(p => {
+                this._panelCatalogFlat.push(Object.assign({ _mfr: mfr, _searchKey: (mfr + ' ' + (p.name || '')).toLowerCase() }, p));
+            });
+        });
+    }
+
     _loadPanelCatalog() {
         const listEl = document.getElementById('panel-catalog-list');
         const mfrSel = document.getElementById('panel-catalog-mfr');
@@ -4198,8 +4233,11 @@ class LEDRasterApp {
         if (!listEl) return;
         listEl.innerHTML = '<div style="padding: 12px; color: #888; font-size: 12px;">Loading catalog…</div>';
         const finish = () => {
-            // Populate manufacturer dropdown (once)
-            if (mfrSel && mfrSel.options.length <= 1) {
+            // Repopulate manufacturer dropdown when source changes (e.g. after refresh).
+            if (mfrSel) {
+                const cur = mfrSel.value;
+                // Clear all but the "All manufacturers" option
+                while (mfrSel.options.length > 1) mfrSel.remove(1);
                 const mfrs = Object.keys(this._panelCatalog).sort((a, b) => a.localeCompare(b));
                 mfrs.forEach(m => {
                     const opt = document.createElement('option');
@@ -4207,7 +4245,11 @@ class LEDRasterApp {
                     opt.textContent = `${m.replace(/_/g, ' ')} (${this._panelCatalog[m].length})`;
                     mfrSel.appendChild(opt);
                 });
-                mfrSel.addEventListener('change', () => this._renderPanelCatalogList());
+                if (cur && Array.from(mfrSel.options).some(o => o.value === cur)) mfrSel.value = cur;
+                if (!mfrSel._pickerWired) {
+                    mfrSel._pickerWired = true;
+                    mfrSel.addEventListener('change', () => this._renderPanelCatalogList());
+                }
             }
             if (searchEl && !searchEl._pickerWired) {
                 searchEl._pickerWired = true;
@@ -4222,21 +4264,144 @@ class LEDRasterApp {
                 countEl.textContent = `· ${total.toLocaleString()} panels · ${Object.keys(this._panelCatalog).length} mfrs`;
             }
             this._renderPanelCatalogList();
+            this._renderCatalogSourceTag();
         };
         if (this._panelCatalog) { finish(); return; }
+        // Prefer the cached refreshed catalog if present, else the bundled file.
+        const cached = this._getCachedCatalog();
+        if (cached) {
+            this._ingestCatalog(cached);
+            finish();
+            return;
+        }
         fetch('/static/data/panel_catalog.json').then(r => r.json()).then(data => {
-            this._panelCatalog = data || {};
-            // Flatten once for search
-            this._panelCatalogFlat = [];
-            Object.keys(this._panelCatalog).forEach(mfr => {
-                (this._panelCatalog[mfr] || []).forEach(p => {
-                    this._panelCatalogFlat.push(Object.assign({ _mfr: mfr, _searchKey: (mfr + ' ' + (p.name || '')).toLowerCase() }, p));
-                });
-            });
+            this._ingestCatalog(data);
             finish();
         }).catch(() => {
             listEl.innerHTML = '<div style="padding: 12px; color: #c55; font-size: 12px;">Failed to load panel catalog.</div>';
         });
+    }
+
+    // Background check on app boot — fetches the upstream catalog SHA and
+    // stashes the fresh catalog in localStorage if it differs from what the
+    // user currently has loaded. Sets `_catalogUpdateAvailable` so the picker
+    // can show an "Update available" badge next time it's opened.
+    checkPanelCatalogUpdate() {
+        // Resolve the user's current effective SHA (cached refresh wins over bundled).
+        const cachedSha = this._getCachedCatalogSha();
+        const baselineSha = cachedSha || (this._bundledCatalogSha || '');
+        const apply = (payload) => {
+            if (!payload || !payload.sha) return;
+            this._latestCatalogSha = payload.sha;
+            this._latestCatalogFetchedAt = payload.fetchedAt || '';
+            this._latestCatalogPanelCount = payload.panelCount || 0;
+            // Stash the catalog so the user can apply it instantly without
+            // another network call when they click the badge.
+            if (payload.catalog) this._pendingCatalog = payload.catalog;
+            const baseline = cachedSha || (this._bundledCatalogSha || '');
+            this._catalogUpdateAvailable = !!baseline && payload.sha !== baseline;
+            this._renderCatalogSourceTag();
+        };
+        // First pull bundled SHA (cheap, no network), then ask the upstream proxy.
+        const infoFetch = this._bundledCatalogSha
+            ? Promise.resolve({ bundledSha: this._bundledCatalogSha })
+            : fetch('/api/panel-catalog/info').then(r => r.json()).then(d => {
+                this._bundledCatalogSha = d.bundledSha || '';
+                this._bundledCatalogPanelCount = d.panelCount || 0;
+                return d;
+            }).catch(() => ({}));
+        infoFetch.then(() => fetch('/api/panel-catalog/refresh').then(r => r.ok ? r.json() : Promise.reject(r)))
+            .then(apply)
+            .catch(() => { /* offline / blocked — silently keep current */ });
+    }
+
+    // Manual user-triggered refresh from the button in the catalog header.
+    refreshPanelCatalogNow(opts = {}) {
+        const btn = document.getElementById('panel-catalog-refresh-btn');
+        const tag = document.getElementById('panel-catalog-source-tag');
+        if (btn) { btn.disabled = true; btn.textContent = '↻ Refreshing…'; }
+        return fetch('/api/panel-catalog/refresh').then(r => r.ok ? r.json() : Promise.reject(r))
+            .then(payload => {
+                if (!payload || !payload.catalog) throw new Error('bad payload');
+                this._setCachedCatalog(payload.catalog, payload.sha, payload.fetchedAt);
+                this._latestCatalogSha = payload.sha;
+                this._latestCatalogFetchedAt = payload.fetchedAt || '';
+                this._catalogUpdateAvailable = false;
+                this._pendingCatalog = null;
+                this._ingestCatalog(payload.catalog);
+                this._renderPanelCatalogList();
+                this._renderCatalogSourceTag();
+                if (!opts.silent) {
+                    const count = payload.panelCount || 0;
+                    this._toast(`Catalog refreshed — ${count.toLocaleString()} panels`);
+                }
+            })
+            .catch(() => {
+                if (!opts.silent) this._toast('Couldn’t reach GitHub — keeping current catalog', true);
+            })
+            .finally(() => {
+                if (btn) { btn.disabled = false; btn.textContent = '↻ Refresh'; }
+            });
+    }
+
+    // Renders the small "source tag" shown in the catalog column header:
+    //   - "Bundled (vX.Y.Z)" or "Updated <date>"
+    //   - When an update is available, the tag becomes a clickable green pill.
+    _renderCatalogSourceTag() {
+        const el = document.getElementById('panel-catalog-source-tag');
+        if (!el) return;
+        const cachedAt = this._getCachedCatalogAt();
+        const updateAvail = !!this._catalogUpdateAvailable;
+        if (updateAvail) {
+            el.style.cssText = 'display:inline-block; cursor:pointer; padding:2px 8px; border-radius:10px; background:#1a5fb4; color:#fff; font-size:10px; font-weight:600; letter-spacing:0.3px;';
+            el.textContent = '📦 Update available · click to apply';
+            el.title = 'A newer panel catalog is available from GitHub. Click to apply.';
+            el.onclick = () => {
+                if (this._pendingCatalog) {
+                    this._setCachedCatalog(this._pendingCatalog, this._latestCatalogSha, this._latestCatalogFetchedAt);
+                    this._ingestCatalog(this._pendingCatalog);
+                    this._catalogUpdateAvailable = false;
+                    this._pendingCatalog = null;
+                    // Re-render dropdown + list with new data
+                    this._loadPanelCatalog();
+                    this._toast('Catalog updated');
+                } else {
+                    // Pending data wasn't stashed (boot check failed?) — fall back to a fresh refresh
+                    this.refreshPanelCatalogNow();
+                }
+            };
+        } else {
+            el.style.cssText = 'display:inline-block; padding:2px 0; color:#777; font-size:10px;';
+            el.onclick = null;
+            if (cachedAt) {
+                const d = new Date(cachedAt);
+                const when = isNaN(d) ? cachedAt : d.toLocaleDateString();
+                el.textContent = `Updated ${when}`;
+                el.title = `Catalog last refreshed from GitHub on ${cachedAt}`;
+            } else {
+                el.textContent = 'Bundled';
+                el.title = 'Using the panel catalog bundled with this app version. Click Refresh to pull updates.';
+            }
+        }
+    }
+
+    _toast(msg, isError) {
+        let host = document.getElementById('app-toast-host');
+        if (!host) {
+            host = document.createElement('div');
+            host.id = 'app-toast-host';
+            host.style.cssText = 'position:fixed; bottom:20px; left:50%; transform:translateX(-50%); z-index:11000; display:flex; flex-direction:column; gap:6px; align-items:center;';
+            document.body.appendChild(host);
+        }
+        const t = document.createElement('div');
+        t.style.cssText = `padding:10px 16px; border-radius:6px; font-size:13px; color:#fff; background:${isError ? '#a8324b' : '#2d4a7a'}; box-shadow:0 2px 12px rgba(0,0,0,0.4); opacity:0; transition:opacity 0.18s ease;`;
+        t.textContent = msg;
+        host.appendChild(t);
+        requestAnimationFrame(() => { t.style.opacity = '1'; });
+        setTimeout(() => {
+            t.style.opacity = '0';
+            setTimeout(() => t.remove(), 220);
+        }, 2400);
     }
 
     // A panel is "verified" if its `source` flags it as cross-checked against
@@ -4511,6 +4676,15 @@ class LEDRasterApp {
             body: bodyLines.join('\n'),
         });
         const url = `https://github.com/kman1898/LED-Raster-Designer/issues/new?${params.toString()}`;
+        // Make sure the user knows the GitHub tab is the actual submission —
+        // we've had submissions get lost because the user filled out the
+        // app-side prompts and assumed that was enough.
+        const ok = confirm(
+            'This will open GitHub in a new tab with your submission pre-filled.\n\n' +
+            'IMPORTANT: You must be signed in to GitHub and click the green "Submit new issue" button there for it to actually reach us.\n\n' +
+            'Continue?'
+        );
+        if (!ok) return;
         window.open(url, '_blank', 'noopener');
     }
 
@@ -4643,6 +4817,9 @@ class LEDRasterApp {
             e.preventDefault();
             this.openPanelSpecCorrection();
         });
+
+        const refreshBtn = document.getElementById('panel-catalog-refresh-btn');
+        if (refreshBtn) refreshBtn.addEventListener('click', () => this.refreshPanelCatalogNow());
 
         const saveCancel = document.getElementById('preset-save-cancel');
         const saveConfirm = document.getElementById('preset-save-confirm');

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.7.1</title>
+    <title>LED Raster Designer v0.7.7.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.7.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.7.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1608,9 +1608,13 @@
                 </div>
                 <!-- Panel catalog column -->
                 <div style="flex: 1; display: flex; flex-direction: column;">
-                    <div style="color: #ddd; font-size: 12px; font-weight: 600; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px; display: flex; justify-content: space-between; align-items: center;">
+                    <div style="color: #ddd; font-size: 12px; font-weight: 600; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px; display: flex; justify-content: space-between; align-items: center; gap: 8px;">
                         <span>Panel Catalog <span id="panel-catalog-count" style="color:#777; font-weight:normal; text-transform:none; letter-spacing:0;"></span></span>
-                        <span style="color:#777; font-weight:normal; text-transform:none; letter-spacing:0; font-size:11px;" title="Most panels come from FidoLED's database — accurate but sometimes slightly older than current manufacturer specs. ⭐ marks panels we've cross-checked against the manufacturer's own spec sheet.">⭐ = manufacturer-verified</span>
+                        <span style="display:flex; align-items:center; gap:8px; font-weight:normal; text-transform:none; letter-spacing:0;">
+                            <span id="panel-catalog-source-tag" style="color:#777; font-size:10px;" title="Source of the panel catalog currently loaded">Bundled</span>
+                            <button type="button" id="panel-catalog-refresh-btn" class="btn" style="background:#2a2a2a; border:1px solid #3a3a3a; color:#ccc; font-size:11px; padding:3px 8px;" title="Pull the latest panel catalog from GitHub">↻ Refresh</button>
+                            <span style="color:#777; font-size:11px;" title="Most panels come from FidoLED's database — accurate but sometimes slightly older than current manufacturer specs. ⭐ marks panels we've cross-checked against the manufacturer's own spec sheet.">⭐ = verified</span>
+                        </span>
                     </div>
                     <div style="display: flex; gap: 6px; margin-bottom: 6px;">
                         <input id="panel-catalog-search" type="text" placeholder="🔍 Search name or manufacturer…"
@@ -1623,6 +1627,7 @@
                     <div style="font-size: 11px; color: #777; margin-top: 6px; text-align: right;">
                         Bad specs or missing panel?
                         <a href="#" id="panel-submit-correction" style="color: #8ab4f8; text-decoration: none;">Submit a correction or add a panel →</a>
+                        <div style="color: #888; font-size: 10px; margin-top: 2px;">Opens GitHub in a new tab — you must be signed in and click <b>“Submit new issue”</b> for it to reach us.</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add Screen modal: live catalog refresh from GitHub via Flask-proxied `/api/panel-catalog/refresh`
- Boot-time silent check shows "📦 Update available" pill when upstream is newer
- Refreshed catalog persists in localStorage per browser
- Submission flow: confirm dialog + inline note so users don't lose submissions by closing the GitHub tab early
- `spec-correction` / `add-panel` labels created on the repo so future submissions land filterable

## Test plan
- [x] Refresh button toasts "Catalog refreshed — N panels" and updates the source tag
- [x] Submit a correction → confirm dialog appears → GitHub issue lands with proper label (verified via #55)
- [ ] Boot check: with bundled catalog older than upstream main, the "Update available" pill renders (will verify in next step by pushing the Absen X5 fix to main directly)