### PR TITLE
release.yml: auto-publish on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,13 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: "LED Raster Designer ${{ github.ref_name }}"
-          draft: true
+          # Auto-publish on tag push so the README "Download latest" link
+          # and the in-app sidebar link always resolve to the just-built
+          # release. Previously this was draft:true and required manual
+          # publish, which led to releases piling up as drafts and the
+          # /releases/latest page pointing at an old version.
+          draft: false
+          make_latest: true
           generate_release_notes: true
           files: |
             artifacts/macos-build/*.zip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.7.2
+# LED Raster Designer v0.7.7.3
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 
@@ -98,6 +98,7 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 - Over-capacity error detection with visual overlay
 - Per-screen primary / backup port colors and label sizes
 - Optional per-port info display directly on the panel
+- **Front / Back view perspective** — independent toggle in the sidebar. Back view horizontally mirrors the canvas geometry (so wiring matches what you see standing behind the wall) while keeping every label readable, shows a "BACK VIEW" badge in the corner, and auto-appends `_back` to the export filename suffix.
 
 ### Power Tab
 - Circuit-based serpentine routing with configurable voltage, amperage, and watts
@@ -107,6 +108,7 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 - 1-phase and 3-phase power calculations
 - Circuit start labels with directional pointers
 - Per-circuit label overrides
+- **Front / Back view perspective** — same independent toggle as Data, with mirrored geometry and "BACK VIEW" badge.
 
 ### Project Management
 - Save / open projects as `.json` files (preserves all layers, settings, and panel state)
@@ -126,7 +128,9 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 ### Verified Panel Catalog
 - Built-in panel presets for many manufacturers (ROE, Leyard, Barco, INFiLED, ARTFOX, etc.)
 - ⭐ marker on panels with verified specs (cross-checked against manufacturer datasheets)
-- "Submit a correction" / "Add missing panel" link inside the app opens a pre-filled GitHub issue
+- **Live catalog refresh** — `↻ Refresh` button in the Add Screen modal pulls the latest `panel_catalog.json` from GitHub without needing to reinstall the app. Boot-time silent check shows a "📦 Update available" pill when newer panels are out. Refreshed catalog persists per browser.
+- **Favorites** — heart any panel in the catalog to pin it to the left column alongside your saved presets. Drag-reorder the left column to suit your typical workflow. Per-user, persists in localStorage.
+- "Submit a correction" / "Add missing panel" link inside the app opens a pre-filled GitHub issue (with a confirmation that the user must click "Submit new issue" on GitHub for it to actually reach us — submissions used to silently drop)
 
 ### Preferences
 - Default raster size, grid colors, flow patterns, and line widths

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,30 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.7.7.3 - May 1, 2026
+----------------------------
+- FIX: Panel catalog refresh failed in the macOS bundled app with
+  "Couldn't reach GitHub". Root cause: Python's stdlib ssl module
+  inside the PyInstaller .app couldn't find the system CA cert
+  store, so every HTTPS handshake to raw.githubusercontent.com
+  failed. We were already bundling certifi for this exact reason
+  but never actually pointing urllib at it. Now the refresh route
+  builds an SSL context with cafile=certifi.where() so verification
+  succeeds in both dev and bundled builds.
+- UX: Refresh button now properly suppresses spam clicks (previously
+  9 stacked fetches were possible while it said "Refreshing…"),
+  has a hard 15s client-side AbortController timeout so a hung
+  request can't pin the UI, and surfaces the underlying server
+  error in the failure toast instead of just "couldn't reach".
+- LOGS: Server now logs panel_catalog_refresh_start/done/error so
+  failures can be diagnosed without guessing whether the request
+  reached Flask.
+- INFRA: Release workflow auto-publishes tagged releases instead of
+  leaving them as drafts (was the reason /releases/latest pointed
+  at v0.7.6.4 even though .7.0/.1/.2 had been built).
+- DELETE: Removed broken v0.7.7.2 release from GitHub Releases
+  (catalog refresh never worked on macOS in that build).
+
 v0.7.7.2 - May 1, 2026
 ----------------------------
 - FEATURE: Panel catalog can now be refreshed live from GitHub without

--- a/src/app.py
+++ b/src/app.py
@@ -737,10 +737,28 @@ def delete_preset(name):
 import hashlib
 import urllib.request
 import urllib.error
+import ssl
+try:
+    import certifi
+    _CERTIFI_PATH = certifi.where()
+except Exception:
+    _CERTIFI_PATH = None
 
 _PANEL_CATALOG_RAW_URL = 'https://raw.githubusercontent.com/kman1898/LED-Raster-Designer/main/src/static/data/panel_catalog.json'
 _panel_catalog_cache = {'fetched_at': 0, 'payload': None}
 _PANEL_CATALOG_CACHE_TTL = 300  # seconds
+
+def _make_ssl_context():
+    """Build an SSL context using certifi's CA bundle when available.
+    Fixes outbound HTTPS calls from the PyInstaller-bundled .app, where
+    Python's stdlib ssl module can't find the system cert store and every
+    handshake fails with URLError("CERTIFICATE_VERIFY_FAILED")."""
+    if _CERTIFI_PATH:
+        try:
+            return ssl.create_default_context(cafile=_CERTIFI_PATH)
+        except Exception:
+            pass
+    return ssl.create_default_context()
 
 def _bundled_panel_catalog_path():
     return os.path.join(os.path.dirname(__file__), 'static', 'data', 'panel_catalog.json')
@@ -780,15 +798,17 @@ def panel_catalog_refresh():
     now = time.time()
     cached = _panel_catalog_cache
     if cached['payload'] and (now - cached['fetched_at']) < _PANEL_CATALOG_CACHE_TTL:
+        log_event('panel_catalog_refresh_cache_hit', {'age_s': round(now - cached['fetched_at'], 1)})
         payload = dict(cached['payload'])
         payload['fromCache'] = True
         return jsonify(payload)
+    log_event('panel_catalog_refresh_start', {'url': _PANEL_CATALOG_RAW_URL, 'cafile': _CERTIFI_PATH or 'system'})
     try:
         req = urllib.request.Request(
             _PANEL_CATALOG_RAW_URL,
             headers={'User-Agent': 'led-raster-designer'}
         )
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=10, context=_make_ssl_context()) as resp:
             data = resp.read()
         catalog = json.loads(data)
         if not isinstance(catalog, dict):
@@ -805,10 +825,13 @@ def panel_catalog_refresh():
         }
         _panel_catalog_cache['payload'] = payload
         _panel_catalog_cache['fetched_at'] = now
+        log_event('panel_catalog_refresh_done', {'panels': panel_count, 'sha': sha[:8]})
         return jsonify(dict(payload, fromCache=False))
     except urllib.error.URLError as e:
+        log_event('panel_catalog_refresh_error', {'kind': 'network', 'detail': str(e)})
         return jsonify({'error': f'network: {e}'}), 502
     except Exception as e:
+        log_event('panel_catalog_refresh_error', {'kind': 'other', 'detail': str(e)})
         return jsonify({'error': str(e)}), 500
 
 # ── Logs (in-app viewer) ──

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.7.2',
-            'CFBundleVersion': '0.7.7.2',
+            'CFBundleShortVersionString': '0.7.7.3',
+            'CFBundleVersion': '0.7.7.3',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -4317,10 +4317,26 @@ class LEDRasterApp {
 
     // Manual user-triggered refresh from the button in the catalog header.
     refreshPanelCatalogNow(opts = {}) {
+        // Re-entrancy guard: if a refresh is already in flight, return that
+        // promise instead of starting a parallel one. Spam-clicking the
+        // button used to stack 9 fetches behind each other and confuse the
+        // UI state.
+        if (this._catalogRefreshInFlight) return this._catalogRefreshInFlight;
         const btn = document.getElementById('panel-catalog-refresh-btn');
-        const tag = document.getElementById('panel-catalog-source-tag');
-        if (btn) { btn.disabled = true; btn.textContent = '↻ Refreshing…'; }
-        return fetch('/api/panel-catalog/refresh').then(r => r.ok ? r.json() : Promise.reject(r))
+        if (btn) {
+            btn.disabled = true;
+            // pointer-events:none belt-and-suspenders the disabled attribute
+            // (some bound listeners fire on disabled buttons in webviews).
+            btn.style.pointerEvents = 'none';
+            btn.style.opacity = '0.6';
+            btn.textContent = '↻ Refreshing…';
+        }
+        // Hard 15s client-side timeout so a hung server can't pin the UI.
+        const ctrl = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+        const timeoutId = setTimeout(() => { try { ctrl && ctrl.abort(); } catch {} }, 15000);
+        const fetchOpts = ctrl ? { signal: ctrl.signal } : {};
+        const p = fetch('/api/panel-catalog/refresh', fetchOpts)
+            .then(r => r.ok ? r.json() : r.json().then(b => Promise.reject(b)).catch(() => Promise.reject({status: r.status})))
             .then(payload => {
                 if (!payload || !payload.catalog) throw new Error('bad payload');
                 this._setCachedCatalog(payload.catalog, payload.sha, payload.fetchedAt);
@@ -4336,12 +4352,24 @@ class LEDRasterApp {
                     this._toast(`Catalog refreshed — ${count.toLocaleString()} panels`);
                 }
             })
-            .catch(() => {
-                if (!opts.silent) this._toast('Couldn’t reach GitHub — keeping current catalog', true);
+            .catch((err) => {
+                if (!opts.silent) {
+                    const detail = err && err.error ? ` (${err.error})` : '';
+                    this._toast(`Couldn’t reach GitHub — keeping current catalog${detail}`, true);
+                }
             })
             .finally(() => {
-                if (btn) { btn.disabled = false; btn.textContent = '↻ Refresh'; }
+                clearTimeout(timeoutId);
+                this._catalogRefreshInFlight = null;
+                if (btn) {
+                    btn.disabled = false;
+                    btn.style.pointerEvents = '';
+                    btn.style.opacity = '';
+                    btn.textContent = '↻ Refresh';
+                }
             });
+        this._catalogRefreshInFlight = p;
+        return p;
     }
 
     // Renders the small "source tag" shown in the catalog column header:

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.7.2</title>
+    <title>LED Raster Designer v0.7.7.3</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.7.2</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.7.3</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
- Flips \`draft: true\` → \`draft: false\` and adds \`make_latest: true\` in `.github/workflows/release.yml`.
- Future tagged releases will auto-publish so \`/releases/latest\` always points at the just-built version (which is what the README "Download" links and in-app sidebar link resolve to).
- No app version bump — workflow-only change.

## Test plan
- [ ] Next tagged release pushes through to "Latest" without manual publish step