### PR TITLE
v0.8.0 — Multi-Canvas (MAJOR release)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,8 +12,8 @@
    make install-mac
    ```
 4. When it finishes you get:
-   - **LED Raster Designer.app** in the `dist/` folder — double-click to launch
-   - **Mac LED Raster Designer Installer.zip** — upload this to GitHub Releases
+   - **LED Raster Designer.app** in the `dist/` folder, double-click to launch
+   - **Mac LED Raster Designer Installer.zip**, upload this to GitHub Releases
 
 ## Windows
 
@@ -33,8 +33,8 @@
    pyinstaller led_raster_designer.spec --noconfirm
    ```
 4. When it finishes you get:
-   - **LED Raster Designer.exe** in `dist\LED Raster Designer\` — double-click to launch
-   - **PC LED Raster Designer Installer.zip** — upload this to GitHub Releases
+   - **LED Raster Designer.exe** in `dist\LED Raster Designer\`, double-click to launch
+   - **PC LED Raster Designer Installer.zip**, upload this to GitHub Releases
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Design LED cabinet layouts, plan the real-world stage layout, configure data flo
 1. **[Download the latest Mac release](../../releases/latest)**
 2. Unzip the file
 3. Double-click **LED Raster Designer.app**
-4. Your browser opens automatically — start designing
+4. Your browser opens automatically, start designing
 5. Look for the 💡 in your menu bar to reopen the browser or quit
 
 ### Windows
 1. **[Download the latest Windows release](../../releases/latest)**
 2. Unzip the file
 3. Double-click **LED Raster Designer.exe**
-4. Your browser opens automatically — start designing
+4. Your browser opens automatically, start designing
 5. Look for the lightbulb in your system tray (bottom-right) to reopen the browser or quit
 
 ### Network Access
@@ -35,7 +35,7 @@ Other devices on your local network can use the app by going to `http://[your-ip
 |-----|-------------|
 | **Pixel Map** | Layout view that mirrors what your processor expects. Checkerboard test pattern, panel borders, circle test pattern, and screen labels. |
 | **Cabinet ID** | Cabinet numbering with customizable styles (A1, 1,1, 01, etc.). Matches the Pixel Map layout. |
-| **Show Look** | Rearrange screens to match the real-world stage layout. Pixel Map keeps the processor-required layout; Show Look's layout drives Data and Power so wiring/power maps match how the show is actually built. Per-screen "show position" separate from "processor position" — and an independent raster size. |
+| **Show Look** | Rearrange screens to match the real-world stage layout. Pixel Map keeps the processor-required layout; Show Look's layout drives Data and Power so wiring/power maps match how the show is actually built. Per-screen "show position" separate from "processor position", and an independent raster size. |
 | **Data** | Data routing visualization with serpentine flow patterns and port assignments. Renders at the Show Look layout. |
 | **Power** | Power distribution planning with circuit routing and color-coded visualization. Renders at the Show Look layout. |
 
@@ -49,11 +49,11 @@ Other devices on your local network can use the app by going to `http://[your-ip
 - Save layers as presets to reuse across projects
 
 ### Per-Panel Editing
-Drag-select any group of panels in Pixel Map view, then bulk-toggle their state — or use modifier keys for fast single-panel edits.
+Drag-select any group of panels in Pixel Map view, then bulk-toggle their state, or use modifier keys for fast single-panel edits.
 
 | Action | What it does |
 |--------|-------------|
-| **Alt + Click** | Toggle a panel as **blank** (hidden — useful for non-rectangular walls). When a multi-selection is active, applies to the entire selection. |
+| **Alt + Click** | Toggle a panel as **blank** (hidden, useful for non-rectangular walls). When a multi-selection is active, applies to the entire selection. |
 | **Alt + Shift + Click** | Toggle a panel as **half-tile** (auto-detects half-width vs half-height based on which wall edge the panel sits on). Bulk version uses majority-vote across the selection so a row stays consistent. |
 | **Drag-select** | Marquee-select panels to bulk-action via the sidebar buttons. Count badge shows how many are selected. |
 | **Right-click** | Context menu in Pixel Map view with the same blank / half-tile / restore actions. |
@@ -88,7 +88,7 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 
 ### Data Tab
 - 8 serpentine flow patterns (all corner starts × horizontal/vertical)
-- **Custom data path mode** — click panels in order to draw your own port routing, or drag-select a region and apply a flow pattern just to that region
+- **Custom data path mode**, click panels in order to draw your own port routing, or drag-select a region and apply a flow pattern just to that region
 - Port capacity calculator supporting:
   - **NovaStar** (Legacy, Armor, COEX)
   - **Brompton Tessera**
@@ -98,17 +98,17 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 - Over-capacity error detection with visual overlay
 - Per-screen primary / backup port colors and label sizes
 - Optional per-port info display directly on the panel
-- **Front / Back view perspective** — independent toggle in the sidebar. Back view horizontally mirrors the canvas geometry (so wiring matches what you see standing behind the wall) while keeping every label readable, shows a "BACK VIEW" badge in the corner, and auto-appends `_back` to the export filename suffix.
+- **Front / Back view perspective**, independent toggle in the sidebar. Back view horizontally mirrors the canvas geometry (so wiring matches what you see standing behind the wall) while keeping every label readable, shows a "BACK VIEW" badge in the corner, and auto-appends `_back` to the export filename suffix.
 
 ### Power Tab
 - Circuit-based serpentine routing with configurable voltage, amperage, and watts
-- **Custom power path mode** — draw circuits manually for non-standard wiring
+- **Custom power path mode**, draw circuits manually for non-standard wiring
 - Color-coded circuit visualization with customizable per-circuit colors
 - Organized and max-capacity mapping modes
 - 1-phase and 3-phase power calculations
 - Circuit start labels with directional pointers
 - Per-circuit label overrides
-- **Front / Back view perspective** — same independent toggle as Data, with mirrored geometry and "BACK VIEW" badge.
+- **Front / Back view perspective**, same independent toggle as Data, with mirrored geometry and "BACK VIEW" badge.
 
 ### Project Management
 - Save / open projects as `.json` files (preserves all layers, settings, and panel state)
@@ -117,7 +117,7 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 - Per-panel state (hidden, half-tile) survives column/row resizes (state is anchored to grid position, not sequential id)
 
 ### Export
-- Multi-view PNG export — pick which views (Pixel Map, Cabinet ID, Show Look, Data, Power) to render in one go
+- Multi-view PNG export, pick which views (Pixel Map, Cabinet ID, Show Look, Data, Power) to render in one go
 - PSD export with per-screen layers
 - PDF export
 - Resolume Arena Advanced Output XML export
@@ -128,9 +128,9 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 ### Verified Panel Catalog
 - Built-in panel presets for many manufacturers (ROE, Leyard, Barco, INFiLED, ARTFOX, etc.)
 - ⭐ marker on panels with verified specs (cross-checked against manufacturer datasheets)
-- **Live catalog refresh** — `↻ Refresh` button in the Add Screen modal pulls the latest `panel_catalog.json` from GitHub without needing to reinstall the app. Boot-time silent check shows a "📦 Update available" pill when newer panels are out. Refreshed catalog persists per browser.
-- **Favorites** — heart any panel in the catalog to pin it to the left column alongside your saved presets. Drag-reorder the left column to suit your typical workflow. Per-user, persists in localStorage.
-- "Submit a correction" / "Add missing panel" link inside the app opens a pre-filled GitHub issue (with a confirmation that the user must click "Submit new issue" on GitHub for it to actually reach us — submissions used to silently drop)
+- **Live catalog refresh**, `↻ Refresh` button in the Add Screen modal pulls the latest `panel_catalog.json` from GitHub without needing to reinstall the app. Boot-time silent check shows a "📦 Update available" pill when newer panels are out. Refreshed catalog persists per browser.
+- **Favorites**, heart any panel in the catalog to pin it to the left column alongside your saved presets. Drag-reorder the left column to suit your typical workflow. Per-user, persists in localStorage.
+- "Submit a correction" / "Add missing panel" link inside the app opens a pre-filled GitHub issue (with a confirmation that the user must click "Submit new issue" on GitHub for it to actually reach us, submissions used to silently drop)
 
 ### Preferences
 - Default raster size, grid colors, flow patterns, and line widths
@@ -140,12 +140,12 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 
 ---
 
-## For Developers — Building from Source
+## For Developers, Building from Source
 
 If you want to build the app yourself instead of downloading the release:
 
 ### Prerequisites
-- **Python 3.10+** — Download from [python.org](https://www.python.org/downloads/)
+- **Python 3.10+**, Download from [python.org](https://www.python.org/downloads/)
 - **Windows users:** During Python install, CHECK the box **"Add Python to PATH"**
 
 ### Mac
@@ -155,12 +155,12 @@ If you want to build the app yourself instead of downloading the release:
    cd "/path/to/LED Raster Designer"
    make mac
    ```
-3. The app appears in the folder — double-click **LED Raster Designer.app**
+3. The app appears in the folder, double-click **LED Raster Designer.app**
 
 ### Windows
 1. Clone or download this repo
 2. Double-click **Build Windows.bat**
-3. The app appears in the folder — double-click **LED Raster Designer App\LED Raster Designer.exe**
+3. The app appears in the folder, double-click **LED Raster Designer App\LED Raster Designer.exe**
 
 ### Cleaning Build Files
 - **Mac:** `make clean`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ Other devices on your local network can use the app by going to `http://[your-ip
 
 ## Features
 
+### Multi-Canvas (new in v0.8)
+
+A project can hold multiple independent **canvases**, each with its own raster size, workspace position, perspective, and layers. Think of one canvas per processor / per stage / per tour leg.
+
+- Right-sidebar **Screens** panel groups layers by canvas. Each canvas has a color swatch, name, eye toggle (visibility), and a **+ Add** button to drop new layers in.
+- Drag a canvas by its dashed outline to reposition it in the workspace. Magnetic snap aligns edges with neighboring canvases.
+- Drag (Shift+Drag) a screen layer onto another canvas to **move** it there. Cmd/Alt+Shift+Drag duplicates instead. The layer snaps to (0,0) in the new canvas.
+- Per-canvas raster: the toolbar **Raster: W x H** and the Show Look raster always reflect the active canvas. Each canvas can be sized independently.
+- Per-canvas Front/Back perspective for Data and Power. Switching the active canvas updates the toggle.
+- **Cross-canvas multi-select**: Shift+click layers in different canvases and bulk-edit them at once (panel size, voltage, processor type, etc.). The selection survives the active-canvas auto-switch.
+- **Hidden canvases** are excluded from the Data/Power totals and from exports by default.
+- **Per-canvas presets**: a new screen added to a canvas inherits hardware settings (voltage, amperage, panel size, processor type) from the most recent screen already in that canvas.
+
 ### Five View Modes
 
 | Tab | What it does |
@@ -115,12 +128,14 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 - Recent Files menu in the File menu
 - Auto-update check (notifies when a new release is available)
 - Per-panel state (hidden, half-tile) survives column/row resizes (state is anchored to grid position, not sequential id)
+- **v0.7 → v0.8 auto-migration** on load: opens any older project and converts it into the multi-canvas format with one canvas containing all the original layers. A one-time toast reminds you to save in the new format. v0.7 builds opening a v0.8 file get a clean "format newer than supported" error.
 
 ### Export
 - Multi-view PNG export, pick which views (Pixel Map, Cabinet ID, Show Look, Data, Power) to render in one go
-- PSD export with per-screen layers
-- PDF export
-- Resolume Arena Advanced Output XML export
+- **Multi-canvas aware** (v0.8): the Export dialog adds a Canvases section above Views. Each (canvas × view) is one PNG / one PSD / one PDF page. PDF page headers include canvas + view name. Resolume XML now emits one `<Screen>` per canvas, sized to that canvas's raster.
+- PSD export with per-screen layers (per-canvas filtered, only that canvas's layers in each PSD)
+- PDF export (multi-page across selected canvases × views)
+- Resolume Arena Advanced Output XML export (one `<Screen>` per canvas, named after the canvas)
 - NovaStar SCR export (sending-card mapping)
 - Configurable export filename suffixes per view (saved as defaults)
 - Project-name input flags illegal filename characters (\\ / : * ? " < > |) and auto-sanitizes them on export

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.7.7.4
+# LED Raster Designer v0.8.0
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/docs/multi-canvas-design.md
+++ b/docs/multi-canvas-design.md
@@ -195,7 +195,7 @@ The workspace shows **every visible canvas** at its `workspace_x, workspace_y` p
 
 In every case the screen position of a layer is `canvas.workspace_x + layer_offset_within_canvas`.
 
-**Canvas rect drawn only if canvas has at least one visible layer.** Empty canvases don't clutter the workspace but still exist (visible in the sidebar; the user can add layers to them).
+**Canvas rect always drawn (when `canvas.visible !== false`)** — even when the canvas has no layers. Empty canvases need to remain a valid drop target for cross-canvas layer drag (Slice 7). Hide via the canvas-level eye toggle if a canvas is in the way.
 
 ### 5.3 Color coding
 

--- a/docs/multi-canvas-design.md
+++ b/docs/multi-canvas-design.md
@@ -1,4 +1,4 @@
-# Multi-Canvas Design — v0.8
+# Multi-Canvas Design, v0.8
 
 Status: **DRAFT**, awaiting final approval.
 Branch: `feature/v0.8`.
@@ -11,7 +11,7 @@ This document is the source of truth for the multi-canvas feature. Edits here re
 ## 1. Goals
 
 - One project can contain **multiple canvases**, each representing a separate processor / output / raster.
-- A canvas is essentially a self-contained raster — same as today's single-canvas project, just one of many.
+- A canvas is essentially a self-contained raster, same as today's single-canvas project, just one of many.
 - Layers can be **dragged from one canvas to another** (move) or duplicated to another canvas (Cmd/Alt+drag).
 - Every view tab (Pixel Map, Cabinet ID, Show Look, Data, Power) renders **all canvases simultaneously** in the workspace.
 - Existing v0.7 single-canvas projects **auto-migrate** to one canvas on load.
@@ -20,7 +20,7 @@ This document is the source of truth for the multi-canvas feature. Edits here re
 
 - A single layer being a member of multiple canvases simultaneously (shared/aliased layers). One layer = one canvas. Future v0.9+.
 - Per-canvas Save (saving a single canvas to its own file). Future, optional.
-- Backwards compatibility with v0.7 — once a project is opened + saved as v0.8 it is no longer openable in v0.7.
+- Backwards compatibility with v0.7, once a project is opened + saved as v0.8 it is no longer openable in v0.7.
 - A separate project-level "show raster". The workspace itself is the stage.
 - SCR (NovaStar) export changes. Currently broken; out of scope.
 
@@ -124,7 +124,7 @@ This document is the source of truth for the multi-canvas feature. Edits here re
 
 Notes:
 - Processor type stays on each layer because: today a layer can override its canvas's defaults, and we don't want to lose that flexibility. Adding a layer to a canvas should *default* the layer's processor to the canvas's preferred type, but the user can still change it per-layer.
-- Per-canvas defaults (voltage / amperage / panel watts) live in the canvas object as **defaults applied to new layers added to that canvas** — actual values still live on the layer.
+- Per-canvas defaults (voltage / amperage / panel watts) live in the canvas object as **defaults applied to new layers added to that canvas**, actual values still live on the layer.
 
 ### 4.4 Migration (v0.7 → v0.8)
 
@@ -149,7 +149,7 @@ On project load:
 
 ## 5. UI architecture
 
-### 5.1 Right sidebar — Layer Groups
+### 5.1 Right sidebar, Layer Groups
 
 Replaces today's flat Screens list.
 
@@ -195,14 +195,14 @@ The workspace shows **every visible canvas** at its `workspace_x, workspace_y` p
 
 In every case the screen position of a layer is `canvas.workspace_x + layer_offset_within_canvas`.
 
-**Canvas rect always drawn (when `canvas.visible !== false`)** — even when the canvas has no layers. Empty canvases need to remain a valid drop target for cross-canvas layer drag (Slice 7). Hide via the canvas-level eye toggle if a canvas is in the way.
+**Canvas rect always drawn (when `canvas.visible !== false`)**, even when the canvas has no layers. Empty canvases need to remain a valid drop target for cross-canvas layer drag (Slice 7). Hide via the canvas-level eye toggle if a canvas is in the way.
 
 ### 5.3 Color coding
 
 - Each canvas has a `color` (hex string).
 - Default palette (auto-cycled for new canvases):
   - `#4A90E2` (blue), `#F5A623` (orange), `#7ED321` (green), `#BD10E0` (purple), `#D0021B` (red), `#50E3C2` (teal), `#F8E71C` (yellow), `#9013FE` (deep purple).
-  - After 8 canvases, cycle back to the start (collisions allowed — user can change manually).
+  - After 8 canvases, cycle back to the start (collisions allowed, user can change manually).
 - Color appears on:
   - The canvas's dashed-outline rectangle in the workspace
   - The layer name border / badge in the Screens panel (subtle left-edge stripe in the canvas's color)
@@ -227,7 +227,7 @@ The toolbar `Raster: [W] x [H]` field always edits the **active canvas's** raste
 
 - Hover a canvas's outline → cursor changes to "move" indicator on the outline edges (drag-by-edge model, like keynote-style artboards).
 - Drag → updates `canvas.workspace_x/y`. All layers stay glued (layer offsets are relative to the canvas, so they move with it).
-- **Overlap handling**: if the user drops a canvas overlapping another, show a non-blocking warning toast: *"Canvases overlapping — visual rendering may be confusing."* No auto-snap, no rejection. User decides.
+- **Overlap handling**: if the user drops a canvas overlapping another, show a non-blocking warning toast: *"Canvases overlapping, visual rendering may be confusing."* No auto-snap, no rejection. User decides.
 
 ### 5.6 Auto-layout for new canvases
 
@@ -251,7 +251,7 @@ The toolbar `Raster: [W] x [H]` field always edits the **active canvas's** raste
 - Canvas-level 👁 toggle in the sidebar.
 - Hiding a canvas:
   - Hides the canvas's rect in the workspace
-  - Hides all layers in that canvas (visually only — does not change `layer.visible`)
+  - Hides all layers in that canvas (visually only, does not change `layer.visible`)
   - Layers in the Screens panel under a hidden canvas group are dimmed
   - Hidden canvas not included in capacity / power totals or export selection by default
 - Toggling visible re-shows everything.
@@ -285,7 +285,7 @@ The toolbar `Raster: [W] x [H]` field always edits the **active canvas's** raste
 
 ### 6.4 Toolbar
 
-- `Raster: [W] x [H]` field edits **active canvas's** raster (Pixel Map raster on Pixel Map / Cabinet ID tabs; Show Look raster on Show Look / Data / Power tabs — same per-view behavior as today, just per-canvas).
+- `Raster: [W] x [H]` field edits **active canvas's** raster (Pixel Map raster on Pixel Map / Cabinet ID tabs; Show Look raster on Show Look / Data / Power tabs, same per-view behavior as today, just per-canvas).
 - Project name field unchanged.
 - Fit / 1:1 / zoom buttons operate on the workspace as a whole.
 
@@ -310,7 +310,7 @@ The toolbar `Raster: [W] x [H]` field always edits the **active canvas's** raste
 
 - Cross-canvas layer drag is undoable (restores previous canvas + previous offsets).
 - Canvas creation / deletion / rename / reorder / move / color change are all undoable.
-- Undo history is a single stack at the project level — does not split per canvas.
+- Undo history is a single stack at the project level, does not split per canvas.
 
 ---
 
@@ -395,7 +395,7 @@ After Slice 13, **multi-canvas is rock solid** and we move to the expanded proce
 
 ### 10.1 Per-slice version stance
 
-- Slices 1-12 ship as PRs into `feature/v0.8` (no version bump on each — feature branch is WIP).
+- Slices 1-12 ship as PRs into `feature/v0.8` (no version bump on each, feature branch is WIP).
 - Slice 13 (or whichever final slice ships v0.8.0) is the version bump + tag + release.
 
 ---
@@ -416,17 +416,17 @@ After Slice 13, **multi-canvas is rock solid** and we move to the expanded proce
 
 ## 12. Open questions
 
-(none — all design decisions locked through Round 3. This section reserved for issues found during implementation.)
+(none, all design decisions locked through Round 3. This section reserved for issues found during implementation.)
 
 ---
 
 ## 13. Out of scope (deferred)
 
 - **Sharing a layer across canvases** (one layer in two canvases simultaneously). Likely v0.9 if real demand emerges.
-- **Per-canvas Show Look toggle to "combine all canvases into one virtual stage"** — current model lets users do this manually by overlapping canvases or dragging layers cross-canvas.
-- **Export of a single layer in isolation** — user mentioned as a "not bad idea later." Out for v0.8.
-- **SCR (NovaStar sending card) export** — currently broken. Separate fix, not part of v0.8.
-- **Per-canvas keyboard shortcut** (e.g. Cmd+1 jumps to Canvas 1) — easy to add later if users want it.
+- **Per-canvas Show Look toggle to "combine all canvases into one virtual stage"**, current model lets users do this manually by overlapping canvases or dragging layers cross-canvas.
+- **Export of a single layer in isolation**, user mentioned as a "not bad idea later." Out for v0.8.
+- **SCR (NovaStar sending card) export**, currently broken. Separate fix, not part of v0.8.
+- **Per-canvas keyboard shortcut** (e.g. Cmd+1 jumps to Canvas 1), easy to add later if users want it.
 
 ---
 

--- a/docs/multi-canvas-design.md
+++ b/docs/multi-canvas-design.md
@@ -1,0 +1,436 @@
+# Multi-Canvas Design — v0.8
+
+Status: **DRAFT**, awaiting final approval.
+Branch: `feature/v0.8`.
+Owner: kman1898.
+
+This document is the source of truth for the multi-canvas feature. Edits here require a brief comment in the PR explaining why. Everything below is locked unless explicitly amended.
+
+---
+
+## 1. Goals
+
+- One project can contain **multiple canvases**, each representing a separate processor / output / raster.
+- A canvas is essentially a self-contained raster — same as today's single-canvas project, just one of many.
+- Layers can be **dragged from one canvas to another** (move) or duplicated to another canvas (Cmd/Alt+drag).
+- Every view tab (Pixel Map, Cabinet ID, Show Look, Data, Power) renders **all canvases simultaneously** in the workspace.
+- Existing v0.7 single-canvas projects **auto-migrate** to one canvas on load.
+
+## 2. Non-goals (explicitly OUT for v0.8)
+
+- A single layer being a member of multiple canvases simultaneously (shared/aliased layers). One layer = one canvas. Future v0.9+.
+- Per-canvas Save (saving a single canvas to its own file). Future, optional.
+- Backwards compatibility with v0.7 — once a project is opened + saved as v0.8 it is no longer openable in v0.7.
+- A separate project-level "show raster". The workspace itself is the stage.
+- SCR (NovaStar) export changes. Currently broken; out of scope.
+
+## 3. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Canvas** | A single raster + processor. Has a workspace position, its own raster size, and a set of layers. |
+| **Workspace** | The unbounded 2D area inside the canvas viewport where canvases are laid out. Pan + zoom. |
+| **Active canvas** | The canvas whose properties are shown in the left sidebar; receives `+ Add Screen`; its raster size is what the toolbar `Raster` field edits. |
+| **Layer** | An on-screen element (screen / image / text). Belongs to exactly one canvas. Has positions in *that canvas's* coordinate space. |
+| **Show Look** | A view mode where each layer renders at its `showOffsetX/Y` (still relative to its canvas's raster). |
+| **Layer group** | The visual grouping of layers under a canvas in the right-side Screens panel. One layer group per canvas. |
+
+---
+
+## 4. Data model
+
+### 4.1 v0.7 (current)
+
+```jsonc
+{
+  "name": "MyShow",
+  "raster_width": 11520,
+  "raster_height": 2272,
+  "show_raster_width": 11520,
+  "show_raster_height": 2272,
+  "data_flow_perspective": "front",
+  "power_perspective": "front",
+  "layers": [
+    { "id": 1, "name": "SR", "offset_x": 0, "offset_y": 0,
+      "showOffsetX": 0, "showOffsetY": 0,
+      "processorType": "novastar-armor",
+      "powerVoltage": 208, "powerAmperage": 20,
+      ... }
+  ]
+}
+```
+
+`raster_width/height`, `show_raster_*`, processor type, voltage/amperage are project-level today. They are about to be canvas-level.
+
+### 4.2 v0.8 (target)
+
+```jsonc
+{
+  "name": "MyShow",
+  "format_version": "0.8",                  // NEW. presence of this field === multi-canvas project
+  "active_canvas_id": "c1",                 // NEW. which canvas's properties show in sidebar
+  "canvases": [                             // NEW. array, ordered (z-order in sidebar reflects this)
+    {
+      "id": "c1",
+      "name": "Canvas 1",
+      "color": "#4A90E2",                   // auto-cycled from palette, user-overridable
+      "workspace_x": 0,                     // NEW. position in workspace (px)
+      "workspace_y": 0,
+      "raster_width": 11520,                // moved from project to canvas
+      "raster_height": 2272,
+      "show_raster_width": 11520,           // moved from project to canvas
+      "show_raster_height": 2272,
+      "data_flow_perspective": "front",     // moved from project to canvas
+      "power_perspective": "front",         // moved from project to canvas
+      "visible": true                       // NEW. canvas-level eye toggle (hides canvas + all its layers)
+    }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "canvas_id": "c1",                    // NEW. which canvas this layer belongs to
+      "name": "SR",
+      "offset_x": 0, "offset_y": 0,         // unchanged. relative to canvas.raster
+      "showOffsetX": 0, "showOffsetY": 0,   // unchanged. relative to canvas.show_raster
+      "processorType": "novastar-armor",    // remains on layer (each layer can technically override
+                                            //  its canvas's processor; sidebar picker still works
+                                            //  per-layer for backwards compatibility)
+      ... everything else unchanged
+    }
+  ]
+}
+```
+
+**Key invariants:**
+
+- `canvases` array is non-empty (at least one canvas always exists).
+- Every `layer.canvas_id` matches an existing `canvas.id`.
+- `active_canvas_id` matches an existing `canvas.id`.
+- Canvas IDs are stable strings (e.g. `c1`, `c2`, …). Renaming a canvas does not change its ID.
+- Layer IDs remain globally unique (current behavior). They are not re-numbered when moving between canvases.
+
+### 4.3 What stays project-level vs moves to canvas
+
+| Field | v0.7 location | v0.8 location |
+|-------|---------------|---------------|
+| `raster_width` / `raster_height` | project | canvas |
+| `show_raster_width` / `show_raster_height` | project | canvas |
+| `data_flow_perspective` | project | canvas |
+| `power_perspective` | project | canvas |
+| `name` | project | project (unchanged) |
+| Layers (the array) | project | project (unchanged); each entry now has `canvas_id` |
+| Processor type / voltage / amperage / panel watts | layer | layer (unchanged) |
+| Recent files, presets, preferences | project / user | unchanged |
+
+Notes:
+- Processor type stays on each layer because: today a layer can override its canvas's defaults, and we don't want to lose that flexibility. Adding a layer to a canvas should *default* the layer's processor to the canvas's preferred type, but the user can still change it per-layer.
+- Per-canvas defaults (voltage / amperage / panel watts) live in the canvas object as **defaults applied to new layers added to that canvas** — actual values still live on the layer.
+
+### 4.4 Migration (v0.7 → v0.8)
+
+On project load:
+
+1. Read project file.
+2. If `format_version` is not present (`undefined` or any pre-0.8 value), it's a v0.7 project. Run the migrator:
+   - Generate one canvas (`id: "c1"`, `name: project.name || "Canvas 1"`, color from palette[0], `workspace_x: 0`, `workspace_y: 0`).
+   - Copy `raster_width`, `raster_height`, `show_raster_width`, `show_raster_height`, `data_flow_perspective`, `power_perspective` from project → canvas.
+   - For every layer, set `layer.canvas_id = "c1"`.
+   - Set `project.canvases = [c1]`, `project.active_canvas_id = "c1"`, `project.format_version = "0.8"`.
+   - Strip the migrated fields from the project root.
+3. **Show one-time toast** on first migration: *"Project upgraded to multi-canvas format (v0.8). Save to keep changes. Older app versions can no longer open this file."*
+   - Toast appears only once per project, gated by checking if the project file on disk lacks `format_version`. If user saves, future loads see `format_version: "0.8"` and toast does not appear.
+
+### 4.5 Backwards-compat policy
+
+- v0.7 builds opening a v0.8 file: the project file's top-level `raster_width` is missing → app shows a "Project format is newer than this version. Please update." dialog and refuses to load. (CI test: open v0.8 file in v0.7 build, assert clean error.)
+- We do **not** ship a "Save as legacy v0.7" option in v0.8.
+
+---
+
+## 5. UI architecture
+
+### 5.1 Right sidebar — Layer Groups
+
+Replaces today's flat Screens list.
+
+```
+SCREENS
+─────────────────────────
+🟦 Canvas 1                [👁] [⋮]   ← color swatch, visibility toggle, action menu
+   [Lock all]   [+ Add Screen]
+   ⋮⋮ SR                              ← drag-handle on left for reorder
+   ⋮⋮ UPSTAGE
+   ⋮⋮ SL
+
+🟧 Canvas 2                [👁] [⋮]   ← active canvas: subtle highlight + colored ring
+   [Lock all]   [+ Add Screen]
+   ⋮⋮ DJ
+─────────────────────────
+[+ Add Canvas]
+```
+
+**Canvas action menu (⋮)** options:
+- Rename
+- Duplicate canvas (creates a copy with all layers; new canvas auto-positioned in workspace; layer IDs reassigned)
+- Change color
+- Delete canvas (confirm dialog; if canvas has layers, warn "Delete canvas + N layers?"; deleting the last canvas not allowed)
+
+**Canvas drag-handle** on the canvas header → reorder canvases (changes canvases array order = z-order).
+
+**Layer drag-handle** → reorder within group, OR drag onto another canvas group → moves layer cross-canvas (G3 behavior: offset_x/y reset to 0,0; showOffsetX/Y reset to 0,0).
+
+**Cmd/Alt+drag** a layer to another canvas → duplicate (new layer ID, copied properties, dropped at 0,0 in new canvas).
+
+### 5.2 Workspace rendering
+
+The workspace shows **every visible canvas** at its `workspace_x, workspace_y` position. Each canvas is an dashed-outlined rectangle of size `raster_width × raster_height` (or `show_raster_width × show_raster_height` in Show Look). Inside each canvas, its layers render at their per-canvas-relative offsets.
+
+| Tab | Canvas rect uses | Layers positioned at |
+|-----|------------------|----------------------|
+| Pixel Map | `raster_width × raster_height` | `offset_x, offset_y` |
+| Cabinet ID | `raster_width × raster_height` | `offset_x, offset_y` |
+| Show Look | `show_raster_width × show_raster_height` | `showOffsetX, showOffsetY` |
+| Data Flow | `show_raster_width × show_raster_height` | `showOffsetX, showOffsetY` |
+| Power | `show_raster_width × show_raster_height` | `showOffsetX, showOffsetY` |
+
+In every case the screen position of a layer is `canvas.workspace_x + layer_offset_within_canvas`.
+
+**Canvas rect drawn only if canvas has at least one visible layer.** Empty canvases don't clutter the workspace but still exist (visible in the sidebar; the user can add layers to them).
+
+### 5.3 Color coding
+
+- Each canvas has a `color` (hex string).
+- Default palette (auto-cycled for new canvases):
+  - `#4A90E2` (blue), `#F5A623` (orange), `#7ED321` (green), `#BD10E0` (purple), `#D0021B` (red), `#50E3C2` (teal), `#F8E71C` (yellow), `#9013FE` (deep purple).
+  - After 8 canvases, cycle back to the start (collisions allowed — user can change manually).
+- Color appears on:
+  - The canvas's dashed-outline rectangle in the workspace
+  - The layer name border / badge in the Screens panel (subtle left-edge stripe in the canvas's color)
+  - The layer's outline color for selection highlights
+  - The canvas color swatch in the Screens panel header
+- **Active canvas** gets:
+  - A bolder outline (1.5× line width) on its workspace rect
+  - A faint background tint (canvas color at ~6% alpha) inside its rect
+  - Subtle highlight on the canvas header in the sidebar
+
+### 5.4 Selecting the active canvas
+
+A canvas becomes active when:
+- User clicks the canvas header in the Screens sidebar
+- User clicks any layer in that canvas (sidebar or workspace)
+- User clicks empty area within that canvas's rect in the workspace
+- User adds a new canvas (the new canvas becomes active)
+
+The toolbar `Raster: [W] x [H]` field always edits the **active canvas's** raster (Pixel Map or Show Look depending on view tab). The left sidebar properties panel shows the active canvas's settings.
+
+### 5.5 Dragging canvases in the workspace
+
+- Hover a canvas's outline → cursor changes to "move" indicator on the outline edges (drag-by-edge model, like keynote-style artboards).
+- Drag → updates `canvas.workspace_x/y`. All layers stay glued (layer offsets are relative to the canvas, so they move with it).
+- **Overlap handling**: if the user drops a canvas overlapping another, show a non-blocking warning toast: *"Canvases overlapping — visual rendering may be confusing."* No auto-snap, no rejection. User decides.
+
+### 5.6 Auto-layout for new canvases
+
+- New canvas is placed to the **right** of the rightmost existing canvas, with a gap of `max(200, 5% of rightmost canvas width)` pixels.
+- Default raster size for new canvas = same as the active canvas's raster (so it feels like cloning the dimensions; avoids surprise).
+- Default show raster = matches the new canvas's raster.
+
+### 5.7 Layer drag between canvases (workspace)
+
+- Pick up a layer from any canvas, drag onto another canvas's rect, drop.
+- On drop:
+  - `layer.canvas_id` updated to the new canvas's ID
+  - `layer.offset_x = 0`, `layer.offset_y = 0`
+  - `layer.showOffsetX = 0`, `layer.showOffsetY = 0`
+  - Layer's color reflects new canvas's color (auto)
+- **Cmd/Alt+drag** = duplicate (layer copied with new ID, dropped at 0,0 of target canvas).
+- Drop indicator: target canvas's rect highlights + drop position icon at canvas top-left.
+
+### 5.8 Hidden canvases
+
+- Canvas-level 👁 toggle in the sidebar.
+- Hiding a canvas:
+  - Hides the canvas's rect in the workspace
+  - Hides all layers in that canvas (visually only — does not change `layer.visible`)
+  - Layers in the Screens panel under a hidden canvas group are dimmed
+  - Hidden canvas not included in capacity / power totals or export selection by default
+- Toggling visible re-shows everything.
+
+---
+
+## 6. Per-view behavior
+
+### 6.1 Pixel Map / Cabinet ID
+
+- Each canvas's Pixel Map raster rect drawn at its workspace position.
+- Layers within use `offset_x/y` for position relative to canvas.
+- Standard checkerboard / cabinet ID rendering per layer, unchanged.
+- Front/Back perspective toggle in sidebar → applies to the active canvas only.
+
+### 6.2 Show Look
+
+- Each canvas's Show Look raster rect drawn at its workspace position. May differ in size from that canvas's Pixel Map raster (existing per-view raster size feature, preserved per canvas).
+- Layers within use `showOffsetX/Y` for position relative to canvas.
+- "Reset to Pixel Map Position" button still per-layer; sets `showOffsetX = offset_x` etc.
+- The auto-link feature (drag in Pixel Map syncs Show Look while linked) continues to work per-canvas.
+
+### 6.3 Data Flow / Power
+
+- Same rendering as Show Look (per-canvas, layers at show position, canvas rect = show raster).
+- Front/Back perspective toggle per canvas (sidebar reflects active canvas's setting).
+- Wiring (port labels, arrows, circuit lines) renders per layer based on each layer's processor type.
+- **Sidebar totals** show **active canvas** values (e.g. "Total Amps: 862 A").
+- A new **"Project Total"** section at the bottom of the sidebar shows aggregated totals across all visible canvases (sum of amps, sum of ports, etc.).
+- Capacity / power error badges render on individual layers regardless of which canvas is active (existing behavior, just extended).
+
+### 6.4 Toolbar
+
+- `Raster: [W] x [H]` field edits **active canvas's** raster (Pixel Map raster on Pixel Map / Cabinet ID tabs; Show Look raster on Show Look / Data / Power tabs — same per-view behavior as today, just per-canvas).
+- Project name field unchanged.
+- Fit / 1:1 / zoom buttons operate on the workspace as a whole.
+
+---
+
+## 7. Save / Load
+
+### 7.1 Save flow
+
+- Same save path as today (JSON file on disk).
+- On save, the project structure is written in v0.8 format. `format_version: "0.8"` is always written.
+- Per-user `Recent Files` list updated (existing behavior).
+
+### 7.2 Load flow
+
+- Read JSON.
+- If `format_version === "0.8"`: load directly.
+- If `format_version` missing or older: run migrator (Section 4.4), show one-time toast.
+- If `format_version` newer than supported (e.g. user opens a v0.9 file in v0.8 build): show "Project format is newer than this version" dialog, do not load.
+
+### 7.3 Auto-save / undo
+
+- Cross-canvas layer drag is undoable (restores previous canvas + previous offsets).
+- Canvas creation / deletion / rename / reorder / move / color change are all undoable.
+- Undo history is a single stack at the project level — does not split per canvas.
+
+---
+
+## 8. Export
+
+### 8.1 Export dialog
+
+Expanded with a **canvas picker** above the existing view-mode picker:
+
+```
+EXPORT
+──────────────────────
+Canvases:
+  ☑ Canvas 1     ← all visible canvases checked by default
+  ☑ Canvas 2
+  ☐ Canvas 3 (hidden)
+
+Views:
+  ☑ Pixel Map
+  ☐ Cabinet ID
+  ☑ Show Look
+  ☑ Data
+  ☑ Power
+
+Format:  ◉ PNG   ○ PDF   ○ PSD
+
+Filename pattern:  {project} - {canvas} - {view}.png
+                    └ token preview ─┘
+──────────────────────
+[Cancel]  [Export]
+```
+
+- Filename pattern uses tokens: `{project}`, `{canvas}`, `{view}`. Default per format:
+  - PNG: `{project} - {canvas} - {view}.png`
+  - PDF: `{project} - {view}.pdf` (multi-page; one page per canvas per view)
+  - PSD: `{project} - {canvas} - {view}.psd`
+- **PDF is multi-page**: page order = canvas order × view order. Each page has the canvas + view in its header.
+- **PSD per canvas + view**: one file per (canvas, view) combination.
+- Hidden canvases are unchecked by default but can be re-checked manually.
+
+### 8.2 Resolume Arena XML export
+
+- Already handles per-screen output. Updated to iterate all visible canvases' layers. (Each canvas could be a separate Resolume "screen".)
+
+---
+
+## 9. Keyboard / mouse
+
+| Action | Keys |
+|--------|------|
+| Move layer to other canvas | drag layer onto canvas (workspace) or canvas group (sidebar) |
+| Duplicate layer to other canvas | Cmd/Alt + drag layer onto canvas |
+| Reorder canvas | drag canvas header in sidebar, OR drag canvas in workspace to change `workspace_x/y` |
+| Activate canvas | click anywhere in canvas (workspace), or click canvas header (sidebar) |
+| Hide canvas | click 👁 in sidebar canvas header |
+| Add new canvas | `+ Add Canvas` button in sidebar bottom |
+| Rename canvas | double-click canvas name in sidebar header (or canvas action menu → Rename) |
+
+---
+
+## 10. Implementation slices (vertical tracers)
+
+Each slice is a self-contained PR (target ~120-200 LOC, tests included). Order matters: each slice depends on the previous. All PRs target `feature/v0.8` (not `main`).
+
+| # | Slice | What ships | Tests |
+|---|-------|-----------|-------|
+| 1 | **Data model + migrator** | Project file gains `canvases` + `format_version`; layers gain `canvas_id`; auto-migrator runs on load. UI unchanged (still single canvas). | Unit: migrator on real v0.7 fixtures; round-trip save/load preserves data. |
+| 2 | **Canvas list UI in sidebar** | Sidebar Screens panel groups layers under canvas headers. + Add Canvas button. Rename, Delete, Duplicate, Reorder. Color cycling. | Unit: canvas CRUD; UI snapshot test of sidebar layout. |
+| 3 | **Canvas rect rendering in workspace** | Each canvas's rect drawn at its `workspace_x/y` position (initially auto-laid horizontally). Color-coded outlines. Empty canvases not drawn. | Visual regression: 1-canvas, 2-canvas, 3-canvas projects render correctly. |
+| 4 | **Active canvas selection** | Click on canvas (workspace or sidebar) makes it active. Sidebar properties + toolbar raster reflect active. + Add Screen targets active. | Unit: active-canvas state transitions; integration test for sidebar update. |
+| 5 | **Drag canvas in workspace** | Drag a canvas's outline to reposition. Layers stay glued. Overlap warning toast. | Unit: drag math; integration test for layer follow-along. |
+| 6 | **Per-canvas raster (Pixel Map / Show Look)** | Each canvas has its own raster sizes; toolbar edits active canvas's raster. Layers render relative to their canvas. | Unit: layer position computation; integration: change one canvas raster, others unaffected. |
+| 7 | **Drag layer between canvases** | Drag a layer from one canvas to another (workspace + sidebar). offset/showOffset reset to 0,0. Cmd/Alt+drag = duplicate. | Unit: drop logic; integration: undo restores. |
+| 8 | **Per-canvas processor / perspective settings** | Front/Back perspective per canvas. Voltage/amperage/etc per canvas defaults applied on new layer. | Integration: switching active canvas updates sidebar. |
+| 9 | **Hidden canvases** | 👁 toggle hides canvas + all layers visually. Hidden canvases excluded from totals. | Unit: visibility filter; integration: render skips hidden. |
+| 10 | **Project totals in Data / Power sidebar** | Active-canvas totals + Project total section. | Unit: aggregation math. |
+| 11 | **Export multi-canvas** | Export dialog gains canvas picker. PDF multi-page. Per-canvas PNG/PSD. | Integration: export each format with 2 canvases, verify file structure. |
+| 12 | **Migration UX + cleanup** | One-time toast on first v0.7→v0.8 migration. v0.7 file format detection on save. README + VERSION updates. | Manual: load v0.7 fixture, verify toast + save, reload, verify no second toast. |
+| 13 | **Polish + ship v0.8.0** | Icon set, animations on canvas reorder, edge cases (last-canvas-can't-be-deleted, drag from one canvas onto itself, etc). Final QA pass. Ship release. | Full regression. |
+
+After Slice 13, **multi-canvas is rock solid** and we move to the expanded processor hardware detail feature (XD boxes, CVT counts, etc.).
+
+### 10.1 Per-slice version stance
+
+- Slices 1-12 ship as PRs into `feature/v0.8` (no version bump on each — feature branch is WIP).
+- Slice 13 (or whichever final slice ships v0.8.0) is the version bump + tag + release.
+
+---
+
+## 11. Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| v0.7 project loses data during migration | Auto-migrator round-trip-tested against multiple real v0.7 fixtures (EDC, Griztronics, etc.) before slice 2. |
+| Workspace performance with 5+ canvases | Each canvas's render path is unchanged; only the per-layer translate shifts to include `workspace_x/y`. Should not regress. Benchmark with 10-canvas synthetic project in slice 3. |
+| Accidental cross-canvas drag during normal work | Drop detection requires a clear hover-over-other-canvas state with visual indicator. Drag distance threshold preserved. |
+| Existing per-view raster size (v0.7.6 feature) confuses users in multi-canvas | Each canvas keeps its own per-view raster size pair (Pixel Map raster + Show Look raster). No new concepts introduced. |
+| Color collisions confusing | After 8 canvases palette wraps. User can manually change. Documented. |
+| Load failure on a v0.8 file in v0.7 build | App refuses to load with clean dialog. CI test added (Slice 1). |
+| Undo across canvas operations gets out of sync | All canvas-level operations go through the same undo stack as layer operations. Tested in slice 4 onward. |
+
+---
+
+## 12. Open questions
+
+(none — all design decisions locked through Round 3. This section reserved for issues found during implementation.)
+
+---
+
+## 13. Out of scope (deferred)
+
+- **Sharing a layer across canvases** (one layer in two canvases simultaneously). Likely v0.9 if real demand emerges.
+- **Per-canvas Show Look toggle to "combine all canvases into one virtual stage"** — current model lets users do this manually by overlapping canvases or dragging layers cross-canvas.
+- **Export of a single layer in isolation** — user mentioned as a "not bad idea later." Out for v0.8.
+- **SCR (NovaStar sending card) export** — currently broken. Separate fix, not part of v0.8.
+- **Per-canvas keyboard shortcut** (e.g. Cmd+1 jumps to Canvas 1) — easy to add later if users want it.
+
+---
+
+## 14. Sign-off
+
+- Drafted: 2026-05-02 by kman1898
+- Approved: _pending review_

--- a/src/CODEX_HANDOFF.md
+++ b/src/CODEX_HANDOFF.md
@@ -1,8 +1,8 @@
-# LED Raster Designer — AI Development Handoff
+# LED Raster Designer, AI Development Handoff
 
 > **"LED Raster Designer" is a PLACEHOLDER NAME.** Final product name TBD.
 
-> **Last updated in this file:** v0.5.6.15 — February 10, 2026 (historical snapshot)
+> **Last updated in this file:** v0.5.6.15, February 10, 2026 (historical snapshot)
 >
 > **Current source of truth:**
 > - `README.md` (current behavior/features)
@@ -184,8 +184,8 @@
 
 This application is developed collaboratively between a human developer (Matt) and **two AI coding assistants working in tandem:**
 
-- **AI Assistant** — Primary development partner since project inception. All architecture decisions, core rendering, UI layout, export pipeline, and feature implementation to date have been done through AI-assisted conversations.
-- **Codex (OpenAI)** — Joining development as of v0.5.5.2 for expanded feature work, refactoring, and parallel development tasks.
+- **AI Assistant**, Primary development partner since project inception. All architecture decisions, core rendering, UI layout, export pipeline, and feature implementation to date have been done through AI-assisted conversations.
+- **Codex (OpenAI)**, Joining development as of v0.5.5.2 for expanded feature work, refactoring, and parallel development tasks.
 
 ### Workflow Rules
 
@@ -194,7 +194,7 @@ This application is developed collaboratively between a human developer (Matt) a
 3. **VERSION.txt tracks granular changes.** Check it for detailed per-version changelogs.
 4. **TODO.txt tracks the roadmap.** Check it before starting new features to avoid conflicts.
 5. **Don't assume the other AI's work is wrong.** If something looks unusual, it was probably an intentional design decision. Ask Matt before refactoring existing patterns.
-6. **Version numbering:** Update in TWO places in `index.html` — the `<title>` tag and the `<h1>` header span.
+6. **Version numbering:** Update in TWO places in `index.html`, the `<title>` tag and the `<h1>` header span.
 7. **Client-side properties** are a deliberate pattern, not a bug. Some layer properties live only in localStorage (see details below).
 8. **Archive zips are mandatory for every version.** When the version changes, create `Archive/led_raster_designer_vX.Y.Z.zip` in the parent folder.
 
@@ -238,17 +238,17 @@ python3 app.py
 
 ```
 led_raster_designer/
-├── app.py                      # Flask backend — API routes, project state, export endpoints
+├── app.py                      # Flask backend, API routes, project state, export endpoints
 ├── requirements.txt            # Python dependencies
 ├── start.sh                    # Shell startup script
 ├── templates/
-│   └── index.html              # Single-page app — ALL HTML/UI lives here (~700 lines)
+│   └── index.html              # Single-page app, ALL HTML/UI lives here (~700 lines)
 ├── static/
 │   ├── css/style.css           # All styling
 │   └── js/
-│       ├── app.js              # LEDRasterApp class — UI logic, state, port capacity (~3000 lines)
-│       └── canvas.js           # CanvasRenderer class — all drawing, zoom/pan (~1870 lines)
-├── CODEX_HANDOFF.md            # THIS FILE — primary reference for AI developers
+│       ├── app.js              # LEDRasterApp class, UI logic, state, port capacity (~3000 lines)
+│       └── canvas.js           # CanvasRenderer class, all drawing, zoom/pan (~1870 lines)
+├── CODEX_HANDOFF.md            # THIS FILE, primary reference for AI developers
 ├── DEVELOPER_HANDOFF.md        # Earlier handoff doc (human-focused)
 ├── TODO.txt                    # Feature roadmap with priorities
 ├── VERSION.txt                 # Detailed changelog (every version since v0.3.9.4)
@@ -299,7 +299,7 @@ There are **two types** of layer properties:
    - Tab-specific screen name sizes and positions
    - See `saveClientSideProperties()` and the load block in `handleProjectData()` in app.js
 
-This split is intentional — these are display/calculation settings that don't need server persistence for now. Eventually they should move server-side.
+This split is intentional, these are display/calculation settings that don't need server persistence for now. Eventually they should move server-side.
 
 ### Rendering Pipeline
 
@@ -336,17 +336,17 @@ render() in canvas.js:
 - Fit-to-view and 1:1 zoom buttons
 
 ### View Modes (4 tabs)
-1. **Pixel Map** — Checkerboard pattern, optional circle-with-X test pattern, corner offset labels (TL/TR/BL/BR showing pixel coordinates)
-2. **Cabinet ID** — Panel numbering with 3 schemes (A1/B2, 1-1/2-3, sequential 1/2/3), configurable position (center/corner) and color
-3. **Data Flow** — Serpentine data path visualization with 8 flow patterns (4 corners × horizontal/vertical), port capacity splitting, editable P/R port labels (use # for port number), custom path mode (click/arrow keys or apply patterns to selected panels), configurable colors and line widths
-4. **Power** — Placeholder (not yet implemented)
+1. **Pixel Map**, Checkerboard pattern, optional circle-with-X test pattern, corner offset labels (TL/TR/BL/BR showing pixel coordinates)
+2. **Cabinet ID**, Panel numbering with 3 schemes (A1/B2, 1-1/2-3, sequential 1/2/3), configurable position (center/corner) and color
+3. **Data Flow**, Serpentine data path visualization with 8 flow patterns (4 corners × horizontal/vertical), port capacity splitting, editable P/R port labels (use # for port number), custom path mode (click/arrow keys or apply patterns to selected panels), configurable colors and line widths
+4. **Power**, Placeholder (not yet implemented)
 
 ### Port Capacity System (v0.5.5.0+)
 Multi-processor support with manufacturer lookup tables:
 
 | Processor | Port Speed | Bit Depths | Rectangle Constraint |
 |---|---|---|---|
-| NovaStar Armor (MSD/MRV) | 1G | 8/10/12 (max 120 Hz) | YES — must fill complete rows/columns |
+| NovaStar Armor (MSD/MRV) | 1G | 8/10/12 (max 120 Hz) | YES, must fill complete rows/columns |
 | NovaStar COEX A10s/A8s | 1G | 8/10/12 | No |
 | NovaStar COEX CX40 | 5G | 8/10/12 | No |
 | Brompton Tessera | 1G | 8/10/12 | No |
@@ -357,8 +357,8 @@ Multi-processor support with manufacturer lookup tables:
 All capacity values are from official manufacturer documentation. Lookup tables in `portCapacityTables` in app.js. Frame rates that fall between table entries are linearly interpolated.
 
 ### Port Mapping Modes (v0.5.5.1+)
-- **Organized** — Ports fill complete rows (horizontal flow) or columns (vertical flow). No mid-row/column splits.
-- **Max Capacity** — Ports fill to maximum pixel count, can split anywhere in the flow.
+- **Organized**, Ports fill complete rows (horizontal flow) or columns (vertical flow). No mid-row/column splits.
+- **Max Capacity**, Ports fill to maximum pixel count, can split anywhere in the flow.
 - NovaStar 1G is always locked to organized/rectangle mode (buttons disabled).
 
 ### Hidden Panel Rules
@@ -377,16 +377,16 @@ All capacity values are from official manufacturer documentation. Lookup tables 
 - Corner offset indicators showing pixel coordinates
 
 ### Export
-- **PNG** — Single image or ZIP with all 4 view modes
-- **PDF** — Multi-page document with all views via reportlab
-- **PSD** — Layered Photoshop file, each screen as a separate layer at correct position/size (no background layer)
+- **PNG**, Single image or ZIP with all 4 view modes
+- **PDF**, Multi-page document with all views via reportlab
+- **PSD**, Layered Photoshop file, each screen as a separate layer at correct position/size (no background layer)
 - All exports use an offscreen canvas at exact raster dimensions for pixel accuracy
 
 ---
 
 ## Key Functions Reference
 
-### app.js — LEDRasterApp
+### app.js, LEDRasterApp
 
 | Function | Purpose |
 |---|---|
@@ -399,11 +399,11 @@ All capacity values are from official manufacturer documentation. Lookup tables 
 | `duplicateLayer(layer)` | Full deep copy including hidden panels |
 | `saveState(action)` / `undo()` / `redo()` | State stack management |
 
-### canvas.js — CanvasRenderer
+### canvas.js, CanvasRenderer
 
 | Function | Purpose |
 |---|---|
-| `render()` | Main render loop — clears, transforms, draws everything |
+| `render()` | Main render loop, clears, transforms, draws everything |
 | `renderPanel(panel, layer)` | Dispatches to view-mode-specific renderer |
 | `renderPixelMap(panel, layer)` | Checkerboard fill + borders (hidden = ghost outline) |
 | `renderCabinetID(panel, layer)` | Same fill + cabinet numbers rendered separately |
@@ -418,15 +418,15 @@ All capacity values are from official manufacturer documentation. Lookup tables 
 
 ## Known Issues & Gotchas
 
-1. **PSD export at native resolution** — The export is pixel-accurate at 1:1. Zooming in Photoshop will look blocky because that's actual LED pixels. This is correct behavior.
+1. **PSD export at native resolution**, The export is pixel-accurate at 1:1. Zooming in Photoshop will look blocky because that's actual LED pixels. This is correct behavior.
 
-2. **Client-side property split** — If localStorage is cleared, Data Flow settings (processor, flow pattern, colors) reset to defaults. Layer geometry survives because it's server-side.
+2. **Client-side property split**, If localStorage is cleared, Data Flow settings (processor, flow pattern, colors) reset to defaults. Layer geometry survives because it's server-side.
 
-3. **Raster boundary clipping** — Everything outside the raster is clipped. Offsets, labels, and panel fills all respect this boundary. The red dashed boundary line scales inversely with zoom to stay visible.
+3. **Raster boundary clipping**, Everything outside the raster is clipped. Offsets, labels, and panel fills all respect this boundary. The red dashed boundary line scales inversely with zoom to stay visible.
 
-4. **Data flow arrows still use organized layout internally** — The arrow rendering in `renderDataFlowArrows` splits by rows/columns. Max Capacity mode works for port assignment but the visual arrows use a simplified approach (slicing the ordered panel array by count). Complex non-rectangular port boundaries may not render perfectly in Max Capacity mode.
+4. **Data flow arrows still use organized layout internally**, The arrow rendering in `renderDataFlowArrows` splits by rows/columns. Max Capacity mode works for port assignment but the visual arrows use a simplified approach (slicing the ordered panel array by count). Complex non-rectangular port boundaries may not render perfectly in Max Capacity mode.
 
-5. **Version in two places** — Always update both `<title>` and `<h1>` in index.html.
+5. **Version in two places**, Always update both `<title>` and `<h1>` in index.html.
 
 ---
 
@@ -435,7 +435,7 @@ All capacity values are from official manufacturer documentation. Lookup tables 
 See `TODO.txt` for the full prioritized list. Key upcoming areas:
 
 **High Priority:**
-- Transform Mode (resize/rotate layers) — design doc in TRANSFORM_FEATURE_DESIGN.md
+- Transform Mode (resize/rotate layers), design doc in TRANSFORM_FEATURE_DESIGN.md
 - Power tab implementation
 - Top menu bar (File/Edit/View/Settings/Help)
 - Right-click context menus
@@ -458,17 +458,17 @@ See `TODO.txt` for the full prioritized list. Key upcoming areas:
 
 ## Development Guidelines
 
-1. **Test in the Data Flow tab** — This is the most complex view with capacity calculations, arrow rendering, and port splitting. Changes to layer/panel logic should be verified here.
+1. **Test in the Data Flow tab**, This is the most complex view with capacity calculations, arrow rendering, and port splitting. Changes to layer/panel logic should be verified here.
 
-2. **Hidden panels are tricky** — Different processors treat them differently. NovaStar 1G counts them, everything else skips them. Always check both paths.
+2. **Hidden panels are tricky**, Different processors treat them differently. NovaStar 1G counts them, everything else skips them. Always check both paths.
 
-3. **Export mode** — `this.exportMode` flag in canvas.js suppresses the raster boundary, grid, and selection highlight for clean output. Make sure new visual elements check this flag.
+3. **Export mode**, `this.exportMode` flag in canvas.js suppresses the raster boundary, grid, and selection highlight for clean output. Make sure new visual elements check this flag.
 
-4. **Zoom-independent elements** — Text, labels, and UI overlays should scale with `1/this.zoom` so they maintain constant screen size. World-space elements (panels, borders) scale naturally with zoom.
+4. **Zoom-independent elements**, Text, labels, and UI overlays should scale with `1/this.zoom` so they maintain constant screen size. World-space elements (panels, borders) scale naturally with zoom.
 
-5. **Flask runs on 0.0.0.0:8050** — Accessible from any network interface. The console shows both localhost and LAN URLs on startup.
+5. **Flask runs on 0.0.0.0:8050**, Accessible from any network interface. The console shows both localhost and LAN URLs on startup.
 
-6. **No build step** — Everything is vanilla JS/CSS/HTML served by Flask. Just edit and refresh. Python changes auto-reload in debug mode.
+6. **No build step**, Everything is vanilla JS/CSS/HTML served by Flask. Just edit and refresh. Python changes auto-reload in debug mode.
 
 ---
 

--- a/src/TODO.txt
+++ b/src/TODO.txt
@@ -55,7 +55,7 @@ BACKLOG / FUTURE
 🟢 Multi-Project Tabs
 - Allow multiple projects open simultaneously in a tab system.
 - Implementation considerations:
-  - Server currently holds a single `current_project` in memory — needs to support a project registry (dict of project_id → project_data).
+  - Server currently holds a single `current_project` in memory, needs to support a project registry (dict of project_id → project_data).
   - Each tab in the UI would have its own project_id, independent undo/redo history, and layer state.
   - Tab bar at the top of the app with project name on each tab, close button, and "+" to open/create.
   - WebSocket events need to be scoped per project_id so updates don't cross tabs.

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,72 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.0 - May 4, 2026
+----------------------------
+MULTI-CANVAS RELEASE. Projects can now contain multiple independent
+canvases (think Resolume Screens). Each canvas has its own raster size,
+its own workspace position, its own perspective, and exports as its own
+file (or its own page in PDF / its own Screen in Resolume XML).
+
+Highlights:
+- Multi-canvas project model (format_version: "0.8"). Auto-migrator
+  upgrades v0.7 projects on load and emits a one-time toast asking the
+  user to save in the new format. v0.7 builds opening a v0.8 file get a
+  clean "format newer than supported" error.
+- Canvas list in the right sidebar with per-canvas + Add, color swatch,
+  rename, delete, duplicate, drag-reorder, and visibility toggle.
+- Per-canvas raster (Pixel Map and Show Look). Toolbar Raster: WxH
+  reads/writes the active canvas. Each canvas's layers render relative
+  to its own origin.
+- Per-canvas perspective (Front/Back) for Data Flow + Power. Mirror axis
+  is the workspace bounding box so multi-canvas Back view stays on
+  screen and Fit-to-View works correctly.
+- Drag layers between canvases (workspace + sidebar). Snap to (0,0) on
+  drop. Cmd/Alt+drag to duplicate.
+- Drag canvases by their dashed outline. Magnetic snap to neighbor
+  edges (abut + align). Default gap between auto-placed new canvases is
+  zero (was 50 px).
+- Hidden canvases excluded from sidebar Totals, capacity / power tallies,
+  and exports. Sidebar layer rows dim with the eye toggle remaining
+  bright for re-enable.
+- Per-canvas + project Totals panels in the Data Flow and Power tabs.
+- Text-layer dynamic info gains a Scope dropdown: "This Canvas",
+  "All Canvases", or "Both" for the parent canvas's totals + project
+  totals.
+- Multi-canvas export: PNG (one file per canvas x view), PSD (per
+  canvas+view, layer list filtered to that canvas), PDF (multi-page,
+  one page per canvas x view, headed with the canvas name), and
+  Resolume XML (one <Screen> per canvas, named after the canvas, with
+  its own OutputDeviceVirtual sized to that canvas's raster).
+- New screens added to a canvas inherit hardware settings (processor,
+  voltage, amperage, panel size, panel watts) from the most recently
+  added screen in that same canvas, so each canvas behaves like its own
+  preset bucket.
+- "+ Add Canvas" honors a Default Canvas Size preference.
+
+Bug fixes the multi-canvas work uncovered:
+- Undo now reverts exactly one action. Previously every v0.8 mutation
+  (drag, canvas CRUD, cross-canvas move) called saveState BEFORE the
+  mutation, so one Cmd+Z silently reverted two actions. Every v0.8
+  saveState now runs AFTER the mutation, restoring v0.7 behaviour.
+- 0-byte JSON saves on cloud-synced folders fixed. Skip Chrome's
+  showSaveFilePicker on localhost (Chrome rejects createWritable on
+  Nextcloud / iCloud / Dropbox paths) and route through the native
+  server-side save dialog instead. Same fix applied to multi-file
+  exports.
+- "100%" zoom now means 1 raster pixel = 1 device pixel. Previously
+  100% on Retina rendered at 2x the actual pixel pitch.
+- Settings sidebar now refreshes after a cross-canvas drag's snap so
+  X/Y inputs match the new (0,0) without a deselect/reselect.
+- Custom port / power circuit assignment now rejects panels already
+  wired to a different port or circuit (toast names the conflict).
+- Text layer text now clips to its own box, no more spillover into
+  neighboring canvases.
+- Click-on-overlay (text/image floating on top of a screen) now selects
+  the overlay instead of starting a panel-select on the hidden screen
+  underneath.
+- Em dash characters removed everywhere (UI text, comments, docs).
+
 v0.7.7.4 - May 1, 2026
 ----------------------------
 - FIX: Show Look / Data / Power renders dropped pieces of layers whose

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -12,7 +12,7 @@ v0.7.7.4 - May 1, 2026
   *screen* space, so the right side of show-shifted layers got cut off
   whenever the raster was narrower than the layer's processor right
   edge. Symptom: shrink the show raster below a layer's processor
-  width, then grow it back — half the layer's panels and all its
+  width, then grow it back, half the layer's panels and all its
   labels stayed missing in Show Look / Data / Power even though the
   layer was visually inside the new raster bounds.
   Root cause: each renderer had its own
@@ -64,11 +64,11 @@ v0.7.7.2 - May 1, 2026
   if a newer catalog exists, the source tag turns into a blue
   "📦 Update available · click to apply" pill that swaps in the new
   data with a single click. Refreshed catalog persists in localStorage
-  so it survives reloads — per browser, not per project.
+  so it survives reloads, per browser, not per project.
 - FIX: Panel correction / new-panel submissions were silently dropping.
   The "Submit a correction or add a panel" link opens a pre-filled
   GitHub new-issue page, but users were closing the tab without
-  clicking the green "Submit new issue" button on GitHub itself —
+  clicking the green "Submit new issue" button on GitHub itself,
   so the submission never reached the repo. Added an explicit confirm
   dialog before opening the tab and an inline note under the link
   spelling out the extra step. Also created the missing
@@ -81,7 +81,7 @@ v0.7.7.1 - May 1, 2026
   any row in the Panel Catalog to add it to the left column alongside
   your saved presets. Hearted panels stay there forever (per user, not
   per project) so you don't have to scroll the catalog every time you
-  add the same panel. Drag any row in the left column to reorder —
+  add the same panel. Drag any row in the left column to reorder,
   favorites and presets mix freely. Click the filled heart to remove a
   favorite. Default is always pinned at the top.
 
@@ -117,7 +117,7 @@ v0.7.6.3 - May 1, 2026
   change to the Show Look offset while the two are still equal
   (linked). Without this, moving a layer in Pixel Map left Show Look /
   Data / Power rendering at the old position. Once you set a different
-  Show Look offset, the two stay independent — Pixel Map edits no
+  Show Look offset, the two stay independent, Pixel Map edits no
   longer touch Show Look.
 - FIX: Screen name labels and other per-layer labels were rendered
   off-center in Show Look / Data / Power because the per-layer ctx
@@ -128,7 +128,7 @@ v0.7.6.3 - May 1, 2026
   per-layer translate (selection bounding box, hit-test, magnetic
   snap, screen-name drag, zoom-to-fit).
 - FIX: "Reset to Pixel Map Position" appeared to put screens in the
-  wrong spot — same root cause as the label bug above. Now resets
+  wrong spot, same root cause as the label bug above. Now resets
   cleanly with screens visually matching their pixel-map positions.
 
 v0.7.6.2 - April 30, 2026
@@ -156,7 +156,7 @@ v0.7.6.0 - April 30, 2026
   you rearrange screen layers to match the real-world stage layout
   without affecting the processor's expected layout.
     - Pixel Map and Cabinet ID continue to use each layer's processor
-      position (offset_x / offset_y) — what the processor sends out.
+      position (offset_x / offset_y), what the processor sends out.
     - Show Look has its own per-layer position (showOffsetX / Y), which
       also drives the Data and Power views so the wiring/power maps
       match how the show is actually built on stage.
@@ -185,7 +185,7 @@ v0.7.5.3 - April 30, 2026
   plain click, or right-click in Pixel Map view, so there was no way to
   bulk-restore them via the sidebar buttons. Hidden panels can now be
   selected for bulk Restore. (Alt+Shift+click for half-tile still skips
-  hidden panels — half-tiling a hidden cell would have no visible effect.)
+  hidden panels, half-tiling a hidden cell would have no visible effect.)
 
 v0.7.5.2 - April 30, 2026
 ----------------------------
@@ -225,10 +225,10 @@ v0.7.5.0 - April 30, 2026
       badge in the canvas corner.
     - Right-click a panel (or selection) → context menu with the same
       actions.
-    - Alt + click toggles blank on a single panel (existing) — when a
+    - Alt + click toggles blank on a single panel (existing), when a
       multi-selection is active, applies to the entire selection.
     - Alt + Shift + click toggles half-tile (auto direction) on a single
-      panel — when a multi-selection is active, applies to the entire
+      panel, when a multi-selection is active, applies to the entire
       selection. Auto direction picks 'height' for top/bottom-edge panels
       and 'width' for left/right-edge panels.
     - Plain click on a panel resets selection to that single panel;
@@ -247,7 +247,7 @@ v0.7.5.0 - April 30, 2026
   pixel bounding rect (panel x/y/width/height) instead of the cabinet-
   cell shortcut. Half-tile cabinets correctly contribute half their
   full-cell pixel footprint to the port reservation rectangle.
-- FIX: Pre-existing bug — hidden ("blank") panels in the middle of a
+- FIX: Pre-existing bug, hidden ("blank") panels in the middle of a
   wall would scatter to other positions when columns or rows were
   resized. Panel state was preserved by sequential id, so the same id
   pointed to a different (row, col) cell after a grid resize. State
@@ -257,7 +257,7 @@ v0.7.5.0 - April 30, 2026
 v0.7.4.35 - April 29, 2026
 ----------------------------
 - FIX: Ports Required count and the port-rename editor showed too few
-  ports when using custom data flow paths — e.g. 8 custom paths drawn
+  ports when using custom data flow paths, e.g. 8 custom paths drawn
   but the count stayed at the auto-pattern's 5. The client-computed
   _portsRequired and _autoPortsRequired fields were being clobbered by
   the server's stale echo on every PUT round-trip (server's whitelist
@@ -283,7 +283,7 @@ v0.7.4.33 - April 29, 2026
   slash, backslash, colon, or other characters the OS rejects in
   filenames. Common case: project named "Foo/Bar" produced filenames like
   "Foo/Bar_pixel-map.png", which the File System Access API refuses.
-  Filenames are now sanitized — illegal characters are replaced with "_"
+  Filenames are now sanitized, illegal characters are replaced with "_"
   before being passed to the picker / directory handle. Single-file
   exports (PDF, JSON save, etc.) get the same treatment.
 
@@ -295,7 +295,7 @@ v0.7.4.32 - April 29, 2026
   other starting number ("S2-#", "MULTI3-#", etc.) fell back to a plain
   "#" → circuit-number substitution, so circuits 7+ rolled past 6 instead
   of starting a new soca. The auto-increment now works for any template
-  shaped <prefix><number><sep># — "S2-#" produces S2-1..S2-6, S3-1..S3-6;
+  shaped <prefix><number><sep>#, "S2-#" produces S2-1..S2-6, S3-1..S3-6;
   "MULTI3-#" produces MULTI3-1..MULTI3-6, MULTI4-1..MULTI4-6.
 
 v0.7.4.31 - April 27, 2026
@@ -324,11 +324,11 @@ v0.7.4.29 - April 28, 2026
   and "Info Label Size" to null whenever the selected layers had mixed
   values for those fields. The shared input shows blank for mixed values,
   parseInt('') returns NaN, and the NaN guard slipped past the null check
-  — so every selected layer ended up with labelsFontSize=null. Switched
+ , so every selected layer ended up with labelsFontSize=null. Switched
   both inputs to use the same readNumber() helper the other numeric
   fields in this code path already use, which correctly returns null for
   blank/NaN reads and skips the apply.
-- INTERNAL: Bumped GitHub Actions to Node.js 24-compatible majors —
+- INTERNAL: Bumped GitHub Actions to Node.js 24-compatible majors,
   upload-artifact v6→v7, download-artifact v6→v8, action-gh-release v2→v3
   (resolves the deprecation warning surfaced on PR #34).
 
@@ -340,11 +340,11 @@ v0.7.4.28 - April 25, 2026
   to attach. Issues land at github.com/kman1898/LED-Raster-Designer/issues
   with the spec-correction label, including the panel reference, the
   current catalog values, the user's notes, and the app version.
-- DATA: Leyard verified — CLI-1.9, CLI-2.6, CLO-3.9, CLM-6.9, CLA-1.9
+- DATA: Leyard verified, CLI-1.9, CLI-2.6, CLO-3.9, CLM-6.9, CLA-1.9
   all match Planar/eanixter PDFs. TVF1.5 watts corrected from 180.4W
   → 140W (per official Planar TVF data sheet). Duplicate CLA1.5 +
   CLA1.9 entries deduped (kept hyphenated form to match spec sheets).
-- DATA: Barco verified — X1.9, XT1.5 (renamed from "1.5XT"), X4, NX4
+- DATA: Barco verified, X1.9, XT1.5 (renamed from "1.5XT"), X4, NX4
   cross-checked against barco.com PDFs. X4 watts corrected from 60.5W
   → 188.9W (factor-of-3 error from the original extraction). NX4
   watts corrected from 300.3W → 244W.
@@ -355,7 +355,7 @@ v0.7.4.27 - April 25, 2026
 - FIX: ⭐ verified marker now correctly recognizes ROE panels sourced
   from roevisual.com (brochures + PDFs) and authoritative dealer
   datasheets (ledwallcentral, xled.pro). Verified panel count jumped
-  from ~28 to 75 — primarily 50 ROE models (Carbon, Topaz, Vanish,
+  from ~28 to 75, primarily 50 ROE models (Carbon, Topaz, Vanish,
   Black Pearl/Onyx, Ruby, Graphite, etc.) plus existing Absen / INFiLED
   / UniLumin / Gloshine entries. Entries flagged as "estimated" or
   "derived" are still excluded.
@@ -363,7 +363,7 @@ v0.7.4.27 - April 25, 2026
 v0.7.4.26 - April 25, 2026
 ----------------------------
 - NEW: Add Screen modal redesigned. Picking a panel from the built-in
-  catalog now happens in the same flow as picking a saved preset — two
+  catalog now happens in the same flow as picking a saved preset, two
   columns side by side. Search the catalog by name or manufacturer; pick
   one panel, click Add Screen, and the cabinet/pixel/weight/power values
   fill in automatically (grid size still comes from Preferences).
@@ -371,7 +371,7 @@ v0.7.4.26 - April 25, 2026
   the manufacturer's own published spec sheet/PDF show a star. Currently
   marks ~30 panels across Absen (JP, A3 Pro, A6T, VN), INFiLED (ART,
   AMT, DB), UniLumin (UGM), and Gloshine. Other catalog entries come from
-  FidoLED's database — accurate but occasionally older than current specs.
+  FidoLED's database, accurate but occasionally older than current specs.
 - DATA: Power values for all 2,536 panels re-validated. The original
   extraction missed a 110V voltage selection in FidoLED for a chunk of
   the catalog, leaving panels with corrupt watts (e.g. JP8 Pro showed
@@ -380,7 +380,7 @@ v0.7.4.26 - April 25, 2026
   manually-applied PDF values for the JP series.
 - DATA: 12 phantom panels removed (Mambo-* entries that don't actually
   exist in FidoLED's menus).
-- INTERNAL: clipboard_extract.sh hardened — Escape-key recovery to
+- INTERNAL: clipboard_extract.sh hardened, Escape-key recovery to
   prevent FidoLED popup wedge cascades, case-insensitive title verify,
   abort-on-cascade detection, skip-on-missing-power so we never overwrite
   good data with null. New post_batch.py + prep_no_source_batch.sh make
@@ -392,7 +392,7 @@ v0.7.4.25 - April 24, 2026
 - NEW: Built-in Panel Catalog now covers 2,543 panels across 180
   manufacturers (up from ~1,400). Every panel in FidoLED's database is
   represented with width, height, pixel count, weight, and max power.
-- INTERNAL: Added tools/panel_extractor for maintaining the catalog —
+- INTERNAL: Added tools/panel_extractor for maintaining the catalog,
   a clipboard-based AppleScript pipeline that drives FidoLED's Calculate
   + Copy to Clipboard flow, parses the output, and merges into
   src/static/data/panel_catalog.json.
@@ -417,7 +417,7 @@ v0.7.4.23 - April 22, 2026
   the server's PUT /api/layer/<id> endpoint had an incomplete whitelist that
   silently dropped these fields, so presets would appear to work until any
   subsequent server re-fetch (delete layer, project load) reset them.
-- FIX: Preset sync — `addLayer` now pushes the preset-enriched layer to the
+- FIX: Preset sync, `addLayer` now pushes the preset-enriched layer to the
   server immediately after creation, so the server has complete state instead
   of only the structural fields sent via `/api/layer/add`.
 - FIX: Preset serialization always includes `portMappingMode` and
@@ -454,7 +454,7 @@ v0.7.4.20 - April 16, 2026
   Presets are stored server-side in <app>/presets/*.json and shared across
   clients. Clicking "+ Add Screen" opens a picker showing each preset's
   dimensions and watts/panel; "💾 Save as Preset" captures ~90 layer
-  properties (colors, data flow, power, labels, etc.) — excludes identity,
+  properties (colors, data flow, power, labels, etc.), excludes identity,
   position, panels array, and runtime caches. Duplicate names prompt to
   overwrite; each preset row has a delete button.
 
@@ -505,13 +505,13 @@ v0.7.4.12 - April 6, 2026
 ----------------------------
 - FEATURE: Text/Label layer (#24). New layer type for adding text annotations to the canvas.
   Movable, resizable, with font controls (bold/italic/underline, alignment, size, colors).
-  Per-tab text content — each tab (Pixel Map, Cabinet ID, Data, Power) has its own text.
+  Per-tab text content, each tab (Pixel Map, Cabinet ID, Data, Power) has its own text.
   Per-tab visibility checkboxes. Dynamic info toggles: Raster Size, Project Name, Date,
   Primary Ports, Backup Ports, Circuits, Single Phase, Three Phase.
 - FEATURE: Project Notes panel in right sidebar (#24). Collapsible, resizable textarea
   between Screens and Help. Notes saved with the project file. Starts collapsed.
 - FEATURE: Seamless server restart when changing network interface or port in the
-  launcher menu. No app restart required — server hot-restarts and clients auto-reconnect.
+  launcher menu. No app restart required, server hot-restarts and clients auto-reconnect.
 - FIX: Remote/LAN file save. When accessing the app from another computer over the
   network, Save/Export now downloads files to the client browser instead of opening
   a file dialog on the server machine. Local access still uses native file dialogs.
@@ -541,7 +541,7 @@ v0.7.4.8 - April 1, 2026
 
 v0.7.4.7 - April 1, 2026
 ----------------------------
-- REVERT: Removed #20 focus preservation fixes — issue not reproducible on macOS.
+- REVERT: Removed #20 focus preservation fixes, issue not reproducible on macOS.
   Will revisit when Windows reproduction steps are available.
 
 v0.7.4.6 - April 1, 2026
@@ -565,7 +565,7 @@ v0.7.4.4 - April 1, 2026
 
 v0.7.4.3 - April 1, 2026
 ----------------------------
-- FIX: Per-tab Screen Name checkboxes are now independent — unchecking on one tab no longer
+- FIX: Per-tab Screen Name checkboxes are now independent, unchecking on one tab no longer
   affects other tabs. updateLayerFromInputs() no longer overwrites per-tab label properties.
 - FIX: Second resetApplicationState() now clears lastSelectedLayerId and selectionAnchorLayerId
   to match the primary reset method, preventing stale selection state after file load.
@@ -584,7 +584,7 @@ v0.7.4.2 - March 24, 2026
 
 v0.7.4.1 - March 24, 2026
 ----------------------------
-- NEW: Alt+Click+Drag to bulk hide/show panels — paint mode based on first panel state
+- NEW: Alt+Click+Drag to bulk hide/show panels, paint mode based on first panel state
 - NEW: Bulk panel visibility API endpoint for efficient server sync
 - Added to Keyboard Shortcuts modal
 
@@ -605,7 +605,7 @@ v0.6.5.18 - March 21, 2026
 
 v0.6.5.17 - March 21, 2026
 ----------------------------
-- NEW: Resolume Arena Advanced Output XML export — directly generates slice configuration from screen layers
+- NEW: Resolume Arena Advanced Output XML export, directly generates slice configuration from screen layers
 - Each screen layer maps to a Resolume Slice with matching name, position, and pixel dimensions
 - Export available in Export modal under "Resolume XML (Advanced Output)" format
 - View checkboxes hidden when Resolume XML selected (geometry only, no rendered images)
@@ -614,14 +614,14 @@ v0.6.5.17 - March 21, 2026
 
 v0.6.5.14 - March 21, 2026
 ----------------------------
-- FIX: Layer name editing — double-click to edit name, single-click/drag for reorder
+- FIX: Layer name editing, double-click to edit name, single-click/drag for reorder
 
 v0.6.5.13 - March 18, 2026
 ----------------------------
 - CHANGED: Reverted to separate launcher_mac.py (rumps) and launcher_pc.py (pystray)
-- CHANGED: Removed Tkinter launcher window — caused NSApplication crashes on macOS
-- CHANGED: Removed Start Minimized option — tray/menu bar apps are always minimized
-- CHANGED: Default network interface is localhost (127.0.0.1) — opt-in for network access
+- CHANGED: Removed Tkinter launcher window, caused NSApplication crashes on macOS
+- CHANGED: Removed Start Minimized option, tray/menu bar apps are always minimized
+- CHANGED: Default network interface is localhost (127.0.0.1), opt-in for network access
 - NEW: rumps menu bar with settings: network interface, port, run at login
 - NEW: pystray system tray with same settings on Windows/Linux
 - NEW: Network interface submenu with checkmarks for current selection
@@ -629,7 +629,7 @@ v0.6.5.13 - March 18, 2026
 - NEW: Run at Login toggle (macOS LaunchAgent / Windows registry)
 - NEW: Comprehensive CI build integrity checks (spec refs, version match, imports, static assets)
 - NEW: 21 launcher settings tests (persistence, network detection, Run at Login)
-- FIX: Slow macOS CI — cached get_network_interfaces() across test class
+- FIX: Slow macOS CI, cached get_network_interfaces() across test class
 - FIX: PyInstaller spec references restored for separate launchers
 - CHANGED: Settings persisted to JSON in platform config directory
 
@@ -693,12 +693,12 @@ v0.6.4.7 - March 17, 2026
  BUG FIXES:
  - Fixed color picker crash on Windows (hexToRgbLocal not defined).
  - Fixed clicking on the selection marker ring picking white/black instead of
-   the underlying wheel color — wheel is now redrawn clean before reading.
+   the underlying wheel color, wheel is now redrawn clean before reading.
  - Fixed color picker auto-applying color when opening "Show Colors" modal
-   on Windows — no longer changes the layer color until user picks one.
+   on Windows, no longer changes the layer color until user picks one.
  - Fixed vertical brightness slider not working on Windows/Chrome/Edge by
    using cross-browser vertical slider CSS.
- - Fixed help tooltip panel appearing in wrong position — now correctly
+ - Fixed help tooltip panel appearing in wrong position, now correctly
    sits at the bottom of the right sidebar below the Screens panel.
 
  UI IMPROVEMENTS:
@@ -712,7 +712,7 @@ v0.6.4.7 - March 17, 2026
  - Replaced gear icon with a standard Preferences button next to Export.
  - Moved Offset Labels into the Labels panel, removing the separate Offsets
    section for a cleaner sidebar.
- - Color picker is now non-blocking — canvas can be panned and zoomed while
+ - Color picker is now non-blocking, canvas can be panned and zoomed while
    the color picker is open. The color picker is also draggable by its header.
 
 v0.6.4.3 - March 17, 2026
@@ -727,7 +727,7 @@ v0.6.4.3 - March 17, 2026
 v0.6.4.2 - March 17, 2026
 ----------------------------
  BUG FIXES:
- - Fixed per-tab Screen Name checkbox cross-contamination — unchecking Screen Name
+ - Fixed per-tab Screen Name checkbox cross-contamination, unchecking Screen Name
    on one tab (e.g. Pixel Map) no longer affects other tabs (Cabinet ID, Data Flow,
    Power). Each tab's Screen Name toggle now operates independently.
  - Root cause: loadLayerToInputs() was overwriting the pixel-map checkbox with the
@@ -742,14 +742,14 @@ v0.6.4.1 - March 17, 2026
 v0.6.4.0 - March 16, 2026
 ----------------------------
  BUG FIXES:
- - Fixed PNG export including selection overlays — layer selection borders, drag
+ - Fixed PNG export including selection overlays, layer selection borders, drag
    highlights, multi-select rectangles, custom path selection overlays, and active
    port/circuit badges are now suppressed during export via the existing exportMode flag.
 
 v0.6.3.3 - March 13, 2026
 ----------------------------
  BUG FIXES:
- - Fixed raster size preferences not applying on startup — socket project_data event
+ - Fixed raster size preferences not applying on startup, socket project_data event
    was overwriting preference-applied raster with server default (1920x1080).
  - Socket reconnect now preserves current raster size instead of resetting to server default.
  - Preference enforcement now syncs raster size to server so subsequent socket events
@@ -770,7 +770,7 @@ v0.6.3.2 - March 12, 2026
 v0.6.3 - March 11, 2026
 ----------------------------
  NEW FEATURES:
- - Added automatic update checker — app checks GitHub Releases on startup for newer versions.
+ - Added automatic update checker, app checks GitHub Releases on startup for newer versions.
  - Added "Help" menu with "Check for Updates" button for manual update checks.
  - Added dismissable update notification banner with direct download link.
  - Update checker uses secure HTTPS with TLS 1.2+ and certificate pinning (certifi).
@@ -785,7 +785,7 @@ v0.6.3 - March 11, 2026
  - Added requirements-dev.txt for development dependencies.
 
  BUG FIXES:
- - Fixed float-to-int conversion bug in render_layer_to_image — fractional pixel
+ - Fixed float-to-int conversion bug in render_layer_to_image, fractional pixel
    coordinates now correctly convert to integers before drawing.
  - Removed unused global declarations in save_project and delete_layer.
  - Fixed undo/redo for inline layer rename (double-click rename).

--- a/src/app.py
+++ b/src/app.py
@@ -521,6 +521,54 @@ def _assign_canvas_id(layer, data=None):
         )
 
 
+def _seed_data_with_canvas_defaults(data):
+    """v0.8 Slice 8: when the client adds a NEW screen layer to a canvas that
+    already has screens, seed the request payload with hardware/processor
+    settings from the most recently added screen in that canvas. Mutates
+    and returns ``data``. This makes each canvas behave like its own preset
+    bucket — adding a second SR cabinet inherits SR's voltage/amperage/
+    panel size/etc. without the user reconfiguring.
+
+    Runs BEFORE create_layer() so positional args (cabinet_width/height)
+    flow through correctly and panels are built at the right size. Only
+    fills fields the caller did NOT explicitly provide, so duplicates and
+    pastes (which carry full settings) are unaffected.
+    """
+    if not isinstance(data, dict):
+        return data
+    canvas_id = data.get('canvas_id') or current_project.get('active_canvas_id')
+    if not canvas_id:
+        return data
+    siblings = [
+        l for l in current_project.get('layers', [])
+        if isinstance(l, dict)
+        and l.get('canvas_id') == canvas_id
+        and (l.get('type') or 'screen') == 'screen'
+    ]
+    if not siblings:
+        return data
+    # Most recently added sibling = highest id.
+    try:
+        donor = max(siblings, key=lambda l: int(l.get('id') or 0))
+    except Exception:
+        donor = siblings[-1]
+    inheritable = (
+        'processorType', 'bitDepth', 'frameRate',
+        'powerVoltage', 'powerVoltageCustom', 'powerAmperage', 'powerAmperageCustom',
+        'panelWatts',
+        'panel_width_mm', 'panel_height_mm', 'panel_weight', 'weight_unit',
+        'cabinet_width', 'cabinet_height',
+        'border_color', 'border_color_pixel', 'border_color_cabinet',
+        'border_color_data', 'border_color_power',
+    )
+    for field in inheritable:
+        if field in data:
+            continue  # caller specified — respect it
+        if field in donor and donor[field] is not None:
+            data[field] = donor[field]
+    return data
+
+
 def sync_next_layer_id():
     """Rebase next_layer_id to avoid duplicate IDs after project load/restore."""
     global next_layer_id
@@ -1175,7 +1223,12 @@ def restore_project():
 
 @app.route('/api/layer/add', methods=['POST'])
 def add_layer():
-    data = request.json
+    data = request.json or {}
+    # Slice 8: seed payload with the active canvas's preset bucket BEFORE
+    # create_layer so cabinet_width/height flow into panel construction.
+    # Only fills fields the caller didn't already set, so duplicate/paste
+    # paths (which send full data) are unaffected.
+    _seed_data_with_canvas_defaults(data)
     layer = create_layer(
         name=data.get('name', f'Screen{len(current_project["layers"]) + 1}'),
         columns=data.get('columns', 8),

--- a/src/app.py
+++ b/src/app.py
@@ -148,7 +148,7 @@ def _build_panels(layer, panel_states=None):
         ps = panel_states.get((r, c), {}) if panel_states else {}
         return ps.get('halfTile', 'none')
 
-    # Per-panel width/height — half-tiles render at half cabinet size.
+    # Per-panel width/height, half-tiles render at half cabinet size.
     def panel_w(r, c):
         return cabinet_width / 2 if _half_at(r, c) == 'width' else cabinet_width
 
@@ -204,14 +204,14 @@ def _build_panels(layer, panel_states=None):
             y = row_y[r]
 
             # Anchor half-tiles to their neighbor side so the visible cabinet
-            # connects to the rest of the wall — the "missing" half sits on
+            # connects to the rest of the wall, the "missing" half sits on
             # the wall's outer edge (no neighbor side), not between this
             # cabinet and its neighbor.
             if half_tile == 'height' and ph < slot_h:
                 has_above = _has_visible_neighbor(r - 1, c)
                 has_below = _has_visible_neighbor(r + 1, c)
                 if not has_above and has_below:
-                    # Missing half on top — anchor to bottom of slot.
+                    # Missing half on top, anchor to bottom of slot.
                     y = row_y[r] + (slot_h - ph)
                 # else: anchor to top (default; covers top-anchored top edges
                 # and the interior/all-neighbors fallback).
@@ -219,7 +219,7 @@ def _build_panels(layer, panel_states=None):
                 has_left = _has_visible_neighbor(r, c - 1)
                 has_right = _has_visible_neighbor(r, c + 1)
                 if not has_left and has_right:
-                    # Missing half on left — anchor to right of slot.
+                    # Missing half on left, anchor to right of slot.
                     x = col_x[c] + (slot_w - pw)
                 # else: anchor to left (default).
 
@@ -326,7 +326,7 @@ next_layer_id = 1
 
 # Multi-canvas (v0.8) support. The project file format gains a `canvases`
 # array, a `format_version` string, and an `active_canvas_id`. v0.7 projects
-# are auto-migrated on load. Slice 1 is additive only — root-level
+# are auto-migrated on load. Slice 1 is additive only, root-level
 # raster_width/raster_height/show_raster_*/perspectives are still written so
 # the existing single-canvas client keeps working until later slices switch
 # the source-of-truth to per-canvas fields.
@@ -371,7 +371,7 @@ def _migrate_to_v0_8(project):
       every layer has a canvas_id, this is a no-op.
     - Otherwise: build a default canvas from the project's existing raster
       fields, assign every layer to it, set format_version/active_canvas_id.
-      Root-level raster fields are intentionally left in place — Slice 1 is
+      Root-level raster fields are intentionally left in place, Slice 1 is
       additive so the existing single-canvas client keeps reading them.
 
     Returns (project, did_migrate). did_migrate is True only when the
@@ -452,7 +452,7 @@ def _build_initial_project():
         'name': 'Untitled Project',
         'raster_width': 1920,
         'raster_height': 1080,
-        # Show Look has its own raster size — defaults to the same as the
+        # Show Look has its own raster size, defaults to the same as the
         # processor raster so existing projects open identically. The Show
         # Look raster is used as the export canvas size for the Show Look /
         # Data / Power views (which all render at the show position).
@@ -526,7 +526,7 @@ def _seed_data_with_canvas_defaults(data):
     already has screens, seed the request payload with hardware/processor
     settings from the most recently added screen in that canvas. Mutates
     and returns ``data``. This makes each canvas behave like its own preset
-    bucket — adding a second SR cabinet inherits SR's voltage/amperage/
+    bucket, adding a second SR cabinet inherits SR's voltage/amperage/
     panel size/etc. without the user reconfiguring.
 
     Runs BEFORE create_layer() so positional args (cabinet_width/height)
@@ -563,7 +563,7 @@ def _seed_data_with_canvas_defaults(data):
     )
     for field in inheritable:
         if field in data:
-            continue  # caller specified — respect it
+            continue  # caller specified, respect it
         if field in donor and donor[field] is not None:
             data[field] = donor[field]
     return data
@@ -596,7 +596,7 @@ def create_layer(name, columns, rows, cabinet_width, cabinet_height, offset_x=0,
         'cabinet_height': cabinet_height,
         'offset_x': offset_x,
         'offset_y': offset_y,
-        # Show Look position — used by the Show Look / Data / Power tabs.
+        # Show Look position, used by the Show Look / Data / Power tabs.
         # Defaults to the same values as offset_x/offset_y until the user
         # rearranges the layer in the Show Look view, at which point the
         # two positions diverge: pixel-map / cabinet-id keep using
@@ -1184,7 +1184,7 @@ def restore_project():
     current_project = data
     current_project['is_pristine'] = False
     # Backfill showOffsetX/Y on layers from older projects that pre-date the
-    # Show Look feature — default them to the layer's processor offset so
+    # Show Look feature, default them to the layer's processor offset so
     # existing projects open with the show layout = pixel layout.
     for layer in current_project.get('layers', []):
         if layer.get('showOffsetX') is None:
@@ -1221,7 +1221,7 @@ def restore_project():
     socketio.emit('project_updated', current_project)
     # Slice 12: surface a one-time migration notice to the client when the
     # incoming file lacked a v0.8 format_version. Carried as a top-level
-    # transient field on the response only — never stored on disk because
+    # transient field on the response only, never stored on disk because
     # the next save will write the now-present format_version, and future
     # loads of that same file won't re-migrate (and won't re-toast).
     response = dict(current_project)
@@ -1431,7 +1431,7 @@ def update_layer(layer_id):
             or 'halfFirstRow' in data or 'halfLastRow' in data):
         # Save existing panel states (hidden, blank, halfTile) before regenerating.
         # Key by (row, col) so state stays anchored to its grid cell when columns
-        # or rows change — keying by sequential id meant a column resize would
+        # or rows change, keying by sequential id meant a column resize would
         # shuffle blanks/half-tiles across the wall.
         old_panel_states = {}
         if 'panels' in layer:
@@ -1532,7 +1532,7 @@ def _next_canvas_workspace_position():
     Returns ``(workspace_x, workspace_y)``.
     """
     canvases = current_project.get('canvases') or []
-    # v0.8 Slice 9: default gap is 0 — most LED installs are abutting walls,
+    # v0.8 Slice 9: default gap is 0, most LED installs are abutting walls,
     # not floating screens. Server preference still wins when set.
     gap = 0
     try:
@@ -1753,7 +1753,7 @@ def set_active_canvas(canvas_id):
     if not _find_canvas(canvas_id):
         return jsonify({'error': 'Canvas not found'}), 404
     current_project['active_canvas_id'] = canvas_id
-    # Note: not flagging pristine — active canvas is a UI cursor, not data.
+    # Note: not flagging pristine, active canvas is a UI cursor, not data.
     log_event('canvas_set_active', {'id': canvas_id})
     socketio.emit('project_updated', current_project)
     return jsonify(current_project)
@@ -3159,7 +3159,7 @@ def generate_resolume_xml(project, project_name, raster_w, raster_h):
     OutputDeviceVirtual for each Screen is sized to that canvas's raster.
 
     The project-wide CurrentCompositionTextureSize is the workspace bounding
-    box of all visible canvases — that's the source-composition size the
+    box of all visible canvases, that's the source-composition size the
     user would feed in Resolume to drive every canvas at once.
 
     Legacy projects (no canvases array) fall through to a single synthetic
@@ -3177,7 +3177,7 @@ def generate_resolume_xml(project, project_name, raster_w, raster_h):
         if not layer.get('panels'):
             layer['panels'] = _build_panels(layer)
 
-    # Resolve canvases. Visible only — hiding a canvas in the sidebar is
+    # Resolve canvases. Visible only, hiding a canvas in the sidebar is
     # the user's signal that it shouldn't appear in the export. Legacy:
     # synthetic single canvas at (0, 0) using project-root raster.
     project_canvases = project.get('canvases') or []

--- a/src/app.py
+++ b/src/app.py
@@ -1332,7 +1332,7 @@ def add_text_layer():
     for key in ('fontSize', 'fontFamily', 'fontColor', 'bgColor', 'bgOpacity',
                 'textAlign', 'textPadding', 'showBorder', 'borderColor',
                 'showOnPixelMap', 'showOnCabinetId', 'showOnDataFlow', 'showOnPower',
-                'showRasterSize'):
+                'showRasterSize', 'dynamicInfoScope'):
         if key in data:
             layer[key] = data[key]
     _assign_canvas_id(layer, data)
@@ -1380,6 +1380,7 @@ def update_layer(layer_id):
                 'showProjectName', 'showDate',
                 'showPrimaryPorts', 'showBackupPorts',
                 'showCircuits', 'showSinglePhase', 'showThreePhase',
+                'dynamicInfoScope',
                 'fontBold', 'fontItalic', 'fontUnderline',
                 # Data flow / processing settings (previously silently dropped on PUT
                 # which broke preset application and label updates on re-fetch)

--- a/src/app.py
+++ b/src/app.py
@@ -1646,6 +1646,13 @@ def move_layer_to_canvas(layer_id):
         clone['offset_y'] = 0
         clone['showOffsetX'] = 0
         clone['showOffsetY'] = 0
+        # Re-anchor panel coordinates to the clone's new (0, 0) origin in
+        # the target canvas. Without this rebuild, panel.x / panel.y stay
+        # at their pre-drag absolute positions and the layer renders far
+        # off in the new canvas instead of snapping to the top-left.
+        # _rebuild_layer_geometry_from_panel_states preserves per-panel
+        # hidden / blank / halfTile state.
+        _rebuild_layer_geometry_from_panel_states(clone)
         current_project['layers'].append(clone)
         log_event('layer_duplicate_to_canvas', {
             'src_layer_id': layer_id, 'new_layer_id': clone['id'],
@@ -1657,6 +1664,8 @@ def move_layer_to_canvas(layer_id):
         layer['offset_y'] = 0
         layer['showOffsetX'] = 0
         layer['showOffsetY'] = 0
+        # Same panel re-anchor as the duplicate branch above.
+        _rebuild_layer_geometry_from_panel_states(layer)
         log_event('layer_move_to_canvas', {
             'layer_id': layer_id, 'target_canvas_id': target_id,
         })

--- a/src/app.py
+++ b/src/app.py
@@ -1352,6 +1352,256 @@ def delete_layer(layer_id):
     socketio.emit('layer_deleted', {'id': layer_id})
     return jsonify(current_project)
 
+# ---------------------------------------------------------------------------
+# Multi-canvas (v0.8) Slice 2: canvas CRUD endpoints.
+#
+# These mutate ``current_project['canvases']`` in place. The sidebar UI
+# routes all canvas operations through these endpoints; layer rendering in
+# the workspace is unchanged in Slice 2.
+# ---------------------------------------------------------------------------
+
+
+def _next_canvas_id():
+    """Pick the next free canvas id of the form ``c<N>``.
+
+    Scans existing canvases, finds the max numeric suffix, and returns one
+    above. Falls back to ``c1`` if the array is empty.
+    """
+    canvases = current_project.get('canvases') or []
+    max_n = 0
+    for c in canvases:
+        cid = (c or {}).get('id', '')
+        if isinstance(cid, str) and cid.startswith('c'):
+            try:
+                n = int(cid[1:])
+                if n > max_n:
+                    max_n = n
+            except ValueError:
+                pass
+    return f'c{max_n + 1}'
+
+
+def _next_canvas_color():
+    """Pick the first palette color not already used by another canvas.
+
+    If all 8 palette colors are taken, falls back to palette[N % 8] where N
+    is the count of existing canvases (so we still pick a sensible default
+    without surprising the user with random hex values).
+    """
+    canvases = current_project.get('canvases') or []
+    used = {(c or {}).get('color') for c in canvases}
+    for color in DEFAULT_CANVAS_PALETTE:
+        if color not in used:
+            return color
+    return DEFAULT_CANVAS_PALETTE[len(canvases) % len(DEFAULT_CANVAS_PALETTE)]
+
+
+def _find_canvas(canvas_id):
+    for c in current_project.get('canvases') or []:
+        if c.get('id') == canvas_id:
+            return c
+    return None
+
+
+@app.route('/api/canvas', methods=['POST'])
+def create_canvas():
+    data = request.json or {}
+    canvases = current_project.setdefault('canvases', [])
+    new_id = _next_canvas_id()
+    # Default name: "Canvas <N>" where N matches the numeric id suffix.
+    default_name = f'Canvas {new_id[1:]}'
+    # Inherit raster defaults from the active canvas so a freshly added
+    # canvas feels like a clone of the user's current setup. Slice 5 will
+    # add real workspace placement; for now stack at 0,0.
+    active = _find_canvas(current_project.get('active_canvas_id')) or (
+        canvases[0] if canvases else None
+    )
+    canvas = {
+        'id': new_id,
+        'name': data.get('name') or default_name,
+        'color': data.get('color') or _next_canvas_color(),
+        'workspace_x': 0,
+        'workspace_y': 0,
+        'raster_width': (active or {}).get('raster_width', 1920),
+        'raster_height': (active or {}).get('raster_height', 1080),
+        'show_raster_width': (active or {}).get('show_raster_width', 1920),
+        'show_raster_height': (active or {}).get('show_raster_height', 1080),
+        'data_flow_perspective': (active or {}).get('data_flow_perspective', 'front'),
+        'power_perspective': (active or {}).get('power_perspective', 'front'),
+        'visible': True,
+    }
+    canvases.append(canvas)
+    current_project['active_canvas_id'] = new_id
+    current_project['is_pristine'] = False
+    log_event('canvas_create', {'id': new_id, 'name': canvas['name']})
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/canvas/<canvas_id>', methods=['PUT'])
+def update_canvas(canvas_id):
+    canvas = _find_canvas(canvas_id)
+    if not canvas:
+        return jsonify({'error': 'Canvas not found'}), 404
+    data = request.json or {}
+    allowed = {
+        'name', 'color', 'visible',
+        'workspace_x', 'workspace_y',
+        'raster_width', 'raster_height',
+        'show_raster_width', 'show_raster_height',
+        'data_flow_perspective', 'power_perspective',
+    }
+    changed = {}
+    for key, val in data.items():
+        if key in allowed:
+            canvas[key] = val
+            changed[key] = val
+    current_project['is_pristine'] = False
+    log_event('canvas_update', {'id': canvas_id, 'changed': changed})
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/canvas/<canvas_id>', methods=['DELETE'])
+def delete_canvas(canvas_id):
+    canvases = current_project.get('canvases') or []
+    if len(canvases) <= 1:
+        return jsonify({
+            'error': 'Cannot delete the last remaining canvas. '
+                     'A project must contain at least one canvas.'
+        }), 400
+    canvas = _find_canvas(canvas_id)
+    if not canvas:
+        return jsonify({'error': 'Canvas not found'}), 404
+    deleted_name = canvas.get('name', '?')
+    # Remove the canvas itself.
+    current_project['canvases'] = [c for c in canvases if c.get('id') != canvas_id]
+    # Remove all layers belonging to this canvas.
+    layers_before = len(current_project.get('layers', []))
+    current_project['layers'] = [
+        l for l in current_project.get('layers', [])
+        if l.get('canvas_id') != canvas_id
+    ]
+    layers_removed = layers_before - len(current_project['layers'])
+    # Reassign active_canvas_id to the next remaining canvas.
+    if current_project.get('active_canvas_id') == canvas_id:
+        current_project['active_canvas_id'] = current_project['canvases'][0]['id']
+    current_project['is_pristine'] = False
+    log_event('canvas_delete', {
+        'id': canvas_id, 'name': deleted_name,
+        'layers_removed': layers_removed,
+    })
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/canvas/<canvas_id>/duplicate', methods=['POST'])
+def duplicate_canvas(canvas_id):
+    global next_layer_id
+    src = _find_canvas(canvas_id)
+    if not src:
+        return jsonify({'error': 'Canvas not found'}), 404
+    new_id = _next_canvas_id()
+    new_canvas = json.loads(json.dumps(src))
+    new_canvas['id'] = new_id
+    new_canvas['name'] = f"{src.get('name', 'Canvas')} Copy"
+    new_canvas['color'] = _next_canvas_color()
+    current_project['canvases'].append(new_canvas)
+    # Clone every layer in the source canvas, with a new layer id.
+    src_layers = [
+        l for l in current_project.get('layers', [])
+        if l.get('canvas_id') == canvas_id
+    ]
+    for src_layer in src_layers:
+        clone = json.loads(json.dumps(src_layer))
+        clone['id'] = next_layer_id
+        next_layer_id += 1
+        clone['canvas_id'] = new_id
+        current_project['layers'].append(clone)
+    current_project['active_canvas_id'] = new_id
+    current_project['is_pristine'] = False
+    log_event('canvas_duplicate', {
+        'src_id': canvas_id, 'new_id': new_id,
+        'layers_cloned': len(src_layers),
+    })
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/canvas/reorder', methods=['POST'])
+def reorder_canvases():
+    data = request.json or {}
+    canvas_ids = data.get('canvas_ids') or []
+    canvases = current_project.get('canvases') or []
+    by_id = {c.get('id'): c for c in canvases}
+    if set(canvas_ids) != set(by_id.keys()):
+        return jsonify({
+            'error': 'canvas_ids must be a permutation of existing canvas ids',
+        }), 400
+    current_project['canvases'] = [by_id[cid] for cid in canvas_ids]
+    current_project['is_pristine'] = False
+    log_event('canvas_reorder', {'order': canvas_ids})
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/canvas/<canvas_id>/active', methods=['PUT'])
+def set_active_canvas(canvas_id):
+    if not _find_canvas(canvas_id):
+        return jsonify({'error': 'Canvas not found'}), 404
+    current_project['active_canvas_id'] = canvas_id
+    # Note: not flagging pristine — active canvas is a UI cursor, not data.
+    log_event('canvas_set_active', {'id': canvas_id})
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/layer/<int:layer_id>/canvas', methods=['PUT'])
+def move_layer_to_canvas(layer_id):
+    """Move or duplicate a layer onto a different canvas.
+
+    Body: ``{canvas_id: "...", mode: "move" | "duplicate"}``. For "move",
+    the layer's ``canvas_id`` is updated and offset_x/y + showOffsetX/Y are
+    reset to 0,0 (per design Section 5.7). For "duplicate", a clone with a
+    fresh layer id is appended at 0,0 in the target canvas.
+    """
+    global next_layer_id
+    data = request.json or {}
+    target_id = data.get('canvas_id')
+    mode = data.get('mode', 'move')
+    if not _find_canvas(target_id):
+        return jsonify({'error': 'Target canvas not found'}), 404
+    layer = next((l for l in current_project['layers'] if l.get('id') == layer_id), None)
+    if not layer:
+        return jsonify({'error': 'Layer not found'}), 404
+    if mode == 'duplicate':
+        clone = json.loads(json.dumps(layer))
+        clone['id'] = next_layer_id
+        next_layer_id += 1
+        clone['canvas_id'] = target_id
+        clone['offset_x'] = 0
+        clone['offset_y'] = 0
+        clone['showOffsetX'] = 0
+        clone['showOffsetY'] = 0
+        current_project['layers'].append(clone)
+        log_event('layer_duplicate_to_canvas', {
+            'src_layer_id': layer_id, 'new_layer_id': clone['id'],
+            'target_canvas_id': target_id,
+        })
+    else:
+        layer['canvas_id'] = target_id
+        layer['offset_x'] = 0
+        layer['offset_y'] = 0
+        layer['showOffsetX'] = 0
+        layer['showOffsetY'] = 0
+        log_event('layer_move_to_canvas', {
+            'layer_id': layer_id, 'target_canvas_id': target_id,
+        })
+    current_project['is_pristine'] = False
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
 @app.route('/api/layer/<int:layer_id>/panel/<int:panel_id>/toggle', methods=['POST'])
 def toggle_panel_blank(layer_id, panel_id):
     layer = next((l for l in current_project['layers'] if l['id'] == layer_id), None)

--- a/src/app.py
+++ b/src/app.py
@@ -1523,7 +1523,9 @@ def _next_canvas_workspace_position():
     Returns ``(workspace_x, workspace_y)``.
     """
     canvases = current_project.get('canvases') or []
-    gap = 50
+    # v0.8 Slice 9: default gap is 0 — most LED installs are abutting walls,
+    # not floating screens. Server preference still wins when set.
+    gap = 0
     try:
         pref_gap = (server_preferences or {}).get('canvasGap')
         if pref_gap is not None:

--- a/src/app.py
+++ b/src/app.py
@@ -1219,7 +1219,15 @@ def restore_project():
         'layer_names': [l.get('name', '?') for l in current_project.get('layers', [])]
     })
     socketio.emit('project_updated', current_project)
-    return jsonify(current_project)
+    # Slice 12: surface a one-time migration notice to the client when the
+    # incoming file lacked a v0.8 format_version. Carried as a top-level
+    # transient field on the response only — never stored on disk because
+    # the next save will write the now-present format_version, and future
+    # loads of that same file won't re-migrate (and won't re-toast).
+    response = dict(current_project)
+    if did_migrate:
+        response['_migration_notice'] = True
+    return jsonify(response)
 
 @app.route('/api/layer/add', methods=['POST'])
 def add_layer():

--- a/src/app.py
+++ b/src/app.py
@@ -324,26 +324,122 @@ SERVER_START_TIME = int(time.time() * 1000)  # milliseconds
 # Counter for unique layer IDs - never reuses IDs
 next_layer_id = 1
 
-current_project = {
-    'name': 'Untitled Project',
-    'raster_width': 1920,
-    'raster_height': 1080,
-    # Show Look has its own raster size — defaults to the same as the
-    # processor raster so existing projects open identically. The Show Look
-    # raster is used as the export canvas size for the Show Look / Data /
-    # Power views (which all render at the show position).
-    'show_raster_width': 1920,
-    'show_raster_height': 1080,
-    # Wiring view perspective per tab. 'front' shows the layout as the
-    # audience sees it (matching Show Look). 'back' horizontally mirrors
-    # the geometry so the techs working behind the wall see it from their
-    # perspective. Labels stay readable in either view. Per-tab so a Data
-    # tech and a Power tech can configure independently.
-    'data_flow_perspective': 'front',
-    'power_perspective': 'front',
-    'layers': [],
-    'is_pristine': True
-}
+# Multi-canvas (v0.8) support. The project file format gains a `canvases`
+# array, a `format_version` string, and an `active_canvas_id`. v0.7 projects
+# are auto-migrated on load. Slice 1 is additive only — root-level
+# raster_width/raster_height/show_raster_*/perspectives are still written so
+# the existing single-canvas client keeps working until later slices switch
+# the source-of-truth to per-canvas fields.
+CURRENT_FORMAT_VERSION = "0.8"
+DEFAULT_CANVAS_PALETTE = [
+    "#4A90E2", "#F5A623", "#7ED321", "#BD10E0",
+    "#D0021B", "#50E3C2", "#F8E71C", "#9013FE",
+]
+
+
+def _make_default_canvas(project, idx=0):
+    """Build a canvas dict from a project's current root-level raster fields.
+
+    Used both when constructing a fresh project (idx=0) and when migrating a
+    v0.7 project. The canvas inherits the project's existing raster /
+    perspective values so the migration is loss-free.
+    """
+    return {
+        'id': f'c{idx + 1}',
+        'name': f'Canvas {idx + 1}',
+        'color': DEFAULT_CANVAS_PALETTE[idx % len(DEFAULT_CANVAS_PALETTE)],
+        'workspace_x': 0,
+        'workspace_y': 0,
+        'raster_width': project.get('raster_width', 1920),
+        'raster_height': project.get('raster_height', 1080),
+        'show_raster_width': project.get(
+            'show_raster_width', project.get('raster_width', 1920)
+        ),
+        'show_raster_height': project.get(
+            'show_raster_height', project.get('raster_height', 1080)
+        ),
+        'data_flow_perspective': project.get('data_flow_perspective', 'front'),
+        'power_perspective': project.get('power_perspective', 'front'),
+        'visible': True,
+    }
+
+
+def _migrate_to_v0_8(project):
+    """Idempotent additive migrator from v0.7 to v0.8.
+
+    - If the project already declares format_version 0.8 AND has canvases AND
+      every layer has a canvas_id, this is a no-op.
+    - Otherwise: build a default canvas from the project's existing raster
+      fields, assign every layer to it, set format_version/active_canvas_id.
+      Root-level raster fields are intentionally left in place — Slice 1 is
+      additive so the existing single-canvas client keeps reading them.
+
+    Returns (project, did_migrate). did_migrate is True only when the
+    structure actually changed, so callers can avoid noisy log spam.
+    """
+    if not isinstance(project, dict):
+        return project, False
+    canvases = project.get('canvases')
+    layers = project.get('layers') or []
+    has_canvases = isinstance(canvases, list) and len(canvases) > 0
+    all_layers_assigned = all(
+        isinstance(l, dict) and l.get('canvas_id') for l in layers
+    )
+    if (
+        project.get('format_version') == CURRENT_FORMAT_VERSION
+        and has_canvases
+        and all_layers_assigned
+    ):
+        return project, False
+
+    if not has_canvases:
+        canvas = _make_default_canvas(project, 0)
+        project['canvases'] = [canvas]
+        project['active_canvas_id'] = canvas['id']
+    else:
+        # Canvases exist but format_version may be older or layers unassigned.
+        if not project.get('active_canvas_id'):
+            project['active_canvas_id'] = project['canvases'][0]['id']
+
+    default_canvas_id = project['canvases'][0]['id']
+    for layer in layers:
+        if isinstance(layer, dict) and not layer.get('canvas_id'):
+            layer['canvas_id'] = default_canvas_id
+
+    project['format_version'] = CURRENT_FORMAT_VERSION
+    return project, True
+
+
+def _build_initial_project():
+    """Build the in-memory project dict used at app startup and by /new."""
+    project = {
+        'name': 'Untitled Project',
+        'raster_width': 1920,
+        'raster_height': 1080,
+        # Show Look has its own raster size — defaults to the same as the
+        # processor raster so existing projects open identically. The Show
+        # Look raster is used as the export canvas size for the Show Look /
+        # Data / Power views (which all render at the show position).
+        'show_raster_width': 1920,
+        'show_raster_height': 1080,
+        # Wiring view perspective per tab. 'front' shows the layout as the
+        # audience sees it (matching Show Look). 'back' horizontally mirrors
+        # the geometry so the techs working behind the wall see it from their
+        # perspective. Labels stay readable in either view. Per-tab so a Data
+        # tech and a Power tech can configure independently.
+        'data_flow_perspective': 'front',
+        'power_perspective': 'front',
+        'layers': [],
+        'is_pristine': True,
+    }
+    # Pre-populate v0.8 fields so a fresh project already passes the
+    # migrator as a no-op. Root raster fields are still present for the
+    # client's current single-canvas code paths.
+    _migrate_to_v0_8(project)
+    return project
+
+
+current_project = _build_initial_project()
 
 # Add a default layer on startup
 def initialize_default_layer():
@@ -358,7 +454,36 @@ def initialize_default_layer():
             offset_x=0,
             offset_y=0
         )
+        # Assign to the active canvas. _build_initial_project / migrator
+        # guarantees at least one canvas exists at this point.
+        canvases = current_project.get('canvases') or []
+        if canvases:
+            default_layer['canvas_id'] = current_project.get(
+                'active_canvas_id', canvases[0]['id']
+            )
         current_project['layers'].append(default_layer)
+
+def _assign_canvas_id(layer, data=None):
+    """Stamp a layer with a canvas_id (caller-provided or active canvas).
+
+    Centralised so all add-layer paths (screen / image / text) get the same
+    behaviour: respect a client-supplied canvas_id if it matches an existing
+    canvas, otherwise fall back to the project's active canvas. Guarantees
+    layer['canvas_id'] is set to a non-empty string when at least one
+    canvas exists.
+    """
+    canvases = current_project.get('canvases') or []
+    if not canvases:
+        return
+    valid_ids = {c.get('id') for c in canvases if isinstance(c, dict)}
+    requested = (data or {}).get('canvas_id') if isinstance(data, dict) else None
+    if requested and requested in valid_ids:
+        layer['canvas_id'] = requested
+    else:
+        layer['canvas_id'] = current_project.get(
+            'active_canvas_id', canvases[0].get('id')
+        )
+
 
 def sync_next_layer_id():
     """Rebase next_layer_id to avoid duplicate IDs after project load/restore."""
@@ -919,17 +1044,7 @@ def reveal_logs_folder():
 def new_project():
     global current_project, next_layer_id
     next_layer_id = 1  # Reset counter for new project
-    current_project = {
-        'name': 'Untitled Project',
-        'raster_width': 1920,
-        'raster_height': 1080,
-        'show_raster_width': 1920,
-        'show_raster_height': 1080,
-        'data_flow_perspective': 'front',
-        'power_perspective': 'front',
-        'layers': [],
-        'is_pristine': True
-    }
+    current_project = _build_initial_project()
     # Add default layer to new projects
     initialize_default_layer()
     log_event('new_project')
@@ -949,7 +1064,19 @@ def save_project():
 def restore_project():
     """Restore entire project state (used by undo/redo and file load)"""
     global current_project
-    data = request.json
+    data = request.json or {}
+    # Refuse to load projects authored by a newer app version. Simple string
+    # comparison is fine for the foreseeable "0.x" range; revisit if we ever
+    # ship a 0.10 / 1.0.
+    incoming_version = data.get('format_version') if isinstance(data, dict) else None
+    if incoming_version and incoming_version > CURRENT_FORMAT_VERSION:
+        return jsonify({
+            'error': (
+                f'Project format {incoming_version} is newer than this '
+                f'version supports ({CURRENT_FORMAT_VERSION}). '
+                f'Please update the app.'
+            )
+        }), 400
     current_project = data
     current_project['is_pristine'] = False
     # Backfill showOffsetX/Y on layers from older projects that pre-date the
@@ -972,6 +1099,15 @@ def restore_project():
         current_project['data_flow_perspective'] = 'front'
     if current_project.get('power_perspective') not in ('front', 'back'):
         current_project['power_perspective'] = 'front'
+    # Multi-canvas migration. Additive: leaves root-level raster fields in
+    # place so the existing single-canvas client keeps working. Slice 6 will
+    # switch the source-of-truth to per-canvas fields.
+    current_project, did_migrate = _migrate_to_v0_8(current_project)
+    if did_migrate:
+        log_event('project_migrated', {
+            'from_version': '<0.8',
+            'to_version': CURRENT_FORMAT_VERSION,
+        })
     sync_next_layer_id()
     log_event('restore_project', {
         'name': current_project.get('name', '?'),
@@ -993,7 +1129,8 @@ def add_layer():
         offset_x=data.get('offset_x', 0),
         offset_y=data.get('offset_y', 0)
     )
-    
+    _assign_canvas_id(layer, data)
+
     # Apply additional settings from request (for duplicate/paste)
     optional_fields = [
         'color1', 'color2', 'panel_width_mm', 'panel_height_mm', 'panel_weight',
@@ -1065,6 +1202,7 @@ def add_image_layer():
     )
     if 'imageScale' in data:
         layer['imageScale'] = data['imageScale']
+    _assign_canvas_id(layer, data)
     log_event('add_image_layer', {'name': layer.get('name'), 'id': layer.get('id')})
     current_project['layers'].append(layer)
     current_project['is_pristine'] = False
@@ -1088,6 +1226,7 @@ def add_text_layer():
                 'showRasterSize'):
         if key in data:
             layer[key] = data[key]
+    _assign_canvas_id(layer, data)
     log_event('add_text_layer', {'name': layer.get('name'), 'id': layer.get('id')})
     current_project['layers'].append(layer)
     current_project['is_pristine'] = False

--- a/src/app.py
+++ b/src/app.py
@@ -1529,16 +1529,33 @@ def create_canvas():
         canvases[0] if canvases else None
     )
     ws_x, ws_y = _next_canvas_workspace_position()
+    # Resolve raster dimensions: explicit request body wins (so the client can
+    # honor the user's "Default Canvas Size" preference), otherwise fall back
+    # to the active canvas's raster, otherwise the hard-coded 1920x1080.
+    def _pos_int(value, fallback):
+        try:
+            n = int(value)
+            return n if n > 0 else fallback
+        except (TypeError, ValueError):
+            return fallback
+    rw_default = (active or {}).get('raster_width', 1920)
+    rh_default = (active or {}).get('raster_height', 1080)
+    sw_default = (active or {}).get('show_raster_width', rw_default)
+    sh_default = (active or {}).get('show_raster_height', rh_default)
+    raster_w = _pos_int(data.get('raster_width'), rw_default)
+    raster_h = _pos_int(data.get('raster_height'), rh_default)
+    show_w = _pos_int(data.get('show_raster_width'), sw_default if 'show_raster_width' not in data else raster_w)
+    show_h = _pos_int(data.get('show_raster_height'), sh_default if 'show_raster_height' not in data else raster_h)
     canvas = {
         'id': new_id,
         'name': data.get('name') or default_name,
         'color': data.get('color') or _next_canvas_color(),
         'workspace_x': ws_x,
         'workspace_y': ws_y,
-        'raster_width': (active or {}).get('raster_width', 1920),
-        'raster_height': (active or {}).get('raster_height', 1080),
-        'show_raster_width': (active or {}).get('show_raster_width', 1920),
-        'show_raster_height': (active or {}).get('show_raster_height', 1080),
+        'raster_width': raster_w,
+        'raster_height': raster_h,
+        'show_raster_width': show_w,
+        'show_raster_height': show_h,
         'data_flow_perspective': (active or {}).get('data_flow_perspective', 'front'),
         'power_perspective': (active or {}).get('power_perspective', 'front'),
         'visible': True,

--- a/src/app.py
+++ b/src/app.py
@@ -3142,9 +3142,23 @@ def _resolume_slice(layer, unique_id):
     )
 
 def generate_resolume_xml(project, project_name, raster_w, raster_h):
-    """Generate Resolume Arena Advanced Output XML from project layers."""
+    """Generate Resolume Arena Advanced Output XML from project layers.
+
+    v0.8 (Slice 11): one <Screen> per project canvas. Each Screen's layers
+    are the screen-type layers belonging to that canvas; coordinates inside
+    the Polygon/Slice are CANVAS-LOCAL (panel.x/y are stored that way after
+    Slice 6), which matches the per-canvas Resolume composition model. The
+    OutputDeviceVirtual for each Screen is sized to that canvas's raster.
+
+    The project-wide CurrentCompositionTextureSize is the workspace bounding
+    box of all visible canvases — that's the source-composition size the
+    user would feed in Resolume to drive every canvas at once.
+
+    Legacy projects (no canvases array) fall through to a single synthetic
+    Screen using the project-root raster dimensions, byte-equivalent to the
+    pre-Slice-11 export so v0.7 workflows aren't disrupted.
+    """
     import random
-    screen_id = random.randint(1000000000000, 9999999999999)
 
     layers = project.get('layers', [])
     # Filter to visible screen layers only
@@ -3155,15 +3169,41 @@ def generate_resolume_xml(project, project_name, raster_w, raster_h):
         if not layer.get('panels'):
             layer['panels'] = _build_panels(layer)
 
-    slices_xml = ""
-    for layer in screen_layers:
-        slice_id = random.randint(1000000000000, 9999999999999)
-        if _layer_has_hidden_panels(layer):
-            slices_xml += _resolume_polygon(layer, slice_id)
-        else:
-            slices_xml += _resolume_slice(layer, slice_id)
+    # Resolve canvases. Visible only — hiding a canvas in the sidebar is
+    # the user's signal that it shouldn't appear in the export. Legacy:
+    # synthetic single canvas at (0, 0) using project-root raster.
+    project_canvases = project.get('canvases') or []
+    if project_canvases:
+        export_canvases = [
+            c for c in project_canvases
+            if isinstance(c, dict) and c.get('visible', True) is not False
+        ]
+    else:
+        export_canvases = [{
+            'id': None,
+            'name': 'Screen 1',
+            'workspace_x': 0,
+            'workspace_y': 0,
+            'raster_width': raster_w,
+            'raster_height': raster_h,
+        }]
 
-    # Screen-level output params
+    # Workspace bounding box -> CurrentCompositionTextureSize. If no canvases
+    # have content yet, fall back to the client-supplied raster_w/h (which
+    # comes from the toolbar, i.e. the active canvas).
+    if export_canvases:
+        min_x = min((c.get('workspace_x') or 0) for c in export_canvases)
+        min_y = min((c.get('workspace_y') or 0) for c in export_canvases)
+        max_x = max((c.get('workspace_x') or 0) + (c.get('raster_width') or 0)
+                    for c in export_canvases)
+        max_y = max((c.get('workspace_y') or 0) + (c.get('raster_height') or 0)
+                    for c in export_canvases)
+        composition_w = max(int(max_x - min_x), int(raster_w))
+        composition_h = max(int(max_y - min_y), int(raster_h))
+    else:
+        composition_w, composition_h = int(raster_w), int(raster_h)
+
+    # Screen-level output params (used for every Screen block)
     def screen_param_range(name, default="0", value="0", min_val="-1", max_val="1"):
         return (
             f'\t\t\t\t\t<ParamRange name="{name}" T="DOUBLE" default="{default}" value="{value}">\n'
@@ -3196,7 +3236,73 @@ def generate_resolume_xml(project, project_name, raster_w, raster_h):
             f'\t\t\t\t\t\t</ParamRange>\n'
         )
 
-    device_hash = random.randint(1000000000000000000, 9999999999999999999)
+    # Build one <Screen> per canvas with its scoped layers.
+    screens_xml = ""
+    for canvas in export_canvases:
+        canvas_id = canvas.get('id')
+        canvas_name = canvas.get('name') or 'Screen'
+        canvas_w = int(canvas.get('raster_width') or raster_w)
+        canvas_h = int(canvas.get('raster_height') or raster_h)
+        # Screen-scoped layers: visible screen-type layers in this canvas.
+        # Legacy synthetic canvas (id=None) takes every visible layer so
+        # pre-multi-canvas projects export identically to v0.7.
+        if canvas_id:
+            canvas_layers = [l for l in screen_layers if l.get('canvas_id') == canvas_id]
+        else:
+            canvas_layers = screen_layers
+
+        slices_xml = ""
+        for layer in canvas_layers:
+            slice_id = random.randint(1000000000000, 9999999999999)
+            if _layer_has_hidden_panels(layer):
+                slices_xml += _resolume_polygon(layer, slice_id)
+            else:
+                slices_xml += _resolume_slice(layer, slice_id)
+
+        screen_unique_id = random.randint(1000000000000, 9999999999999)
+        device_hash = random.randint(1000000000000000000, 9999999999999999999)
+        # Escape any "&", quote chars in the canvas name for XML attributes.
+        safe_name = (str(canvas_name)
+                     .replace('&', '&amp;').replace('<', '&lt;')
+                     .replace('>', '&gt;').replace('"', '&quot;'))
+
+        screens_xml += (
+            f'\t\t\t<Screen name="{safe_name}" uniqueId="{screen_unique_id}">\n'
+            f'\t\t\t\t<Params name="Params">\n'
+            f'\t\t\t\t\t<Param name="Name" T="STRING" default="" value="{safe_name}"/>\n'
+            f'\t\t\t\t\t<Param name="Enabled" T="BOOL" default="1" value="1"/>\n'
+            f'\t\t\t\t\t<Param name="Hidden" T="BOOL" default="0" value="0"/>\n'
+            f'\t\t\t\t</Params>\n'
+            f'\t\t\t\t<Params name="Output">\n'
+            f'{screen_output}'
+            f'\t\t\t\t</Params>\n'
+            f'\t\t\t\t<guides>\n'
+            f'\t\t\t\t\t<ScreenGuide name="ScreenGuide" type="0">\n'
+            f'\t\t\t\t\t\t<Params name="Params">\n'
+            f'\t\t\t\t\t\t\t<ParamPixels name="Image"/>\n'
+            f'\t\t\t\t\t\t\t<ParamRange name="Opacity" T="DOUBLE" default="0.25" value="0.25">\n'
+            f'\t\t\t\t\t\t\t\t<PhaseSourceStatic name="PhaseSourceStatic"/>\n'
+            f'\t\t\t\t\t\t\t\t<BehaviourDouble name="BehaviourDouble"/>\n'
+            f'\t\t\t\t\t\t\t\t<ValueRange name="defaultRange" min="0" max="1"/>\n'
+            f'\t\t\t\t\t\t\t\t<ValueRange name="minMax" min="0" max="1"/>\n'
+            f'\t\t\t\t\t\t\t\t<ValueRange name="startStop" min="0" max="1"/>\n'
+            f'\t\t\t\t\t\t\t</ParamRange>\n'
+            f'\t\t\t\t\t\t</Params>\n'
+            f'\t\t\t\t\t</ScreenGuide>\n'
+            f'\t\t\t\t</guides>\n'
+            f'\t\t\t\t<layers>\n'
+            f'{slices_xml}'
+            f'\t\t\t\t</layers>\n'
+            f'\t\t\t\t<OutputDevice>\n'
+            f'\t\t\t\t\t<OutputDeviceVirtual name="{safe_name}" deviceId="Virtual{safe_name}" idHash="{device_hash}" width="{canvas_w}" height="{canvas_h}">\n'
+            f'\t\t\t\t\t\t<Params name="Params">\n'
+            f'{device_param_range("Width", "800", str(canvas_w))}'
+            f'{device_param_range("Height", "600", str(canvas_h))}'
+            f'\t\t\t\t\t\t</Params>\n'
+            f'\t\t\t\t\t</OutputDeviceVirtual>\n'
+            f'\t\t\t\t</OutputDevice>\n'
+            f'\t\t\t</Screen>\n'
+        )
 
     # SoftEdging params
     def soft_edge_param(name, default, value, min_val, max_val):
@@ -3216,43 +3322,9 @@ def generate_resolume_xml(project, project_name, raster_w, raster_h):
         f'\t<versionInfo name="Resolume Arena" majorVersion="7" minorVersion="24" microVersion="3" revision="63742"/>\n'
         f'\t<ScreenSetup name="ScreenSetup">\n'
         f'\t\t<Params name="ScreenSetupParams"/>\n'
-        f'\t\t<CurrentCompositionTextureSize width="{raster_w}" height="{raster_h}"/>\n'
+        f'\t\t<CurrentCompositionTextureSize width="{composition_w}" height="{composition_h}"/>\n'
         f'\t\t<screens>\n'
-        f'\t\t\t<Screen name="Screen 1" uniqueId="{screen_id}">\n'
-        f'\t\t\t\t<Params name="Params">\n'
-        f'\t\t\t\t\t<Param name="Name" T="STRING" default="" value="Screen 1"/>\n'
-        f'\t\t\t\t\t<Param name="Enabled" T="BOOL" default="1" value="1"/>\n'
-        f'\t\t\t\t\t<Param name="Hidden" T="BOOL" default="0" value="0"/>\n'
-        f'\t\t\t\t</Params>\n'
-        f'\t\t\t\t<Params name="Output">\n'
-        f'{screen_output}'
-        f'\t\t\t\t</Params>\n'
-        f'\t\t\t\t<guides>\n'
-        f'\t\t\t\t\t<ScreenGuide name="ScreenGuide" type="0">\n'
-        f'\t\t\t\t\t\t<Params name="Params">\n'
-        f'\t\t\t\t\t\t\t<ParamPixels name="Image"/>\n'
-        f'\t\t\t\t\t\t\t<ParamRange name="Opacity" T="DOUBLE" default="0.25" value="0.25">\n'
-        f'\t\t\t\t\t\t\t\t<PhaseSourceStatic name="PhaseSourceStatic"/>\n'
-        f'\t\t\t\t\t\t\t\t<BehaviourDouble name="BehaviourDouble"/>\n'
-        f'\t\t\t\t\t\t\t\t<ValueRange name="defaultRange" min="0" max="1"/>\n'
-        f'\t\t\t\t\t\t\t\t<ValueRange name="minMax" min="0" max="1"/>\n'
-        f'\t\t\t\t\t\t\t\t<ValueRange name="startStop" min="0" max="1"/>\n'
-        f'\t\t\t\t\t\t\t</ParamRange>\n'
-        f'\t\t\t\t\t\t</Params>\n'
-        f'\t\t\t\t\t</ScreenGuide>\n'
-        f'\t\t\t\t</guides>\n'
-        f'\t\t\t\t<layers>\n'
-        f'{slices_xml}'
-        f'\t\t\t\t</layers>\n'
-        f'\t\t\t\t<OutputDevice>\n'
-        f'\t\t\t\t\t<OutputDeviceVirtual name="Screen 1" deviceId="VirtualScreen 1" idHash="{device_hash}" width="{raster_w}" height="{raster_h}">\n'
-        f'\t\t\t\t\t\t<Params name="Params">\n'
-        f'{device_param_range("Width", "800", str(raster_w))}'
-        f'{device_param_range("Height", "600", str(raster_h))}'
-        f'\t\t\t\t\t\t</Params>\n'
-        f'\t\t\t\t\t</OutputDeviceVirtual>\n'
-        f'\t\t\t\t</OutputDevice>\n'
-        f'\t\t\t</Screen>\n'
+        f'{screens_xml}'
         f'\t\t</screens>\n'
         f'\t\t<SoftEdging>\n'
         f'\t\t\t<Params name="Soft Edge">\n'

--- a/src/app.py
+++ b/src/app.py
@@ -407,7 +407,43 @@ def _migrate_to_v0_8(project):
             layer['canvas_id'] = default_canvas_id
 
     project['format_version'] = CURRENT_FORMAT_VERSION
+    _mirror_active_canvas_to_root(project)
     return project, True
+
+
+def _mirror_active_canvas_to_root(project):
+    """Slice 6 compatibility shim.
+
+    Source-of-truth for raster fields moved to the per-canvas object. The
+    server keeps writing the mirrored values back onto the project root
+    (raster_width, raster_height, show_raster_*, *_perspective) so that:
+      - Older test code reading project['raster_width'] keeps working.
+      - A client that hasn't yet upgraded to per-canvas reads still sees
+        sane numbers (the active canvas's raster).
+      - The PNG / PDF / PSD export paths (which still read root raster
+        for the export size) keep working until they're rewritten per
+        canvas in a later slice.
+
+    No-op on projects with no canvases (pre-Slice-1 legacy state).
+    """
+    if not isinstance(project, dict):
+        return project
+    canvases = project.get('canvases') or []
+    if not canvases:
+        return project
+    active_id = project.get('active_canvas_id')
+    active = next((c for c in canvases if isinstance(c, dict) and c.get('id') == active_id), None)
+    if active is None:
+        active = canvases[0]
+    for key in (
+        'raster_width', 'raster_height',
+        'show_raster_width', 'show_raster_height',
+        'data_flow_perspective', 'power_perspective',
+    ):
+        val = active.get(key)
+        if val is not None:
+            project[key] = val
+    return project
 
 
 def _build_initial_project():
@@ -1053,9 +1089,29 @@ def new_project():
 
 @app.route('/api/project', methods=['POST'])
 def save_project():
-    data = request.json
+    data = request.json or {}
+    # Slice 6: source-of-truth for raster lives on the active canvas. If the
+    # client sent root-level raster_* fields without a canvases payload
+    # (backwards-compat clients / older tests), propagate those into the
+    # active canvas so the canvas object reflects the new values. Then
+    # re-mirror canvas → root so root stays consistent.
+    canvases = current_project.get('canvases') or []
+    if canvases and not data.get('canvases'):
+        active_id = current_project.get('active_canvas_id')
+        active = next(
+            (c for c in canvases if isinstance(c, dict) and c.get('id') == active_id),
+            canvases[0],
+        )
+        for key in (
+            'raster_width', 'raster_height',
+            'show_raster_width', 'show_raster_height',
+            'data_flow_perspective', 'power_perspective',
+        ):
+            if key in data and data[key] is not None:
+                active[key] = data[key]
     current_project.update(data)
     current_project['is_pristine'] = False
+    _mirror_active_canvas_to_root(current_project)
     sync_next_layer_id()
     log_event('save_project', {'name': current_project.get('name')})
     return jsonify({'status': 'success'})
@@ -1514,6 +1570,9 @@ def update_canvas(canvas_id):
             canvas[key] = val
             changed[key] = val
     current_project['is_pristine'] = False
+    # Slice 6: keep the project-root raster mirror in sync so any
+    # client/test still reading root sees the latest active-canvas values.
+    _mirror_active_canvas_to_root(current_project)
     log_event('canvas_update', {'id': canvas_id, 'changed': changed})
     socketio.emit('project_updated', current_project)
     return jsonify(current_project)

--- a/src/app.py
+++ b/src/app.py
@@ -1403,6 +1403,35 @@ def _find_canvas(canvas_id):
     return None
 
 
+def _next_canvas_workspace_position():
+    """Pick a workspace position for a freshly created canvas.
+
+    Auto-places the new canvas to the right of the existing rightmost
+    canvas, leaving a horizontal gap controlled by the ``canvasGap``
+    server preference (default 50 px). Vertical position resets to 0
+    so canvases line up along the workspace's top edge by default.
+
+    Returns ``(workspace_x, workspace_y)``.
+    """
+    canvases = current_project.get('canvases') or []
+    gap = 50
+    try:
+        pref_gap = (server_preferences or {}).get('canvasGap')
+        if pref_gap is not None:
+            pref_gap = float(pref_gap)
+            if pref_gap >= 0:
+                gap = pref_gap
+    except (TypeError, ValueError):
+        pass
+    if not canvases:
+        return (0, 0)
+    rightmost = max(
+        (c.get('workspace_x') or 0) + (c.get('raster_width') or 0)
+        for c in canvases
+    )
+    return (rightmost + gap, 0)
+
+
 @app.route('/api/canvas', methods=['POST'])
 def create_canvas():
     data = request.json or {}
@@ -1416,12 +1445,13 @@ def create_canvas():
     active = _find_canvas(current_project.get('active_canvas_id')) or (
         canvases[0] if canvases else None
     )
+    ws_x, ws_y = _next_canvas_workspace_position()
     canvas = {
         'id': new_id,
         'name': data.get('name') or default_name,
         'color': data.get('color') or _next_canvas_color(),
-        'workspace_x': 0,
-        'workspace_y': 0,
+        'workspace_x': ws_x,
+        'workspace_y': ws_y,
         'raster_width': (active or {}).get('raster_width', 1920),
         'raster_height': (active or {}).get('raster_height', 1080),
         'show_raster_width': (active or {}).get('show_raster_width', 1920),
@@ -1506,6 +1536,12 @@ def duplicate_canvas(canvas_id):
     new_canvas['id'] = new_id
     new_canvas['name'] = f"{src.get('name', 'Canvas')} Copy"
     new_canvas['color'] = _next_canvas_color()
+    # Auto-place the duplicate to the right of the existing canvases so it
+    # doesn't visually overlap its source. (Computed BEFORE the duplicate is
+    # appended, so the rightmost-edge calc covers existing canvases only.)
+    ws_x, ws_y = _next_canvas_workspace_position()
+    new_canvas['workspace_x'] = ws_x
+    new_canvas['workspace_y'] = ws_y
     current_project['canvases'].append(new_canvas)
     # Clone every layer in the source canvas, with a new layer id.
     src_layers = [

--- a/src/app.py
+++ b/src/app.py
@@ -3454,7 +3454,7 @@ if __name__ == '__main__':
     local_ip = get_local_ip()
 
     # Allow `--port N` (or `--port=N`) on the command line to override 8050.
-    # Useful when running under Claude Preview alongside other Flask apps.
+    # Useful when running alongside other Flask apps on the same machine.
     _port = 8050
     _argv = sys.argv[1:]
     for i, a in enumerate(_argv):

--- a/src/app.py
+++ b/src/app.py
@@ -1432,6 +1432,33 @@ def _next_canvas_workspace_position():
     return (rightmost + gap, 0)
 
 
+def _next_duplicate_canvas_name(src_name):
+    """Pick a name for the duplicate of a canvas named ``src_name``.
+
+    Strips a trailing " <number>" from the source name to get the base,
+    then finds the highest existing trailing-number across all canvases
+    sharing that base, and returns "<base> <max+1>". Examples:
+
+        "Canvas 2" + ["Canvas 1", "Canvas 2"] → "Canvas 3"
+        "EDC"      + ["EDC"]                  → "EDC 1"
+        "EDC 1"    + ["EDC", "EDC 1"]         → "EDC 2"
+    """
+    import re
+    name = (src_name or 'Canvas').strip()
+    m = re.match(r'^(.*?)\s+(\d+)$', name)
+    base = (m.group(1) if m else name).strip() or 'Canvas'
+    canvases = current_project.get('canvases') or []
+    pat = re.compile(r'^' + re.escape(base) + r'(?:\s+(\d+))?$')
+    max_n = 0
+    for c in canvases:
+        cm = pat.match((c.get('name') or '').strip())
+        if cm:
+            n = int(cm.group(1)) if cm.group(1) else 0
+            if n > max_n:
+                max_n = n
+    return f"{base} {max_n + 1}"
+
+
 @app.route('/api/canvas', methods=['POST'])
 def create_canvas():
     data = request.json or {}
@@ -1534,7 +1561,7 @@ def duplicate_canvas(canvas_id):
     new_id = _next_canvas_id()
     new_canvas = json.loads(json.dumps(src))
     new_canvas['id'] = new_id
-    new_canvas['name'] = f"{src.get('name', 'Canvas')} Copy"
+    new_canvas['name'] = _next_duplicate_canvas_name(src.get('name', 'Canvas'))
     new_canvas['color'] = _next_canvas_color()
     # Auto-place the duplicate to the right of the existing canvases so it
     # doesn't visually overlap its source. (Computed BEFORE the duplicate is

--- a/src/launcher_mac.py
+++ b/src/launcher_mac.py
@@ -266,7 +266,7 @@ def main():
     # Auto-open browser on launch
     webbrowser.open(get_display_url(settings))
 
-    # Run the menu bar app (blocks on main thread — required by macOS)
+    # Run the menu bar app (blocks on main thread, required by macOS)
     run_menubar(settings)
 
 

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.7.7.4',
-            'CFBundleVersion': '0.7.7.4',
+            'CFBundleShortVersionString': '0.8.0',
+            'CFBundleVersion': '0.8.0',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -452,12 +452,20 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
     background: #1e1e1e;
     border-top: 1px solid #3a3a3a;
     width: 260px;
-    min-height: 200px;
-    max-height: 280px;
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
+    /* Expanded state: bounded so it never grows past a reasonable preview
+       size, but the layer-groups list above gets every spare pixel. */
+    min-height: 0;
+    max-height: 200px;
 }
+#help-tooltip-panel.collapsed {
+    /* Collapsed: header only, body hidden. Matches the Notes panel idiom
+       so the user can still see "Help" and re-open it on demand. */
+    max-height: none;
+}
+#help-tooltip-panel.collapsed #help-tooltip-body { display: none; }
 #help-tooltip-header {
     display: flex;
     justify-content: space-between;
@@ -467,7 +475,13 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
     font-size: 13px;
     font-weight: 600;
     color: #ccc;
+    cursor: pointer;
 }
+#help-tooltip-panel.collapsed #help-tooltip-header { border-bottom: none; }
+#help-tooltip-panel:not(.collapsed) #help-tooltip-toggle::before { content: '▼'; }
+#help-tooltip-panel.collapsed #help-tooltip-toggle::before { content: '▶'; }
+#help-tooltip-panel #help-tooltip-toggle { font-size: 0; }
+#help-tooltip-panel #help-tooltip-toggle::before { font-size: 10px; }
 #help-tooltip-body {
     padding: 10px 12px;
     font-size: 12px;

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -364,12 +364,14 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 .layer-btn:hover { color: #e0e0e0; }
 .layer-btn:disabled { color: #444; cursor: default; }
 .layer-btn:disabled:hover { color: #444; }
-/* Compact reorder arrows (Slice 2.5). */
+/* Compact reorder arrows (Slice 2.5). Stacked vertically. */
+.layer-arrows { display: flex; flex-direction: column; gap: 1px; }
 .layer-btn.layer-move-up,
 .layer-btn.layer-move-down {
-    font-size: 10px;
-    padding: 2px 3px;
+    font-size: 9px;
+    padding: 0 4px;
     line-height: 1;
+    height: 11px;
 }
 .layer-item.drag-over { outline: 2px solid #4A90E2; }
 .layer-item.drag-over { outline: none; }

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -74,9 +74,11 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
     border-right: none;
     border-left: none;
 }
-#right-sidebar > .panel { margin: 0 10px 0 10px; flex: 1; overflow-y: auto; min-height: 0; }
+#right-sidebar > .panel { margin: 0 10px 0 10px; flex: 1; overflow: hidden; min-height: 0; display: flex; flex-direction: column; }
+#right-sidebar > .panel > .panel-content { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+#right-sidebar > .panel > .panel-content > #layers-list { flex: 1; min-height: 0; overflow-y: auto; }
 .panel { background: #2a2a2a; border: 1px solid #3a3a3a; border-radius: 6px; margin-bottom: 10px; }
-.panel-header { padding: 12px; border-bottom: 1px solid #3a3a3a; }
+.panel-header { padding: 12px; border-bottom: 1px solid #3a3a3a; flex-shrink: 0; }
 .panel-header h2 { font-size: 12px; color: #4A90E2; text-transform: uppercase; margin: 0; }
 .panel-content { padding: 12px; box-sizing: border-box; }
 .image-only { display: none; }
@@ -463,7 +465,8 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 #help-tooltip-panel.collapsed {
     /* Collapsed: header only, body hidden. Matches the Notes panel idiom
        so the user can still see "Help" and re-open it on demand. */
-    max-height: none;
+    min-height: 36px;
+    max-height: 36px;
 }
 #help-tooltip-panel.collapsed #help-tooltip-body { display: none; }
 #help-tooltip-header {
@@ -476,12 +479,9 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
     font-weight: 600;
     color: #ccc;
     cursor: pointer;
+    flex-shrink: 0;
 }
 #help-tooltip-panel.collapsed #help-tooltip-header { border-bottom: none; }
-#help-tooltip-panel:not(.collapsed) #help-tooltip-toggle::before { content: '▼'; }
-#help-tooltip-panel.collapsed #help-tooltip-toggle::before { content: '▶'; }
-#help-tooltip-panel #help-tooltip-toggle { font-size: 0; }
-#help-tooltip-panel #help-tooltip-toggle::before { font-size: 10px; }
 #help-tooltip-body {
     padding: 10px 12px;
     font-size: 12px;

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -118,7 +118,7 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 .checkbox-row input[type="checkbox"] { margin: 0; }
 .checkbox-row label { color: #e0e0e0; font-size: 12px; margin: 0; text-transform: none; cursor: pointer; }
 
-#layers-list { margin-bottom: 10px; max-height: 400px; overflow-y: auto; overflow-x: hidden; scrollbar-gutter: stable; }
+#layers-list { margin-bottom: 10px; overflow-y: auto; overflow-x: hidden; scrollbar-gutter: stable; }
 .layer-item { background: #1a1a1a; border: 1px solid #3a3a3a; border-radius: 4px; padding: 10px; margin-bottom: 8px; cursor: pointer; box-sizing: border-box; width: 100%; }
 .layer-item:hover { background: #2a2a2a; }
 .layer-item.active { border-color: #4A90E2; background: #1a2a3a; }

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -719,3 +719,172 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
     background: #2a2a2a;
     border-color: #555;
 }
+
+/* ----------------------------------------------------------------------
+ * Multi-canvas (v0.8 Slice 2) — sidebar canvas group styling.
+ * Each canvas gets a header (color swatch, name, eye toggle, action menu,
+ * drag handle) and a body with its layers + a per-canvas + Add Screen.
+ * Active canvas is highlighted with a faint colored ring matching the
+ * canvas's color field.
+ * ---------------------------------------------------------------------- */
+.canvas-group {
+    --canvas-color: #4A90E2;
+    background: #161616;
+    border: 1px solid #2c2c2c;
+    border-radius: 6px;
+    margin-bottom: 12px;
+    overflow: hidden;
+    transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.canvas-group.active {
+    border-color: var(--canvas-color);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--canvas-color) 35%, transparent);
+}
+.canvas-group.hidden { opacity: 0.55; }
+.canvas-group.dragging { opacity: 0.4; }
+.canvas-group.drag-target {
+    outline: 2px dashed var(--canvas-color);
+    outline-offset: -2px;
+}
+.canvas-group-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    background: linear-gradient(180deg, #1d1d1d 0%, #181818 100%);
+    border-bottom: 1px solid #262626;
+    cursor: pointer;
+    user-select: none;
+}
+.canvas-drag-handle {
+    color: #666;
+    font-size: 11px;
+    line-height: 1;
+    cursor: grab;
+    padding: 0 2px;
+}
+.canvas-drag-handle:active { cursor: grabbing; }
+.canvas-color-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 1px solid rgba(255,255,255,0.18);
+    flex: 0 0 auto;
+}
+.canvas-name-input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    color: #e8e8e8;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+.canvas-name-input:not([readonly]) {
+    background: #1a1a1a;
+    border-color: #4A90E2;
+}
+.canvas-vis-btn,
+.canvas-menu-btn {
+    background: transparent;
+    border: none;
+    color: #999;
+    cursor: pointer;
+    padding: 2px 6px;
+    font-size: 13px;
+    line-height: 1;
+    border-radius: 3px;
+}
+.canvas-vis-btn:hover,
+.canvas-menu-btn:hover { background: #2a2a2a; color: #fff; }
+.canvas-group-body { padding: 8px 8px 0; }
+.canvas-group-body:empty { padding: 0; }
+.canvas-group-body .layer-item {
+    border-left: 3px solid var(--canvas-color);
+}
+.canvas-group-footer {
+    padding: 4px 8px 8px;
+}
+.canvas-group-footer .canvas-add-screen-btn {
+    width: 100%;
+    font-size: 12px;
+    padding: 6px 8px;
+}
+
+/* Action menu popup (Rename / Duplicate / Change Color / Delete). */
+.canvas-menu-popup {
+    background: #1f1f1f;
+    border: 1px solid #3a3a3a;
+    border-radius: 5px;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.45);
+    min-width: 160px;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+}
+.canvas-menu-popup button {
+    background: transparent;
+    border: none;
+    color: #e0e0e0;
+    text-align: left;
+    padding: 7px 10px;
+    font-size: 12.5px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+.canvas-menu-popup button:hover { background: #2c2c2c; }
+.canvas-menu-popup button.danger { color: #e57373; }
+.canvas-menu-popup button.danger:hover { background: #3a1f1f; color: #ffb4b4; }
+
+/* Color picker popup (palette swatches + hex). */
+.canvas-color-popup {
+    background: #1f1f1f;
+    border: 1px solid #3a3a3a;
+    border-radius: 5px;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.45);
+    padding: 10px;
+    min-width: 200px;
+}
+.canvas-color-swatches {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+    margin-bottom: 8px;
+}
+.canvas-color-swatches .color-swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid #2c2c2c;
+    cursor: pointer;
+    padding: 0;
+}
+.canvas-color-swatches .color-swatch:hover { border-color: #fff; }
+.canvas-color-hex-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.canvas-color-hex-row label { color: #aaa; font-size: 11px; }
+.canvas-color-hex-row input {
+    flex: 1;
+    background: #111;
+    border: 1px solid #333;
+    color: #e0e0e0;
+    border-radius: 3px;
+    padding: 4px 6px;
+    font-size: 12px;
+    font-family: monospace;
+}
+.canvas-color-hex-row .canvas-color-apply {
+    background: #2d4a7a;
+    border: none;
+    color: #fff;
+    padding: 4px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+}
+.canvas-color-hex-row .canvas-color-apply:hover { background: #3a5d96; }

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -39,7 +39,7 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 /* ── Collapsible side panels ─────────────────────────────────────────── */
 /* Each toggle button hugs the inner edge of its sidebar. Click to hide
    the entire panel; click again to bring it back. The two sides are
-   independent and the state persists across reloads (localStorage —
+   independent and the state persists across reloads (localStorage,
    see app.js initSidebarToggles). */
 .sidebar-toggle {
     position: fixed;
@@ -59,7 +59,7 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 }
 .sidebar-toggle:hover { background: #3a3a3a; color: #fff; }
 /* The actual left/right pixel positions are set in JS (initSidebarToggles)
-   based on the sidebar's live geometry — this lets the toggle hug the
+   based on the sidebar's live geometry, this lets the toggle hug the
    sidebar's inner edge regardless of monitor size, window resize, or any
    future change to sidebar width. */
 #left-sidebar-toggle { border-left: none; border-radius: 0 4px 4px 0; }
@@ -746,7 +746,7 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 }
 
 /* ----------------------------------------------------------------------
- * Multi-canvas (v0.8 Slice 2) — sidebar canvas group styling.
+ * Multi-canvas (v0.8 Slice 2), sidebar canvas group styling.
  * Each canvas gets a header (color swatch, name, eye toggle, action menu,
  * drag handle) and a body with its layers + a per-canvas + Add Screen.
  * Active canvas is highlighted with a faint colored ring matching the

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -765,7 +765,11 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
     border-color: var(--canvas-color);
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--canvas-color) 35%, transparent);
 }
-.canvas-group.hidden { opacity: 0.55; }
+/* v0.8 Slice 9: dim only the layer rows + footer of a hidden canvas
+   group, leaving the header (and especially the eye toggle) crisp so
+   the user can re-enable visibility without hunting through faded UI. */
+.canvas-group.hidden .canvas-group-body,
+.canvas-group.hidden .canvas-group-footer { opacity: 0.45; }
 .canvas-group.dragging { opacity: 0.4; }
 .canvas-group.drag-target {
     outline: 2px dashed var(--canvas-color);

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -359,9 +359,18 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 }
 .layer-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px; }
 .layer-name { font-size: 13px; color: #e0e0e0; font-weight: 600; }
-.layer-controls { display: flex; gap: 5px; }
+.layer-controls { display: flex; gap: 5px; align-items: center; }
 .layer-btn { background: transparent; border: none; color: #888; cursor: pointer; padding: 2px 6px; font-size: 14px; }
 .layer-btn:hover { color: #e0e0e0; }
+.layer-btn:disabled { color: #444; cursor: default; }
+.layer-btn:disabled:hover { color: #444; }
+/* Compact reorder arrows (Slice 2.5). */
+.layer-btn.layer-move-up,
+.layer-btn.layer-move-down {
+    font-size: 10px;
+    padding: 2px 3px;
+    line-height: 1;
+}
 .layer-item.drag-over { outline: 2px solid #4A90E2; }
 .layer-item.drag-over { outline: none; }
 .layer-item.drag-over-top { box-shadow: inset 0 2px 0 0 #4A90E2; }
@@ -807,7 +816,7 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 .canvas-group-footer {
     padding: 4px 8px 8px;
 }
-.canvas-group-footer .canvas-add-screen-btn {
+.canvas-group-footer .canvas-add-btn {
     width: 100%;
     font-size: 12px;
     padding: 6px 8px;

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -9083,7 +9083,7 @@ class LEDRasterApp {
                         });
                         if (typeof this._toast === 'function') {
                             this._toast(
-                                'Project upgraded to multi-canvas format (v0.8). Save to keep changes — older app versions can no longer open this file.',
+                                'Project upgraded to multi-canvas format (v0.8). Save to keep changes. Older app versions can no longer open this file.',
                                 false,
                                 10000
                             );
@@ -11626,7 +11626,7 @@ class LEDRasterApp {
                                     });
                                     if (typeof this._toast === 'function') {
                                         this._toast(
-                                            'Project upgraded to multi-canvas format (v0.8). Save to keep changes — older app versions can no longer open this file.',
+                                            'Project upgraded to multi-canvas format (v0.8). Save to keep changes. Older app versions can no longer open this file.',
                                             false,
                                             10000
                                         );

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10455,6 +10455,42 @@ class LEDRasterApp {
         }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
     }
 
+    /**
+     * Slice 5: after a canvas-drag drop, warn (non-blocking) if the
+     * dragged canvas's workspace bounds intersect any other visible
+     * canvas's bounds. Does NOT auto-snap or reject — just toasts.
+     * Bounds use the active view's raster (pixel-map vs show-look),
+     * matching what the user sees in `_drawCanvasOutline`.
+     */
+    _checkCanvasOverlapAndToast(canvasId) {
+        if (!this.project || !Array.isArray(this.project.canvases)) return;
+        const useShow = !!(window.canvasRenderer && typeof window.canvasRenderer.isShowLookView === 'function'
+            && window.canvasRenderer.isShowLookView());
+        const bounds = (c) => {
+            const w = (useShow && c.show_raster_width) || c.raster_width || 0;
+            const h = (useShow && c.show_raster_height) || c.raster_height || 0;
+            const x = c.workspace_x || 0;
+            const y = c.workspace_y || 0;
+            return { x, y, w, h };
+        };
+        const dragged = this.project.canvases.find(c => c && c.id === canvasId);
+        if (!dragged || dragged.visible === false) return;
+        const a = bounds(dragged);
+        if (a.w <= 0 || a.h <= 0) return;
+        const intersects = (a, b) =>
+            a.x < b.x + b.w && a.x + a.w > b.x &&
+            a.y < b.y + b.h && a.y + a.h > b.y;
+        for (const other of this.project.canvases) {
+            if (!other || other.id === canvasId || other.visible === false) continue;
+            const b = bounds(other);
+            if (b.w <= 0 || b.h <= 0) continue;
+            if (intersects(a, b)) {
+                this._toast('Canvases overlapping — visual rendering may be confusing.', true);
+                return;
+            }
+        }
+    }
+
     deleteCanvas(canvasId) {
         return fetch(`/api/canvas/${canvasId}`, { method: 'DELETE' })
             .then(r => r.json().then(body => ({ ok: r.ok, body })))

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10456,6 +10456,42 @@ class LEDRasterApp {
     }
 
     /**
+     * Slice 7: reassign a layer to a different canvas via the existing
+     * Slice-2 endpoint. ``mode`` is "move" or "duplicate".
+     * - "move": same layer id, offsets reset to 0,0; selection follows.
+     * - "duplicate": new layer id appended in target canvas; original
+     *   stays put and remains selected.
+     */
+    moveLayerCrossCanvas(layerId, targetCanvasId, mode) {
+        const wantMove = (mode !== 'duplicate');
+        if (typeof this.saveState === 'function') {
+            this.saveState(wantMove ? 'Move Layer to Canvas' : 'Duplicate Layer to Canvas');
+        }
+        return fetch(`/api/layer/${layerId}/canvas`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ canvas_id: targetCanvasId, mode: wantMove ? 'move' : 'duplicate' })
+        }).then(r => r.json()).then(data => {
+            this._applyProjectUpdate(data);
+            // After move: the same layer id now lives in the target canvas;
+            // make sure it stays the current layer so the sidebar follows.
+            if (wantMove && this.project && Array.isArray(this.project.layers)) {
+                const moved = this.project.layers.find(l => l.id === layerId);
+                if (moved) {
+                    this.currentLayer = moved;
+                    if (this.project) this.project.active_canvas_id = targetCanvasId;
+                    if (typeof this.renderLayers === 'function') this.renderLayers();
+                    if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
+                        window.canvasRenderer.render();
+                    }
+                }
+            }
+            // For duplicate: leave selection on the original (default behavior).
+            return data;
+        });
+    }
+
+    /**
      * Slice 5: after a canvas-drag drop, warn (non-blocking) if the
      * dragged canvas's workspace bounds intersect any other visible
      * canvas's bounds. Does NOT auto-snap or reject — just toasts.

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -4497,7 +4497,7 @@ class LEDRasterApp {
         }
     }
 
-    _toast(msg, isError) {
+    _toast(msg, isError, durationMs) {
         let host = document.getElementById('app-toast-host');
         if (!host) {
             host = document.createElement('div');
@@ -4506,14 +4506,15 @@ class LEDRasterApp {
             document.body.appendChild(host);
         }
         const t = document.createElement('div');
-        t.style.cssText = `padding:10px 16px; border-radius:6px; font-size:13px; color:#fff; background:${isError ? '#a8324b' : '#2d4a7a'}; box-shadow:0 2px 12px rgba(0,0,0,0.4); opacity:0; transition:opacity 0.18s ease;`;
+        t.style.cssText = `padding:10px 16px; border-radius:6px; font-size:13px; color:#fff; background:${isError ? '#a8324b' : '#2d4a7a'}; box-shadow:0 2px 12px rgba(0,0,0,0.4); opacity:0; transition:opacity 0.18s ease; max-width: 520px; text-align: center;`;
         t.textContent = msg;
         host.appendChild(t);
         requestAnimationFrame(() => { t.style.opacity = '1'; });
+        const lifetime = (typeof durationMs === 'number' && durationMs > 0) ? durationMs : 2400;
         setTimeout(() => {
             t.style.opacity = '0';
             setTimeout(() => t.remove(), 220);
-        }, 2400);
+        }, lifetime);
     }
 
     // A panel is "verified" if its `source` flags it as cross-checked against
@@ -9069,6 +9070,25 @@ class LEDRasterApp {
                     setTimeout(() => {
                         document.getElementById('status-message').textContent = 'Ready';
                     }, 2000);
+                    // Slice 12: same migration toast path as loadProjectFromFile.
+                    // Recent-file loads also go through PUT /api/project so the
+                    // server emits _migration_notice when the cached payload
+                    // lacked format_version: "0.8".
+                    if (data && data._migration_notice) {
+                        delete this.project._migration_notice;
+                        sendClientLog('migration_notice_shown', {
+                            name: this.project.name,
+                            layers: this.project.layers ? this.project.layers.length : 0,
+                            source: 'recent'
+                        });
+                        if (typeof this._toast === 'function') {
+                            this._toast(
+                                'Project upgraded to multi-canvas format (v0.8). Save to keep changes — older app versions can no longer open this file.',
+                                false,
+                                10000
+                            );
+                        }
+                    }
                 })
                 .catch(() => {
                     this.resetHistory('Initial State');
@@ -11591,6 +11611,27 @@ class LEDRasterApp {
                                 }, 2000);
                                 this.addToRecentFiles(this.project);
                                 sendClientLog('load_project_file_success', { name: this.project.name, layers: this.project.layers ? this.project.layers.length : 0 });
+                                // Slice 12: server flagged this file as
+                                // freshly migrated from v0.7. Show a one-time
+                                // toast and strip the transient flag so it
+                                // never ends up in the saved JSON. The toast
+                                // is suppressed automatically on subsequent
+                                // loads because the saved file now carries
+                                // format_version: "0.8".
+                                if (data && data._migration_notice) {
+                                    delete this.project._migration_notice;
+                                    sendClientLog('migration_notice_shown', {
+                                        name: this.project.name,
+                                        layers: this.project.layers ? this.project.layers.length : 0
+                                    });
+                                    if (typeof this._toast === 'function') {
+                                        this._toast(
+                                            'Project upgraded to multi-canvas format (v0.8). Save to keep changes — older app versions can no longer open this file.',
+                                            false,
+                                            10000
+                                        );
+                                    }
+                                }
                             })
                             .catch((err) => {
                                 sendClientLog('load_project_file_error', { message: err.message });

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10429,6 +10429,7 @@ class LEDRasterApp {
     }
 
     addCanvas() {
+        if (typeof this.saveState === 'function') this.saveState('Add Canvas');
         return fetch('/api/canvas', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -10436,7 +10437,24 @@ class LEDRasterApp {
         }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
     }
 
-    updateCanvas(canvasId, patch) {
+    // Canvas mutation routed through one helper so every mutating call
+    // gets an undo entry. Most callers don't pass `opts`; canvas-drag
+    // mouseup passes skipSaveState because a 'Move Canvas' snapshot was
+    // already taken at drag-start.
+    updateCanvas(canvasId, patch, opts) {
+        if (typeof this.saveState === 'function' && !(opts && opts.skipSaveState)) {
+            // Pick the most informative undo label from the patch keys.
+            const keys = patch ? Object.keys(patch) : [];
+            let label = 'Update Canvas';
+            if (keys.includes('name')) label = 'Rename Canvas';
+            else if (keys.includes('color')) label = 'Change Canvas Color';
+            else if (keys.includes('visible')) label = 'Toggle Canvas Visibility';
+            else if (keys.includes('workspace_x') || keys.includes('workspace_y')) label = 'Move Canvas';
+            else if (keys.includes('raster_width') || keys.includes('raster_height')
+                || keys.includes('show_raster_width') || keys.includes('show_raster_height')) label = 'Resize Canvas';
+            else if (keys.includes('data_flow_perspective') || keys.includes('power_perspective')) label = 'Change Perspective';
+            this.saveState(label);
+        }
         return fetch(`/api/canvas/${canvasId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
@@ -10451,9 +10469,16 @@ class LEDRasterApp {
      * - "duplicate": new layer id appended in target canvas; original
      *   stays put and remains selected.
      */
-    moveLayerCrossCanvas(layerId, targetCanvasId, mode) {
+    moveLayerCrossCanvas(layerId, targetCanvasId, mode, opts) {
         const wantMove = (mode !== 'duplicate');
-        if (typeof this.saveState === 'function') {
+        // Canvas-drag callers pass skipSaveState:true because the drag-start
+        // already pushed a 'Move Layers' snapshot. Without this option we'd
+        // capture a SECOND snapshot here mid-drag, which contains the
+        // dragged-but-not-yet-cross-canvas state (offset_x at the dragged
+        // position, layer still in source canvas) — so single undo flew
+        // the layer to weird intermediate coords instead of jumping back
+        // to pre-drag.
+        if (typeof this.saveState === 'function' && !(opts && opts.skipSaveState)) {
             this.saveState(wantMove ? 'Move Layer to Canvas' : 'Duplicate Layer to Canvas');
         }
         return fetch(`/api/layer/${layerId}/canvas`, {
@@ -10478,6 +10503,49 @@ class LEDRasterApp {
             // For duplicate: leave selection on the original (default behavior).
             return data;
         });
+    }
+
+    /**
+     * Multi-select cross-canvas drag: PUT each selected layer's canvas
+     * sequentially (avoids server race), then sync state so all moved
+     * layers stay selected and the active canvas follows. Mode applies
+     * to ALL layers in the batch (move OR duplicate, not mixed).
+     */
+    async moveLayersCrossCanvas(layerIds, targetCanvasId, mode, opts) {
+        const wantMove = (mode !== 'duplicate');
+        if (!Array.isArray(layerIds) || layerIds.length === 0) return;
+        // Same skipSaveState convention as moveLayerCrossCanvas — canvas-drag
+        // callers already snapshotted pre-drag.
+        if (typeof this.saveState === 'function' && !(opts && opts.skipSaveState)) {
+            this.saveState(wantMove
+                ? `Move ${layerIds.length} Layers to Canvas`
+                : `Duplicate ${layerIds.length} Layers to Canvas`);
+        }
+        let lastData = null;
+        for (const id of layerIds) {
+            const r = await fetch(`/api/layer/${id}/canvas`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ canvas_id: targetCanvasId, mode: wantMove ? 'move' : 'duplicate' })
+            });
+            lastData = await r.json();
+        }
+        if (lastData) {
+            this._applyProjectUpdate(lastData);
+            if (wantMove && this.project && Array.isArray(this.project.layers)) {
+                // Re-select all moved layers (same ids); set active canvas
+                // to target so the sidebar reflects the destination.
+                this.project.active_canvas_id = targetCanvasId;
+                this.selectedLayerIds = new Set(layerIds);
+                const primary = this.project.layers.find(l => l.id === layerIds[0]);
+                if (primary) this.currentLayer = primary;
+                if (typeof this.renderLayers === 'function') this.renderLayers();
+                if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
+                    window.canvasRenderer.render();
+                }
+            }
+        }
+        return lastData;
     }
 
     /**
@@ -10517,6 +10585,7 @@ class LEDRasterApp {
     }
 
     deleteCanvas(canvasId) {
+        if (typeof this.saveState === 'function') this.saveState('Delete Canvas');
         return fetch(`/api/canvas/${canvasId}`, { method: 'DELETE' })
             .then(r => r.json().then(body => ({ ok: r.ok, body })))
             .then(({ ok, body }) => {
@@ -10529,6 +10598,7 @@ class LEDRasterApp {
     }
 
     duplicateCanvas(canvasId) {
+        if (typeof this.saveState === 'function') this.saveState('Duplicate Canvas');
         return fetch(`/api/canvas/${canvasId}/duplicate`, { method: 'POST' })
             .then(r => r.json()).then(data => this._applyProjectUpdate(data));
     }
@@ -10626,6 +10696,7 @@ class LEDRasterApp {
         if (from < 0 || to < 0 || from === to) return;
         ids.splice(from, 1);
         ids.splice(ids.indexOf(targetId), 0, draggedId);
+        if (typeof this.saveState === 'function') this.saveState('Reorder Canvases');
         return fetch('/api/canvas/reorder', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -10634,6 +10705,9 @@ class LEDRasterApp {
     }
 
     moveLayerToCanvas(layerId, canvasId, mode = 'move') {
+        if (typeof this.saveState === 'function') {
+            this.saveState(mode === 'duplicate' ? 'Duplicate Layer to Canvas' : 'Move Layer to Canvas');
+        }
         return fetch(`/api/layer/${layerId}/canvas`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10013,8 +10013,10 @@ class LEDRasterApp {
                         ${lockBadge}
                     </div>
                     <div class="layer-controls">
-                        <button class="layer-btn layer-move-up" data-layer-id="${layer.id}" title="Move up within canvas">▲</button>
-                        <button class="layer-btn layer-move-down" data-layer-id="${layer.id}" title="Move down within canvas">▼</button>
+                        <div class="layer-arrows">
+                            <button class="layer-btn layer-move-up" data-layer-id="${layer.id}" title="Move up within canvas">▲</button>
+                            <button class="layer-btn layer-move-down" data-layer-id="${layer.id}" title="Move down within canvas">▼</button>
+                        </div>
                         <button class="layer-btn" onclick="app.toggleLayerVisibility(${layer.id})" title="Toggle Visibility">
                             ${layer.visible ? '👁' : '👁‍🗨'}
                         </button>

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2133,9 +2133,11 @@ class LEDRasterApp {
             });
         });
         
-        document.getElementById('btn-add-layer').addEventListener('click', () => {
-            this.openPresetPicker();
-        });
+        // v0.8 Slice 2.5: the global "+ Add Screen / + Add Image / + Add Text"
+        // and "▲ Up / ▼ Down" buttons were removed. Per-canvas "+ Add" chooser
+        // (built in buildCanvasGroupEl) and per-layer ▲▼ arrows now own those
+        // affordances. We still wire the file-input change handler because
+        // the per-canvas "Image / Logo" chooser entry reuses it.
         const addCanvasBtn = document.getElementById('btn-add-canvas');
         if (addCanvasBtn) {
             addCanvasBtn.addEventListener('click', () => this.addCanvas());
@@ -2145,13 +2147,8 @@ class LEDRasterApp {
             savePresetBtn.addEventListener('click', () => this.openPresetSaveModal());
         }
         this.setupPresetModals();
-        const addImageBtn = document.getElementById('btn-add-image');
         const addImageInput = document.getElementById('add-image-input');
-        if (addImageBtn && addImageInput) {
-            addImageBtn.addEventListener('click', () => {
-                this.imageFileAction = 'add';
-                addImageInput.click();
-            });
+        if (addImageInput) {
             addImageInput.addEventListener('change', (e) => {
                 this.handleImageFileSelection(e);
             });
@@ -2165,30 +2162,8 @@ class LEDRasterApp {
             });
         }
 
-        const addTextBtn = document.getElementById('btn-add-text');
-        if (addTextBtn) {
-            addTextBtn.addEventListener('click', () => this.addTextLayer());
-        }
-
         // Text layer sidebar controls
         this.setupTextLayerControls();
-
-        const layerUpBtn = document.getElementById('btn-layer-up');
-        const layerDownBtn = document.getElementById('btn-layer-down');
-        if (layerUpBtn) {
-            layerUpBtn.addEventListener('click', () => {
-                if (this.currentLayer) {
-                    this.moveLayerById(this.currentLayer.id, -1);
-                }
-            });
-        }
-        if (layerDownBtn) {
-            layerDownBtn.addEventListener('click', () => {
-                if (this.currentLayer) {
-                    this.moveLayerById(this.currentLayer.id, 1);
-                }
-            });
-        }
 
         const toggleLockBtn = document.getElementById('toggle-lock-selected');
         if (toggleLockBtn) {
@@ -10027,6 +10002,10 @@ class LEDRasterApp {
                 infoText = `${layer.columns}x${layer.rows} (${activePanels} panels) • ${layer.cabinet_width}×${layer.cabinet_height}px`;
             }
             const lockBadge = layer.locked ? '<span title="Locked" style="margin-left: 6px; color:#bbb;">🔒</span>' : '';
+            // v0.8 Slice 2.5: per-layer ▲▼ arrows replace the global Up/Down
+            // buttons. Disabled state (top/bottom of the layer's canvas group)
+            // is computed in updateLayerOrderControls() after the regroup pass
+            // so we know the within-canvas ordering.
             layerDiv.innerHTML = `
                 <div class="layer-header">
                     <div style="display:flex; align-items:center; gap:4px; flex:1; min-width:0;">
@@ -10034,6 +10013,8 @@ class LEDRasterApp {
                         ${lockBadge}
                     </div>
                     <div class="layer-controls">
+                        <button class="layer-btn layer-move-up" data-layer-id="${layer.id}" title="Move up within canvas">▲</button>
+                        <button class="layer-btn layer-move-down" data-layer-id="${layer.id}" title="Move down within canvas">▼</button>
                         <button class="layer-btn" onclick="app.toggleLayerVisibility(${layer.id})" title="Toggle Visibility">
                             ${layer.visible ? '👁' : '👁‍🗨'}
                         </button>
@@ -10044,6 +10025,24 @@ class LEDRasterApp {
                 </div>
             `;
             
+            // Per-layer reorder arrows (Slice 2.5).
+            const upArrow = layerDiv.querySelector('.layer-move-up');
+            const downArrow = layerDiv.querySelector('.layer-move-down');
+            if (upArrow) {
+                upArrow.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    if (upArrow.disabled) return;
+                    this.moveLayerWithinCanvas(layer.id, -1);
+                });
+            }
+            if (downArrow) {
+                downArrow.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    if (downArrow.disabled) return;
+                    this.moveLayerWithinCanvas(layer.id, 1);
+                });
+            }
+
             // Single click to select
             layerDiv.addEventListener('click', (e) => {
                 if (!e.target.classList.contains('layer-btn') && !e.target.classList.contains('layer-name-input')) {
@@ -10233,7 +10232,7 @@ class LEDRasterApp {
             </div>
             <div class="canvas-group-body"></div>
             <div class="canvas-group-footer">
-                <button class="btn btn-secondary canvas-add-screen-btn" title="Add a screen to this canvas">+ Add Screen</button>
+                <button class="btn btn-secondary canvas-add-btn" title="Add a layer to this canvas">+ Add</button>
             </div>
         `;
         this._wireCanvasGroupEl(wrap, canvas, layerCount);
@@ -10250,7 +10249,7 @@ class LEDRasterApp {
         const nameInput = wrap.querySelector('.canvas-name-input');
         const visBtn = wrap.querySelector('.canvas-vis-btn');
         const menuBtn = wrap.querySelector('.canvas-menu-btn');
-        const addScreenBtn = wrap.querySelector('.canvas-add-screen-btn');
+        const addBtn = wrap.querySelector('.canvas-add-btn');
 
         // Click header anywhere except on inputs/buttons => activate canvas.
         header.addEventListener('click', (e) => {
@@ -10291,14 +10290,9 @@ class LEDRasterApp {
             this.openCanvasMenu(canvas, menuBtn);
         });
 
-        addScreenBtn.addEventListener('click', (e) => {
+        addBtn.addEventListener('click', (e) => {
             e.stopPropagation();
-            // Set the target canvas active so existing add-screen flow lands
-            // here. The PUT is async but the modal user interaction takes
-            // long enough that the server state catches up before any
-            // /api/layer/add request fires.
-            Promise.resolve(this.setActiveCanvas(canvas.id, { silent: true }))
-                .then(() => this.openPresetPicker());
+            this.openCanvasAddMenu(canvas, addBtn);
         });
 
         // -- Drag & drop --
@@ -10459,6 +10453,66 @@ class LEDRasterApp {
         }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
     }
 
+    // v0.8 Slice 2.5: per-canvas "+ Add" chooser (Screen / Image / Text).
+    // Routes to the existing add flows after activating the target canvas
+    // so the new layer always lands in the canvas whose "+ Add" was clicked
+    // (mirrors the Slice 2 add-screen pattern — server uses active_canvas_id
+    // when assigning new layers).
+    openCanvasAddMenu(canvas, anchor) {
+        document.querySelectorAll('.canvas-add-popup, .canvas-menu-popup, .canvas-color-popup').forEach(el => el.remove());
+        const menu = document.createElement('div');
+        menu.className = 'canvas-menu-popup canvas-add-popup';
+        menu.innerHTML = `
+            <button data-action="screen">Screen…</button>
+            <button data-action="image">Image / Logo…</button>
+            <button data-action="text">Text</button>
+        `;
+        document.body.appendChild(menu);
+        const r = anchor.getBoundingClientRect();
+        menu.style.position = 'fixed';
+        menu.style.top = `${r.bottom + 4}px`;
+        menu.style.left = `${Math.max(8, r.left)}px`;
+        menu.style.zIndex = '12000';
+
+        const close = () => {
+            menu.remove();
+            document.removeEventListener('mousedown', onOutside, true);
+            document.removeEventListener('keydown', onKey, true);
+        };
+        const onOutside = (e) => { if (!menu.contains(e.target)) close(); };
+        const onKey = (e) => { if (e.key === 'Escape') close(); };
+        setTimeout(() => {
+            document.addEventListener('mousedown', onOutside, true);
+            document.addEventListener('keydown', onKey, true);
+        }, 0);
+
+        menu.querySelectorAll('button').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const act = btn.dataset.action;
+                close();
+                this._handleCanvasAddAction(canvas, act);
+            });
+        });
+    }
+
+    _handleCanvasAddAction(canvas, action) {
+        // Activate the target canvas so the existing add flows (which look
+        // at active_canvas_id server-side) place the layer correctly.
+        const after = () => {
+            if (action === 'screen') {
+                this.openPresetPicker();
+            } else if (action === 'image') {
+                this.imageFileAction = 'add';
+                const input = document.getElementById('add-image-input');
+                if (input) input.click();
+            } else if (action === 'text') {
+                this.addTextLayer();
+            }
+        };
+        Promise.resolve(this.setActiveCanvas(canvas.id, { silent: true })).then(after);
+    }
+
     openCanvasMenu(canvas, anchor) {
         // Close any pre-existing menu.
         document.querySelectorAll('.canvas-menu-popup').forEach(el => el.remove());
@@ -10573,22 +10627,60 @@ class LEDRasterApp {
     }
 
     updateLayerOrderControls() {
-        const upBtn = document.getElementById('btn-layer-up');
-        const downBtn = document.getElementById('btn-layer-down');
-        if (!upBtn || !downBtn) return;
-        const hasSelection = !!this.currentLayer;
-        upBtn.disabled = !hasSelection;
-        downBtn.disabled = !hasSelection;
+        // v0.8 Slice 2.5: per-layer ▲▼ arrows. Disable the up arrow on the
+        // top-most layer of each canvas group, the down arrow on the
+        // bottom-most. Display order in the sidebar is reverse of the layer
+        // array (newest on top), so within a canvas the FIRST displayed
+        // layer is the LAST one in the array — the up arrow on that one is
+        // disabled, etc.
+        if (!this.project || !this.project.canvases) return;
+        // Group layer ids by canvas, in display order (reverse-array).
+        const reversed = [...(this.project.layers || [])].reverse();
+        const byCanvas = new Map();
+        reversed.forEach(l => {
+            if (!byCanvas.has(l.canvas_id)) byCanvas.set(l.canvas_id, []);
+            byCanvas.get(l.canvas_id).push(l.id);
+        });
+        document.querySelectorAll('#layers-list .layer-item').forEach(el => {
+            const lid = parseInt(el.dataset.layerId, 10);
+            const layer = (this.project.layers || []).find(l => l.id === lid);
+            if (!layer) return;
+            const ids = byCanvas.get(layer.canvas_id) || [];
+            const idx = ids.indexOf(lid);
+            const up = el.querySelector('.layer-move-up');
+            const down = el.querySelector('.layer-move-down');
+            if (up) up.disabled = idx <= 0;
+            if (down) down.disabled = idx < 0 || idx >= ids.length - 1;
+        });
     }
 
     moveLayerById(layerId, delta) {
+        // Kept for backward compatibility (keyboard shortcuts may call this).
+        // Delegates to within-canvas reorder so cross-canvas hops never
+        // happen via arrow-key reorder either.
+        this.moveLayerWithinCanvas(layerId, delta);
+    }
+
+    // v0.8 Slice 2.5: reorder a layer up/down by one slot, but only within
+    // its own canvas group. Display order is reverse of array order, so
+    // delta=-1 (visual up) corresponds to a HIGHER array index swap.
+    moveLayerWithinCanvas(layerId, delta) {
         if (!this.project || !this.project.layers) return;
-        const displayIds = [...document.querySelectorAll('#layers-list .layer-item')].map(el => parseInt(el.dataset.layerId, 10));
-        const idx = displayIds.indexOf(layerId);
-        if (idx < 0) return;
-        const nextIdx = idx + delta;
-        if (nextIdx < 0 || nextIdx >= displayIds.length) return;
-        displayIds.splice(nextIdx, 0, displayIds.splice(idx, 1)[0]);
+        const layer = this.project.layers.find(l => l.id === layerId);
+        if (!layer) return;
+        // Build the within-canvas display-order id list.
+        const reversed = [...this.project.layers].reverse();
+        const sameCanvasIds = reversed.filter(l => l.canvas_id === layer.canvas_id).map(l => l.id);
+        const localIdx = sameCanvasIds.indexOf(layerId);
+        const nextLocal = localIdx + delta;
+        if (localIdx < 0 || nextLocal < 0 || nextLocal >= sameCanvasIds.length) return;
+        const swapWithId = sameCanvasIds[nextLocal];
+        // Build the full display-order id list and swap just those two.
+        const displayIds = reversed.map(l => l.id);
+        const a = displayIds.indexOf(layerId);
+        const b = displayIds.indexOf(swapWithId);
+        if (a < 0 || b < 0) return;
+        [displayIds[a], displayIds[b]] = [displayIds[b], displayIds[a]];
         this.applyDisplayOrder(displayIds, 'Reorder Layers');
     }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2136,6 +2136,10 @@ class LEDRasterApp {
         document.getElementById('btn-add-layer').addEventListener('click', () => {
             this.openPresetPicker();
         });
+        const addCanvasBtn = document.getElementById('btn-add-canvas');
+        if (addCanvasBtn) {
+            addCanvasBtn.addEventListener('click', () => this.addCanvas());
+        }
         const savePresetBtn = document.getElementById('btn-save-preset');
         if (savePresetBtn) {
             savePresetBtn.addEventListener('click', () => this.openPresetSaveModal());
@@ -10158,7 +10162,414 @@ class LEDRasterApp {
             container.appendChild(layerDiv);
         });
 
+        // v0.8 Slice 2: regroup the flat layer list by canvas. The existing
+        // layer items above are preserved as-is — we just lift them into
+        // per-canvas group containers and add canvas headers + per-canvas
+        // "+ Add Screen" buttons + cross-canvas drag/drop.
+        this.regroupLayersByCanvas(container);
+
         this.updateLayerOrderControls();
+    }
+
+    // -------------------------------------------------------------------
+    // Multi-canvas (v0.8 Slice 2) — sidebar canvas grouping.
+    //
+    // Slice 2 keeps workspace rendering unchanged; the sidebar restructure
+    // is the entire visible deliverable. Each canvas gets a header row
+    // (color swatch / name / 👁 / ⋮ / drag handle), its layers underneath
+    // (filtered by layer.canvas_id), and a per-canvas "+ Add Screen"
+    // button. A canvas drag handle reorders canvases. Layers can be
+    // dragged onto another group's header to move them cross-canvas
+    // (Cmd/Alt = duplicate).
+    // -------------------------------------------------------------------
+
+    regroupLayersByCanvas(container) {
+        const project = this.project;
+        if (!project || !Array.isArray(project.canvases) || project.canvases.length === 0) return;
+        const activeId = project.active_canvas_id;
+
+        // Snapshot the existing rendered layer items, keyed by id, then clear.
+        const layerNodes = new Map();
+        container.querySelectorAll('.layer-item').forEach(el => {
+            const lid = parseInt(el.dataset.layerId, 10);
+            if (Number.isFinite(lid)) layerNodes.set(lid, el);
+        });
+        container.innerHTML = '';
+
+        // Sidebar shows canvases in array order, with each canvas's
+        // (reverse-ordered) layers underneath — matches the existing
+        // newest-on-top convention.
+        project.canvases.forEach(canvas => {
+            const group = this.buildCanvasGroupEl(canvas, activeId === canvas.id);
+            container.appendChild(group);
+            const body = group.querySelector('.canvas-group-body');
+
+            // Append matching layer nodes in reverse render order
+            // (Photoshop style — newest on top).
+            const reversed = [...project.layers].reverse();
+            reversed.forEach(layer => {
+                if (layer.canvas_id !== canvas.id) return;
+                const node = layerNodes.get(layer.id);
+                if (node) body.appendChild(node);
+            });
+        });
+    }
+
+    buildCanvasGroupEl(canvas, isActive) {
+        const wrap = document.createElement('div');
+        wrap.className = 'canvas-group' + (isActive ? ' active' : '');
+        if (canvas.visible === false) wrap.classList.add('hidden');
+        wrap.dataset.canvasId = canvas.id;
+        wrap.style.setProperty('--canvas-color', canvas.color || '#4A90E2');
+
+        const layerCount = (this.project.layers || []).filter(l => l.canvas_id === canvas.id).length;
+        wrap.innerHTML = `
+            <div class="canvas-group-header" draggable="true" title="Click to activate · Drag to reorder">
+                <span class="canvas-drag-handle" title="Drag to reorder">⋮⋮</span>
+                <span class="canvas-color-swatch" style="background:${canvas.color || '#4A90E2'};"></span>
+                <input class="canvas-name-input" type="text" value="${this._escapeAttr(canvas.name || 'Canvas')}" readonly>
+                <button class="canvas-vis-btn" title="Toggle canvas visibility">${canvas.visible === false ? '👁‍🗨' : '👁'}</button>
+                <button class="canvas-menu-btn" title="Canvas actions">⋮</button>
+            </div>
+            <div class="canvas-group-body"></div>
+            <div class="canvas-group-footer">
+                <button class="btn btn-secondary canvas-add-screen-btn" title="Add a screen to this canvas">+ Add Screen</button>
+            </div>
+        `;
+        this._wireCanvasGroupEl(wrap, canvas, layerCount);
+        return wrap;
+    }
+
+    _escapeAttr(s) {
+        return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    _wireCanvasGroupEl(wrap, canvas, layerCount) {
+        const header = wrap.querySelector('.canvas-group-header');
+        const nameInput = wrap.querySelector('.canvas-name-input');
+        const visBtn = wrap.querySelector('.canvas-vis-btn');
+        const menuBtn = wrap.querySelector('.canvas-menu-btn');
+        const addScreenBtn = wrap.querySelector('.canvas-add-screen-btn');
+
+        // Click header anywhere except on inputs/buttons => activate canvas.
+        header.addEventListener('click', (e) => {
+            if (e.target.closest('button') || e.target.closest('input')) return;
+            this.setActiveCanvas(canvas.id);
+        });
+
+        // Double-click name to rename inline.
+        nameInput.addEventListener('dblclick', (e) => {
+            e.stopPropagation();
+            nameInput.readOnly = false;
+            nameInput.focus();
+            nameInput.select();
+        });
+        const commitName = () => {
+            nameInput.readOnly = true;
+            const newName = nameInput.value.trim();
+            if (newName && newName !== canvas.name) {
+                this.updateCanvas(canvas.id, { name: newName });
+            } else {
+                nameInput.value = canvas.name || '';
+            }
+        };
+        nameInput.addEventListener('blur', commitName);
+        nameInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); nameInput.blur(); }
+            else if (e.key === 'Escape') { nameInput.value = canvas.name || ''; nameInput.blur(); }
+            if (!nameInput.readOnly) e.stopPropagation();
+        });
+
+        visBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.updateCanvas(canvas.id, { visible: canvas.visible === false });
+        });
+
+        menuBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.openCanvasMenu(canvas, menuBtn);
+        });
+
+        addScreenBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            // Set the target canvas active so existing add-screen flow lands
+            // here. The PUT is async but the modal user interaction takes
+            // long enough that the server state catches up before any
+            // /api/layer/add request fires.
+            Promise.resolve(this.setActiveCanvas(canvas.id, { silent: true }))
+                .then(() => this.openPresetPicker());
+        });
+
+        // -- Drag & drop --
+        // Drag canvas header => reorder canvases.
+        header.addEventListener('dragstart', (e) => {
+            // If the drag originated from the name input (when readonly was true
+            // and user grabbed the field), still treat as canvas reorder.
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData('application/x-canvas-id', canvas.id);
+            e.dataTransfer.setData('text/plain', `canvas:${canvas.id}`);
+            this._dragCanvasId = canvas.id;
+            wrap.classList.add('dragging');
+        });
+        header.addEventListener('dragend', () => {
+            wrap.classList.remove('dragging');
+            this._dragCanvasId = null;
+        });
+
+        // Drop target: canvas header accepts canvas-reorder OR layer drop.
+        wrap.addEventListener('dragover', (e) => {
+            // Layer being dragged onto this canvas => indicate cross-canvas drop.
+            const isCanvas = !!this._dragCanvasId;
+            const isLayer = this.dragLayerId != null && !isCanvas;
+            if (!isCanvas && !isLayer) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = (isLayer && (e.metaKey || e.altKey)) ? 'copy' : 'move';
+            wrap.classList.add('drag-target');
+        });
+        wrap.addEventListener('dragleave', (e) => {
+            // Only clear the highlight when leaving the wrap entirely.
+            if (!wrap.contains(e.relatedTarget)) wrap.classList.remove('drag-target');
+        });
+        wrap.addEventListener('drop', (e) => {
+            wrap.classList.remove('drag-target');
+            // Canvas reorder?
+            const draggedCanvasId = this._dragCanvasId
+                || e.dataTransfer.getData('application/x-canvas-id');
+            if (draggedCanvasId && draggedCanvasId !== canvas.id) {
+                e.preventDefault();
+                this.reorderCanvasBeforeTarget(draggedCanvasId, canvas.id);
+                return;
+            }
+            // Cross-canvas layer drop?
+            // Only handle when the drop landed on the canvas header / footer
+            // (not on an existing layer-item inside this canvas) — otherwise
+            // we would double-fire alongside the within-list reorder handler.
+            if (this.dragLayerId != null) {
+                const onLayerItem = e.target.closest && e.target.closest('.layer-item');
+                if (onLayerItem) return;
+                const draggedLayer = (this.project.layers || []).find(l => l.id === this.dragLayerId);
+                if (draggedLayer && draggedLayer.canvas_id !== canvas.id) {
+                    e.preventDefault();
+                    const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
+                    this.moveLayerToCanvas(draggedLayer.id, canvas.id, mode);
+                }
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------
+    // Canvas API helpers (Slice 2). All call backend endpoints introduced
+    // in /api/canvas* and update this.project from the response.
+    // -------------------------------------------------------------------
+
+    _applyProjectUpdate(data) {
+        if (!data) return;
+        // Preserve client-side properties that may be on existing layers
+        // before we overwrite the project reference.
+        const savedClientProps = {};
+        if (this.project && this.project.layers) {
+            this.project.layers.forEach(l => {
+                savedClientProps[l.id] = this.extractClientSideProps
+                    ? this.extractClientSideProps(l) : null;
+            });
+        }
+        this.project = data;
+        if (data.layers && this.applyClientSideProperties) {
+            // re-apply localStorage-side overrides if available
+            try { this.loadClientSideProperties && this.loadClientSideProperties({ skipPreferences: true }); } catch (_) {}
+        }
+        // If the active canvas's properties changed, sync raster size for
+        // the workspace toolbar (Slice 4 will deepen this — Slice 2 just
+        // keeps the sidebar consistent).
+        if (data.raster_width && data.raster_height && this.syncRasterFromProject) {
+            try { this.syncRasterFromProject(); } catch (_) {}
+        }
+        this.renderLayers();
+        if (this.render) {
+            try { this.render(); } catch (_) {}
+        }
+    }
+
+    addCanvas() {
+        return fetch('/api/canvas', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({})
+        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+    }
+
+    updateCanvas(canvasId, patch) {
+        return fetch(`/api/canvas/${canvasId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(patch || {})
+        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+    }
+
+    deleteCanvas(canvasId) {
+        return fetch(`/api/canvas/${canvasId}`, { method: 'DELETE' })
+            .then(r => r.json().then(body => ({ ok: r.ok, body })))
+            .then(({ ok, body }) => {
+                if (!ok) {
+                    this._toast(body && body.error ? body.error : 'Cannot delete canvas', true);
+                    return;
+                }
+                this._applyProjectUpdate(body);
+            });
+    }
+
+    duplicateCanvas(canvasId) {
+        return fetch(`/api/canvas/${canvasId}/duplicate`, { method: 'POST' })
+            .then(r => r.json()).then(data => this._applyProjectUpdate(data));
+    }
+
+    setActiveCanvas(canvasId, opts = {}) {
+        // Optimistic UI update so the highlight feels instant; backend
+        // confirms.
+        if (this.project) this.project.active_canvas_id = canvasId;
+        if (!opts.silent) this.renderLayers();
+        return fetch(`/api/canvas/${canvasId}/active`, { method: 'PUT' })
+            .then(r => r.json()).then(data => {
+                // Quietly absorb server state without re-rendering twice.
+                if (data && data.canvases) this.project = data;
+            });
+    }
+
+    reorderCanvasBeforeTarget(draggedId, targetId) {
+        if (!this.project || !this.project.canvases) return;
+        const ids = this.project.canvases.map(c => c.id);
+        const from = ids.indexOf(draggedId);
+        const to = ids.indexOf(targetId);
+        if (from < 0 || to < 0 || from === to) return;
+        ids.splice(from, 1);
+        ids.splice(ids.indexOf(targetId), 0, draggedId);
+        return fetch('/api/canvas/reorder', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ canvas_ids: ids })
+        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+    }
+
+    moveLayerToCanvas(layerId, canvasId, mode = 'move') {
+        return fetch(`/api/layer/${layerId}/canvas`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ canvas_id: canvasId, mode })
+        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+    }
+
+    openCanvasMenu(canvas, anchor) {
+        // Close any pre-existing menu.
+        document.querySelectorAll('.canvas-menu-popup').forEach(el => el.remove());
+        const menu = document.createElement('div');
+        menu.className = 'canvas-menu-popup';
+        menu.innerHTML = `
+            <button data-action="rename">Rename</button>
+            <button data-action="duplicate">Duplicate</button>
+            <button data-action="color">Change Color…</button>
+            <button data-action="delete" class="danger">Delete</button>
+        `;
+        document.body.appendChild(menu);
+        const r = anchor.getBoundingClientRect();
+        menu.style.position = 'fixed';
+        menu.style.top = `${r.bottom + 4}px`;
+        menu.style.left = `${Math.max(8, r.right - 160)}px`;
+        menu.style.zIndex = '12000';
+
+        const close = () => {
+            menu.remove();
+            document.removeEventListener('mousedown', onOutside, true);
+            document.removeEventListener('keydown', onKey, true);
+        };
+        const onOutside = (e) => { if (!menu.contains(e.target)) close(); };
+        const onKey = (e) => { if (e.key === 'Escape') close(); };
+        // Defer to avoid catching the click that opened us.
+        setTimeout(() => {
+            document.addEventListener('mousedown', onOutside, true);
+            document.addEventListener('keydown', onKey, true);
+        }, 0);
+
+        menu.querySelectorAll('button').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const act = btn.dataset.action;
+                close();
+                this._handleCanvasMenuAction(canvas, act);
+            });
+        });
+    }
+
+    _handleCanvasMenuAction(canvas, action) {
+        if (action === 'rename') {
+            const input = document.querySelector(`.canvas-group[data-canvas-id="${canvas.id}"] .canvas-name-input`);
+            if (input) {
+                input.readOnly = false;
+                input.focus();
+                input.select();
+            }
+        } else if (action === 'duplicate') {
+            this.duplicateCanvas(canvas.id);
+        } else if (action === 'color') {
+            this.openCanvasColorPicker(canvas);
+        } else if (action === 'delete') {
+            const layerCount = (this.project.layers || []).filter(l => l.canvas_id === canvas.id).length;
+            const msg = layerCount > 0
+                ? `Delete canvas '${canvas.name}' and its ${layerCount} layer${layerCount === 1 ? '' : 's'}? This cannot be undone.`
+                : `Delete canvas '${canvas.name}'?`;
+            if (window.confirm(msg)) this.deleteCanvas(canvas.id);
+        }
+    }
+
+    openCanvasColorPicker(canvas) {
+        document.querySelectorAll('.canvas-color-popup').forEach(el => el.remove());
+        const palette = ['#4A90E2', '#F5A623', '#7ED321', '#BD10E0',
+                         '#D0021B', '#50E3C2', '#F8E71C', '#9013FE'];
+        const popup = document.createElement('div');
+        popup.className = 'canvas-color-popup';
+        popup.innerHTML = `
+            <div class="canvas-color-swatches">
+                ${palette.map(c => `<button class="color-swatch" data-color="${c}" style="background:${c};" title="${c}"></button>`).join('')}
+            </div>
+            <div class="canvas-color-hex-row">
+                <label>Hex:</label>
+                <input type="text" class="canvas-color-hex" value="${canvas.color || ''}" maxlength="7">
+                <button class="canvas-color-apply">Apply</button>
+            </div>
+        `;
+        document.body.appendChild(popup);
+        const anchor = document.querySelector(`.canvas-group[data-canvas-id="${canvas.id}"] .canvas-menu-btn`);
+        if (anchor) {
+            const r = anchor.getBoundingClientRect();
+            popup.style.position = 'fixed';
+            popup.style.top = `${r.bottom + 4}px`;
+            popup.style.left = `${Math.max(8, r.right - 200)}px`;
+            popup.style.zIndex = '12000';
+        }
+        const close = () => {
+            popup.remove();
+            document.removeEventListener('mousedown', onOutside, true);
+        };
+        const onOutside = (e) => { if (!popup.contains(e.target)) close(); };
+        setTimeout(() => document.addEventListener('mousedown', onOutside, true), 0);
+
+        popup.querySelectorAll('.color-swatch').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.updateCanvas(canvas.id, { color: btn.dataset.color });
+                close();
+            });
+        });
+        popup.querySelector('.canvas-color-apply').addEventListener('click', (e) => {
+            e.stopPropagation();
+            const hex = popup.querySelector('.canvas-color-hex').value.trim();
+            if (/^#[0-9A-Fa-f]{6}$/.test(hex)) {
+                this.updateCanvas(canvas.id, { color: hex });
+                close();
+            } else {
+                this._toast('Invalid hex color (expected #RRGGBB)', true);
+            }
+        });
     }
 
     updateLayerOrderControls() {

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2085,8 +2085,14 @@ class LEDRasterApp {
         // expand on demand via the header.
         const helpPanel = document.getElementById('help-tooltip-panel');
         const helpHeader = document.getElementById('help-tooltip-header');
-        if (helpPanel && helpHeader) {
-            helpHeader.addEventListener('click', () => helpPanel.classList.toggle('collapsed'));
+        const helpToggle = document.getElementById('help-tooltip-toggle');
+        if (helpPanel && helpHeader && helpToggle) {
+            const toggleHelp = () => {
+                helpPanel.classList.toggle('collapsed');
+                helpToggle.textContent = helpPanel.classList.contains('collapsed') ? '▶' : '▼';
+            };
+            helpToggle.addEventListener('click', (e) => { e.stopPropagation(); toggleHelp(); });
+            helpHeader.addEventListener('click', toggleHelp);
         }
 
         // View tabs

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5372,6 +5372,8 @@ class LEDRasterApp {
         if (!this.selectionAnchorLayerId) {
             this.selectionAnchorLayerId = layer.id;
         }
+        // Slice 4: auto-activate this layer's canvas (no-op if already active).
+        this._activateCanvasForLayer(this.currentLayer);
         this.renderLayers();
         this.loadLayerToInputs();
         window.canvasRenderer.render();
@@ -5392,6 +5394,8 @@ class LEDRasterApp {
         this.selectedLayerIds = new Set(rangeIds);
         this.currentLayer = layer;
         this.lastSelectedLayerId = layer.id;
+        // Slice 4: auto-activate the canvas of the new primary layer.
+        this._activateCanvasForLayer(layer);
         this.renderLayers();
         this.loadLayerToInputs();
         window.canvasRenderer.render();
@@ -5621,6 +5625,8 @@ class LEDRasterApp {
         if (!this.selectionAnchorLayerId && this.currentLayer) {
             this.selectionAnchorLayerId = this.currentLayer.id;
         }
+        // Slice 4: auto-activate the canvas of the new primary layer.
+        this._activateCanvasForLayer(this.currentLayer);
         this.renderLayers();
         this.loadLayerToInputs();
         this.loadTextLayerToInputs();
@@ -5633,11 +5639,15 @@ class LEDRasterApp {
             console.error('SELECT LAYER: Invalid layer', layer);
             return;
         }
-        
+
         this.currentLayer = layer;
         this.selectedLayerIds = new Set([layer.id]);
         this.lastSelectedLayerId = layer.id;
         this.selectionAnchorLayerId = layer.id;
+        // Slice 4: auto-activate this layer's canvas. Idempotent — short-
+        // circuits when already active so programmatic selectLayer calls
+        // (post-load, post-create, post-delete) don't fire spurious PUTs.
+        this._activateCanvasForLayer(layer);
         sendClientLog('select_layer_before_defaults', {
             layerId: layer.id,
             processorType: layer.processorType,
@@ -10438,13 +10448,56 @@ class LEDRasterApp {
     setActiveCanvas(canvasId, opts = {}) {
         // Optimistic UI update so the highlight feels instant; backend
         // confirms.
-        if (this.project) this.project.active_canvas_id = canvasId;
-        if (!opts.silent) this.renderLayers();
+        if (!this.project) return Promise.resolve();
+        if (this.project.active_canvas_id === canvasId && !opts.force) {
+            // No-op: already active. Skip the network round-trip and
+            // re-render to avoid spamming PUTs from layer-selection paths.
+            return Promise.resolve();
+        }
+        this.project.active_canvas_id = canvasId;
+        // Slice 4: toolbar raster reflects the active canvas's raster.
+        // Mirror the active canvas's raster_* into project root + renderer
+        // so syncRasterFromProject populates the toolbar inputs correctly.
+        this._syncRootRasterFromActiveCanvas();
+        try { this.syncRasterFromProject(); } catch (_) {}
+        if (!opts.silent) {
+            this.renderLayers();
+            if (window.canvasRenderer) window.canvasRenderer.render();
+        }
         return fetch(`/api/canvas/${canvasId}/active`, { method: 'PUT' })
             .then(r => r.json()).then(data => {
                 // Quietly absorb server state without re-rendering twice.
                 if (data && data.canvases) this.project = data;
             });
+    }
+
+    /**
+     * Slice 4: copy the active canvas's raster_* fields into the project
+     * root so syncRasterFromProject (which reads project root) picks up the
+     * right values. Slice 6 will switch the renderer to read straight from
+     * the canvas object and this helper goes away.
+     */
+    _syncRootRasterFromActiveCanvas() {
+        if (!this.project || !this.project.canvases) return;
+        const c = this.project.canvases.find(c => c.id === this.project.active_canvas_id);
+        if (!c) return;
+        if (c.raster_width)        this.project.raster_width = c.raster_width;
+        if (c.raster_height)       this.project.raster_height = c.raster_height;
+        if (c.show_raster_width)   this.project.show_raster_width = c.show_raster_width;
+        if (c.show_raster_height)  this.project.show_raster_height = c.show_raster_height;
+    }
+
+    /**
+     * Slice 4: when a layer becomes the user-selected layer, also activate
+     * its canvas (if different). Idempotent — setActiveCanvas short-circuits
+     * when already active, so we won't spam PUTs from re-selecting the same
+     * layer or selecting siblings inside the already-active canvas.
+     */
+    _activateCanvasForLayer(layer) {
+        if (!layer || !layer.canvas_id) return;
+        if (!this.project) return;
+        if (layer.canvas_id === this.project.active_canvas_id) return;
+        this.setActiveCanvas(layer.canvas_id);
     }
 
     reorderCanvasBeforeTarget(draggedId, targetId) {

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7964,7 +7964,15 @@ class LEDRasterApp {
             hasDirectoryPicker: !!window.showDirectoryPicker,
             hasSaveFilePicker: !!window.showSaveFilePicker
         });
-        if (window.showDirectoryPicker) {
+        // v0.8: same Chrome activation issue we hit on JSON saves — when
+        // the user is on localhost (this Flask app), the multi-canvas export
+        // burns the user-gesture token rendering all the canvases between
+        // showDirectoryPicker resolving and the per-file getFileHandle/
+        // createWritable calls. Chrome rejects with NotAllowedError and we
+        // get zero files on disk. Skip the FS Access API entirely on
+        // localhost and use the native server-side directory dialog, which
+        // doesn't have this restriction.
+        if (window.showDirectoryPicker && !this.isLocalConnection()) {
             try {
                 const dirHandle = await window.showDirectoryPicker();
                 for (const file of files) {
@@ -7977,9 +7985,35 @@ class LEDRasterApp {
                 return;
             } catch (err) {
                 if (err && err.name === 'AbortError') return;
-                throw err;
+                sendClientLog('save_multiple_files_directory_failed', {
+                    name: err && err.name, message: err && err.message
+                });
+                // fall through to native fallback so the user still gets files
             }
         }
+        // Use native server-side directory picker (opens on the host machine).
+        // Tried BEFORE per-file showSaveFilePicker because picking once is
+        // far less work than N separate save dialogs.
+        try {
+            const targetDir = await this.nativeSelectDirectory();
+            if (targetDir) {
+                for (const file of files) {
+                    const filePath = `${targetDir.replace(/[\\/]$/, '')}/${file.filename}`;
+                    const ok = await this.nativeWriteFile(filePath, file.blob);
+                    if (!ok) {
+                        sendClientLog('save_multiple_files_native_dialog_write_failed', { file: file.filename, filePath });
+                        throw new Error(`Native write failed for ${file.filename}`);
+                    }
+                }
+                sendClientLog('save_multiple_files_native_dialog_success', { count: files.length, directory: targetDir });
+                return;
+            }
+            sendClientLog('save_multiple_files_native_dialog_cancelled', { count: files.length });
+        } catch (err) {
+            sendClientLog('save_multiple_files_native_dialog_error', { message: err.message });
+        }
+        // Last resort: per-file saveBlobWithPicker (multiple dialogs) or
+        // browser download.
         if (window.showSaveFilePicker) {
             for (const file of files) {
                 const mimeType = file.blob && file.blob.type ? file.blob.type : 'application/octet-stream';
@@ -7988,24 +8022,8 @@ class LEDRasterApp {
             sendClientLog('save_multiple_files_picker_success', { count: files.length });
             return;
         }
-        // Use native server-side directory picker (opens on the host machine)
-        try {
-            const targetDir = await this.nativeSelectDirectory();
-            if (!targetDir) {
-                sendClientLog('save_multiple_files_native_dialog_cancelled', { count: files.length });
-                return;
-            }
-            for (const file of files) {
-                const filePath = `${targetDir.replace(/[\\/]$/, '')}/${file.filename}`;
-                const ok = await this.nativeWriteFile(filePath, file.blob);
-                if (!ok) {
-                    sendClientLog('save_multiple_files_native_dialog_write_failed', { file: file.filename, filePath });
-                    throw new Error(`Native write failed for ${file.filename}`);
-                }
-            }
-            sendClientLog('save_multiple_files_native_dialog_success', { count: files.length, directory: targetDir });
-        } catch (err) {
-            sendClientLog('save_multiple_files_native_dialog_error', { message: err.message });
+        for (const file of files) {
+            try { this.browserDownload(file.blob, file.filename); } catch (_) {}
         }
     }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10392,8 +10392,13 @@ class LEDRasterApp {
             try { this.syncRasterFromProject(); } catch (_) {}
         }
         this.renderLayers();
-        if (this.render) {
-            try { this.render(); } catch (_) {}
+        // Re-render the workspace canvas. The previous `if (this.render)`
+        // check was always false (app has no .render method), so the
+        // workspace pixels never refreshed after a canvas CRUD response —
+        // most visibly: toggling a canvas's visibility updated state but
+        // never repainted the workspace, so the canvas appeared not to hide.
+        if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
+            try { window.canvasRenderer.render(); } catch (_) {}
         }
     }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2050,6 +2050,20 @@ class LEDRasterApp {
     }
 
     /**
+     * v0.8 Slice 9: ids of all canvases whose visibility is explicitly off.
+     * Used by aggregate counters (data ports, power totals) to exclude
+     * hidden canvases so the numbers in the sidebar match what's drawn.
+     */
+    _hiddenCanvasIdSet() {
+        const set = new Set();
+        if (!this.project || !Array.isArray(this.project.canvases)) return set;
+        this.project.canvases.forEach(c => {
+            if (c && c.visible === false && c.id) set.add(c.id);
+        });
+        return set;
+    }
+
+    /**
      * Reflect the active canvas's perspective values on the toggle buttons.
      * Falls back to the project root for pre-Slice-1 / legacy projects that
      * have no canvas list yet. Called on project load and on every active-
@@ -5141,13 +5155,17 @@ class LEDRasterApp {
         if (underlineBtn) underlineBtn.classList.toggle('active', !!layer.fontUnderline);
     }
 
-    // Aggregate data port counts across all visible screen layers
+    // Aggregate data port counts across all visible screen layers.
+    // Slice 9: exclude layers whose canvas is hidden — totals should match
+    // what's drawn on screen and what the user expects to ship.
     getPortCounts() {
         if (!this.project || !this.project.layers) return { primary: 0, backup: 0 };
         let totalPrimary = 0;
+        const hiddenCanvasIds = this._hiddenCanvasIdSet();
         this.project.layers.forEach(layer => {
             if ((layer.type || 'screen') !== 'screen') return;
             if (!layer.visible) return;
+            if (layer.canvas_id && hiddenCanvasIds.has(layer.canvas_id)) return;
             const activePanels = (layer.panels || []).filter(p => !p.blank && !p.hidden);
             if (activePanels.length === 0) return;
             const assignments = this.calculatePortAssignments(layer);
@@ -5162,15 +5180,19 @@ class LEDRasterApp {
         return { primary: totalPrimary, backup: totalPrimary };
     }
 
-    // Aggregate power stats across all visible screen layers
+    // Aggregate power stats across all visible screen layers.
+    // Slice 9: exclude layers whose canvas is hidden so totals match the
+    // visible workspace.
     getPowerCounts() {
         if (!this.project || !this.project.layers) return { circuits: 0, totalWatts: 0, singlePhaseAmps: 0, threePhaseAmps: 0, voltage: 0 };
         let totalCircuits = 0;
         let totalWattsAll = 0;
         const voltages = new Set();
+        const hiddenCanvasIds = this._hiddenCanvasIdSet();
         this.project.layers.forEach(layer => {
             if ((layer.type || 'screen') !== 'screen') return;
             if (!layer.visible) return;
+            if (layer.canvas_id && hiddenCanvasIds.has(layer.canvas_id)) return;
             const activePanels = (layer.panels || []).filter(p => !p.blank && !p.hidden);
             if (activePanels.length === 0) return;
             const voltage = Number(layer.powerVoltage) || 110;
@@ -7895,7 +7917,7 @@ class LEDRasterApp {
             powerVoltage: 110,
             powerAmperage: 15,
             powerWatts: 200,
-            canvasGap: 50
+            canvasGap: 0
         };
     }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -3737,6 +3737,9 @@ class LEDRasterApp {
             // Set project name from current project
             document.getElementById('export-name').value = this.project.name || 'Untitled Project';
             this.loadExportSuffixesToUI();
+            // Slice 11: rebuild canvas checklist on every open so renames /
+            // additions / deletions show up. Visible canvases default-checked.
+            this.populateExportCanvasesList();
             // Update preview
             this.updateExportPreview();
         });
@@ -3799,6 +3802,17 @@ class LEDRasterApp {
                 return;
             }
 
+            // Slice 11: collect selected canvas IDs from the dynamic
+            // checklist. If the project has no canvases array (legacy /
+            // pre-Slice-1 fallback), pass [null] so performExport treats it
+            // as a single synthetic canvas using project-root raster dims —
+            // matching v0.7 export behaviour exactly.
+            const canvasIds = this.getSelectedExportCanvasIds();
+            if (canvasIds.length === 0) {
+                alert('Please select at least one canvas to export.');
+                return;
+            }
+
             if (!this.supportsFilePickerAPIs() && !this.supportsDirectoryPickerAPIs() && !this._warnedNoFilePickerExport) {
                 this._warnedNoFilePickerExport = true;
                 sendClientLog('export_picker_apis_unavailable_warning', {});
@@ -3808,7 +3822,7 @@ class LEDRasterApp {
             document.getElementById('status-message').textContent = 'Exporting...';
 
             try {
-                await this.performExport(projectName, format, views);
+                await this.performExport(projectName, format, views, canvasIds);
                 
                 document.getElementById('status-message').textContent = 'Export complete!';
                 setTimeout(() => {
@@ -7427,31 +7441,44 @@ class LEDRasterApp {
 
         preview.style.color = '#4A90E2';
 
+        // Slice 11: factor selected canvases into the preview. Each
+        // (canvas, view) combo is one file (PNG/PSD) or one page (PDF).
+        const canvasIds = (typeof this.getSelectedExportCanvasIds === 'function')
+            ? this.getSelectedExportCanvasIds() : [null];
+        if (canvasIds.length === 0) {
+            preview.textContent = '(Select at least one canvas)';
+            preview.style.color = '#ff6b6b';
+            return;
+        }
+        const projectCanvases = (this.project && Array.isArray(this.project.canvases))
+            ? this.project.canvases : [];
+        const canvasNameOf = (cid) => {
+            if (!cid) return '';
+            const c = projectCanvases.find(x => x && x.id === cid);
+            return c ? this.sanitizeFilename(c.name || 'Canvas') : '';
+        };
+        const multiCanvas = canvasIds.length > 1 && canvasIds[0] !== null;
+        const buildName = (cid, suffix, ext) => {
+            const cname = canvasNameOf(cid);
+            return (multiCanvas && cname)
+                ? `${projectName} - ${cname} - ${suffix}.${ext}`
+                : `${projectName} ${suffix}.${ext}`;
+        };
+
         if (format === 'pdf') {
-            // PDF combines all views
-            preview.textContent = `${projectName}.pdf (${views.length} page${views.length > 1 ? 's' : ''})`;
-        } else if (format === 'psd') {
-            // PSD - one file per view, layers inside
-            if (views.length === 1) {
-                const suffix = this.getExportSuffixForView(views[0], suffixes, viewNames);
-                preview.textContent = `${projectName} ${suffix}.psd`;
-            } else {
-                preview.innerHTML = views.map(v => {
+            const pageCount = canvasIds.length * views.length;
+            preview.textContent = `${projectName}.pdf (${pageCount} page${pageCount > 1 ? 's' : ''})`;
+        } else if (format === 'psd' || format === 'png') {
+            const ext = format;
+            const lines = [];
+            for (const cid of canvasIds) {
+                for (const v of views) {
                     const suffix = this.getExportSuffixForView(v, suffixes, viewNames);
-                    return `${projectName} ${suffix}.psd`;
-                }).join('<br>');
+                    lines.push(buildName(cid, suffix, ext));
+                }
             }
-        } else {
-            // PNG - one file per view
-            if (views.length === 1) {
-                const suffix = this.getExportSuffixForView(views[0], suffixes, viewNames);
-                preview.textContent = `${projectName} ${suffix}.png`;
-            } else {
-                preview.innerHTML = views.map(v => {
-                    const suffix = this.getExportSuffixForView(v, suffixes, viewNames);
-                    return `${projectName} ${suffix}.png`;
-                }).join('<br>');
-            }
+            if (lines.length === 1) preview.textContent = lines[0];
+            else preview.innerHTML = lines.join('<br>');
         }
     }
 
@@ -7556,92 +7583,202 @@ class LEDRasterApp {
     }
 
     // Perform export using client-side canvas capture at 1:1 pixel scale
-    async performExport(projectName, format, views) {
+    /**
+     * Slice 11: build the dynamic Canvases checklist in the export modal.
+     * Visible canvases are checked, hidden ones unchecked but still
+     * selectable. Each row gets a stable id so the export-confirm handler
+     * can read them.
+     */
+    populateExportCanvasesList() {
+        const list = document.getElementById('export-canvases-list');
+        if (!list) return;
+        list.innerHTML = '';
+        const canvases = (this.project && Array.isArray(this.project.canvases))
+            ? this.project.canvases : [];
+        if (canvases.length === 0) {
+            // Legacy / pre-Slice-1 project: no canvas list. Show a static
+            // placeholder so the user understands what's being exported.
+            const note = document.createElement('div');
+            note.style.cssText = 'font-size:11px;color:#888;padding:6px 0;';
+            note.textContent = 'Single-canvas project — entire workspace will be exported.';
+            list.appendChild(note);
+            return;
+        }
+        canvases.forEach((c, idx) => {
+            if (!c || !c.id) return;
+            const row = document.createElement('div');
+            row.className = 'export-view-row';
+            const isHidden = c.visible === false;
+            const label = document.createElement('label');
+            label.className = 'export-view-label';
+            label.style.gap = '6px';
+            const swatch = document.createElement('span');
+            swatch.style.cssText = `display:inline-block;width:10px;height:10px;border-radius:2px;background:${c.color || '#4A90E2'};flex:none;`;
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.checked = !isHidden;
+            checkbox.dataset.canvasId = c.id;
+            checkbox.className = 'export-canvas-checkbox';
+            checkbox.addEventListener('change', () => this.updateExportPreview());
+            const text = document.createElement('span');
+            text.textContent = (c.name || `Canvas ${idx + 1}`) + (isHidden ? '  (hidden)' : '');
+            if (isHidden) text.style.color = '#888';
+            label.appendChild(checkbox);
+            label.appendChild(swatch);
+            label.appendChild(text);
+            row.appendChild(label);
+            list.appendChild(row);
+        });
+    }
+
+    /**
+     * Slice 11: read the canvas checkboxes back. Returns array of canvas
+     * ids in their project.canvases order. Returns [null] for legacy
+     * projects so performExport falls into single-canvas mode.
+     */
+    getSelectedExportCanvasIds() {
+        const canvases = (this.project && Array.isArray(this.project.canvases))
+            ? this.project.canvases : [];
+        if (canvases.length === 0) return [null];
+        const checked = new Set();
+        document.querySelectorAll('.export-canvas-checkbox').forEach(cb => {
+            if (cb.checked && cb.dataset.canvasId) checked.add(cb.dataset.canvasId);
+        });
+        // Preserve project.canvases order in the output.
+        return canvases.filter(c => c && checked.has(c.id)).map(c => c.id);
+    }
+
+    /**
+     * Slice 11: multi-canvas-aware export. Iterates canvases × views,
+     * temporarily hiding the OTHER canvases per pass and translating the
+     * render so each canvas becomes its own export image at its native
+     * raster size. canvasIds=[null] is the legacy single-canvas path.
+     */
+    async performExport(projectName, format, views, canvasIds) {
         const viewNames = this.getExportViewNames();
         const suffixes = this.getExportSuffixesFromUI();
-        
-        // Store current state
+
+        // Store current renderer state.
         const originalViewMode = window.canvasRenderer.viewMode;
         const originalZoom = window.canvasRenderer.zoom;
         const originalPanX = window.canvasRenderer.panX;
         const originalPanY = window.canvasRenderer.panY;
-        
-        // Get exact raster dimensions
-        const rasterWidth = window.canvasRenderer.rasterWidth;
-        const rasterHeight = window.canvasRenderer.rasterHeight;
-        
-        // Store original canvas reference
+        const originalActiveCanvasId = (this.project && this.project.active_canvas_id) || null;
         const mainCanvas = window.canvasRenderer.canvas;
         const originalCtx = window.canvasRenderer.ctx;
-        
-        // Check if transparent background is requested
+
         const transparentBg = document.getElementById('export-transparent-bg');
         const useTransparentBg = transparentBg && transparentBg.checked;
 
-        // Create a fresh offscreen canvas at exact raster size
+        // Snapshot every canvas's visibility so we can flip them per pass
+        // and restore at the end. Legacy projects skip this entirely.
+        const canvases = (this.project && Array.isArray(this.project.canvases))
+            ? this.project.canvases : [];
+        const visibilitySnapshot = canvases.map(c => ({ id: c.id, visible: c.visible }));
+
         const exportCanvas = document.createElement('canvas');
-        exportCanvas.width = rasterWidth;
-        exportCanvas.height = rasterHeight;
         const exportCtx = exportCanvas.getContext('2d', { alpha: useTransparentBg });
-        
-        // Swap to export canvas
         window.canvasRenderer.canvas = exportCanvas;
         window.canvasRenderer.ctx = exportCtx;
-        
-        // Set zoom to exactly 1.0 and pan to 0,0 (top-left corner)
         window.canvasRenderer.zoom = 1.0;
-        window.canvasRenderer.panX = 0;
-        window.canvasRenderer.panY = 0;
-        
-        // Enable export mode (hides grid and raster boundary)
         window.canvasRenderer.exportMode = true;
         window.canvasRenderer.exportTransparentBg = useTransparentBg;
-        
-        // Render each view and collect images
-        const renderedViews = [];
-        
-        for (const view of views) {
-            // Set view mode
-            window.canvasRenderer.viewMode = view;
-            
-            // Render at 1:1 to the export canvas
-            window.canvasRenderer.render();
-            
-            // Log dimensions for debugging
-            console.log(`Export: ${view} - Canvas: ${exportCanvas.width}x${exportCanvas.height}, Raster: ${rasterWidth}x${rasterHeight}`);
-            
-            // Get image data directly from canvas
-            const dataUrl = exportCanvas.toDataURL('image/png');
-            const suffix = this.getExportSuffixForView(view, suffixes, viewNames);
-            renderedViews.push({
-                view,
-                suffix,
-                fileBase: `${projectName} ${suffix}`,
-                dataUrl,
-                width: rasterWidth,
-                height: rasterHeight
+
+        const renderedItems = [];
+        const multiCanvas = canvasIds.length > 1 && canvasIds[0] !== null;
+
+        try {
+            for (const cid of canvasIds) {
+                // Resolve target canvas. cid===null means legacy single-
+                // canvas: use project-root raster fields, no workspace shift.
+                const targetCanvas = cid
+                    ? canvases.find(c => c && c.id === cid)
+                    : null;
+                if (cid && !targetCanvas) continue;
+
+                if (cid) {
+                    // Make ONLY this canvas visible during the per-view loop
+                    // so other canvases' layers don't bleed into the export
+                    // (handles overlap, cross-canvas labels, etc.). Active
+                    // canvas swap drives the rasterWidth/Height accessors
+                    // that decide export-canvas dimensions per view.
+                    canvases.forEach(c => { c.visible = (c.id === cid); });
+                    this.project.active_canvas_id = cid;
+                }
+
+                for (const view of views) {
+                    window.canvasRenderer.viewMode = view;
+                    // rasterWidth/Height read from the active canvas (Slice 6)
+                    // and pick show_raster_* automatically when view is
+                    // show-look (so Show Look exports at its own resolution).
+                    const rasterWidth = window.canvasRenderer.rasterWidth || 1920;
+                    const rasterHeight = window.canvasRenderer.rasterHeight || 1080;
+                    exportCanvas.width = rasterWidth;
+                    exportCanvas.height = rasterHeight;
+                    // Translate the workspace so this canvas's top-left
+                    // (workspace_x, workspace_y) lands at (0, 0) in the
+                    // export canvas. Legacy: pan to 0,0.
+                    const wsx = targetCanvas ? (targetCanvas.workspace_x || 0) : 0;
+                    const wsy = targetCanvas ? (targetCanvas.workspace_y || 0) : 0;
+                    window.canvasRenderer.panX = -wsx;
+                    window.canvasRenderer.panY = -wsy;
+
+                    window.canvasRenderer.render();
+
+                    const dataUrl = exportCanvas.toDataURL('image/png');
+                    const suffix = this.getExportSuffixForView(view, suffixes, viewNames);
+                    const canvasName = targetCanvas
+                        ? this.sanitizeFilename(targetCanvas.name || 'Canvas')
+                        : null;
+                    // Filename: include canvas token only when exporting
+                    // more than one. Single-canvas exports keep the v0.7
+                    // naming so existing user workflows aren't disrupted.
+                    const fileBase = (multiCanvas && canvasName)
+                        ? `${projectName} - ${canvasName} - ${suffix}`
+                        : `${projectName} ${suffix}`;
+                    // PDF page label includes canvas + view when multi.
+                    const pdfLabel = (multiCanvas && canvasName)
+                        ? `${canvasName} — ${suffix}`
+                        : suffix;
+                    renderedItems.push({
+                        canvasId: cid,
+                        canvasName,
+                        view,
+                        suffix,
+                        fileBase,
+                        pdfLabel,
+                        dataUrl,
+                        width: rasterWidth,
+                        height: rasterHeight,
+                    });
+                }
+            }
+        } finally {
+            // Restore canvas visibility, active canvas, renderer state.
+            visibilitySnapshot.forEach(s => {
+                const c = canvases.find(c => c && c.id === s.id);
+                if (c) c.visible = s.visible;
             });
+            if (this.project) this.project.active_canvas_id = originalActiveCanvasId;
+            window.canvasRenderer.canvas = mainCanvas;
+            window.canvasRenderer.ctx = originalCtx;
+            window.canvasRenderer.exportMode = false;
+            window.canvasRenderer.exportTransparentBg = false;
+            window.canvasRenderer.viewMode = originalViewMode;
+            window.canvasRenderer.zoom = originalZoom;
+            window.canvasRenderer.panX = originalPanX;
+            window.canvasRenderer.panY = originalPanY;
+            window.canvasRenderer.render();
         }
-        
-        // Restore original canvas and context
-        window.canvasRenderer.canvas = mainCanvas;
-        window.canvasRenderer.ctx = originalCtx;
-        window.canvasRenderer.exportMode = false;
-        window.canvasRenderer.exportTransparentBg = false;
-        window.canvasRenderer.viewMode = originalViewMode;
-        window.canvasRenderer.zoom = originalZoom;
-        window.canvasRenderer.panX = originalPanX;
-        window.canvasRenderer.panY = originalPanY;
-        window.canvasRenderer.render();
-        
-        // Handle the export based on format
+
+        // Dispatch to format-specific writer. Multi-canvas just means
+        // more items — each writer already loops over them.
         if (format === 'png') {
-            await this.downloadRenderedPNGs(renderedViews);
+            await this.downloadRenderedPNGs(renderedItems);
         } else if (format === 'pdf') {
-            // Send to server to create PDF
-            await this.downloadAsPdf(projectName, renderedViews);
+            await this.downloadAsPdf(projectName, renderedItems);
         } else if (format === 'psd') {
-            await this.downloadAsPsd(projectName, renderedViews);
+            await this.downloadAsPsd(projectName, renderedItems);
         }
     }
     
@@ -7886,13 +8023,17 @@ class LEDRasterApp {
     }
     
     async downloadAsPdf(projectName, renderedViews) {
+        // Slice 11: multi-canvas PDF. Each rendered item contributes one
+        // page; the per-page name uses canvas + view when multi-canvas
+        // (set on renderedItem.pdfLabel by performExport), else just the
+        // view suffix. Server already handles variable per-page sizes.
         const response = await fetch('/api/export/pdf-from-images', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 project_name: projectName,
                 images: renderedViews.map(v => ({
-                    name: v.suffix,
+                    name: v.pdfLabel || v.suffix,
                     data: v.dataUrl,
                     width: v.width || window.canvasRenderer.rasterWidth,
                     height: v.height || window.canvasRenderer.rasterHeight
@@ -7901,9 +8042,9 @@ class LEDRasterApp {
                 height: window.canvasRenderer.rasterHeight
             })
         });
-        
+
         if (!response.ok) throw new Error('Failed to create PDF');
-        
+
         const blob = await response.blob();
         await this.saveBlobWithPicker(blob, `${projectName}.pdf`, 'application/pdf');
     }
@@ -7911,6 +8052,24 @@ class LEDRasterApp {
     async downloadAsPsd(projectName, renderedViews) {
         const files = [];
         for (const view of renderedViews) {
+            // Slice 11: when exporting per-canvas, only include layers from
+            // that canvas in the PSD layer list — otherwise the PSD reports
+            // sibling canvases' layers as if they were in this image.
+            // Legacy / single-canvas: include every layer (canvasId is null).
+            const psdLayers = this.project.layers.filter(l => {
+                if (!view.canvasId) return true;
+                return l.canvas_id === view.canvasId;
+            }).map(l => {
+                const b = this.getLayerBounds(l);
+                return {
+                    name: l.name,
+                    offset_x: b.x1,
+                    offset_y: b.y1,
+                    width: b.x2 - b.x1,
+                    height: b.y2 - b.y1,
+                    visible: l.visible
+                };
+            });
             const response = await fetch('/api/export/psd-from-image', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -7920,17 +8079,7 @@ class LEDRasterApp {
                     image_data: view.dataUrl,
                     width: view.width || window.canvasRenderer.rasterWidth,
                     height: view.height || window.canvasRenderer.rasterHeight,
-                    layers: this.project.layers.map(l => {
-                        const b = this.getLayerBounds(l);
-                        return {
-                            name: l.name,
-                            offset_x: b.x1,
-                            offset_y: b.y1,
-                            width: b.x2 - b.x1,
-                            height: b.y2 - b.y1,
-                            visible: l.visible
-                        };
-                    })
+                    layers: psdLayers
                 })
             });
             if (!response.ok) throw new Error('Failed to create PSD');

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5550,6 +5550,22 @@ class LEDRasterApp {
         return ordered;
     }
 
+    // v0.8: workspace offset for the layer's parent canvas. Used by every
+    // rect-test that compares workspace-coord rectangles against panel-coord
+    // (canvas-relative) panel positions. Returns {wx:0, wy:0} for legacy
+    // single-canvas projects so existing math is unaffected.
+    _getLayerWorkspaceOffset(layer) {
+        if (!layer || !this.project) return { wx: 0, wy: 0 };
+        const arr = this.project.canvases;
+        if (!Array.isArray(arr) || arr.length === 0) return { wx: 0, wy: 0 };
+        const cid = layer.canvas_id;
+        if (!cid) return { wx: 0, wy: 0 };
+        for (const c of arr) {
+            if (c && c.id === cid) return { wx: c.workspace_x || 0, wy: c.workspace_y || 0 };
+        }
+        return { wx: 0, wy: 0 };
+    }
+
     getLayerBounds(layer) {
         if (layer && (layer.type || 'screen') === 'image') {
             const scale = Number(layer.imageScale) || 1;
@@ -5599,7 +5615,12 @@ class LEDRasterApp {
         const hits = this.project.layers.filter(layer => {
             if (layer.visible === false) return false;
             const b = this.getLayerBounds(layer);
-            const intersects = b.x1 <= maxX && b.x2 >= minX && b.y1 <= maxY && b.y2 >= minY;
+            // Shift bounds by the layer's canvas's workspace offset so they
+            // line up with the workspace-coord rect (rect is in screen-world
+            // space; bounds are canvas-relative).
+            const off = this._getLayerWorkspaceOffset(layer);
+            const intersects = (b.x1 + off.wx) <= maxX && (b.x2 + off.wx) >= minX
+                && (b.y1 + off.wy) <= maxY && (b.y2 + off.wy) >= minY;
             return intersects;
         }).map(l => l.id);
 
@@ -9544,10 +9565,11 @@ class LEDRasterApp {
         if (!layer) return;
         if (!this.isCustomFlow(layer)) return;
         this.customSelection.clear();
-        const minX = Math.min(rect.x1, rect.x2);
-        const maxX = Math.max(rect.x1, rect.x2);
-        const minY = Math.min(rect.y1, rect.y2);
-        const maxY = Math.max(rect.y1, rect.y2);
+        const off = this._getLayerWorkspaceOffset(layer);
+        const minX = Math.min(rect.x1, rect.x2) - off.wx;
+        const maxX = Math.max(rect.x1, rect.x2) - off.wx;
+        const minY = Math.min(rect.y1, rect.y2) - off.wy;
+        const maxY = Math.max(rect.y1, rect.y2) - off.wy;
         layer.panels.forEach(panel => {
             if (panel.hidden) return;
             const intersects = panel.x <= maxX && (panel.x + panel.width) >= minX &&
@@ -9563,10 +9585,14 @@ class LEDRasterApp {
     selectPixelMapPanelsInRect(layer, rect) {
         if (!layer || !rect) return;
         this.pixelMapSelection.clear();
-        const minX = Math.min(rect.x1, rect.x2);
-        const maxX = Math.max(rect.x1, rect.x2);
-        const minY = Math.min(rect.y1, rect.y2);
-        const maxY = Math.max(rect.y1, rect.y2);
+        // rect is in workspace coords; panel coords are canvas-relative —
+        // shift by the layer's parent canvas's workspace offset before
+        // comparing. (No-op for single-canvas projects.)
+        const off = this._getLayerWorkspaceOffset(layer);
+        const minX = Math.min(rect.x1, rect.x2) - off.wx;
+        const maxX = Math.max(rect.x1, rect.x2) - off.wx;
+        const minY = Math.min(rect.y1, rect.y2) - off.wy;
+        const maxY = Math.max(rect.y1, rect.y2) - off.wy;
         // Include hidden ("blank") panels so they can be selected for bulk
         // restore via the sidebar / Alt+click action.
         (layer.panels || []).forEach(panel => {
@@ -9728,10 +9754,11 @@ class LEDRasterApp {
         if (!layer) return;
         if (!this.isCustomPower(layer)) return;
         this.powerCustomSelection.clear();
-        const minX = Math.min(rect.x1, rect.x2);
-        const maxX = Math.max(rect.x1, rect.x2);
-        const minY = Math.min(rect.y1, rect.y2);
-        const maxY = Math.max(rect.y1, rect.y2);
+        const off = this._getLayerWorkspaceOffset(layer);
+        const minX = Math.min(rect.x1, rect.x2) - off.wx;
+        const maxX = Math.max(rect.x1, rect.x2) - off.wx;
+        const minY = Math.min(rect.y1, rect.y2) - off.wy;
+        const maxY = Math.max(rect.y1, rect.y2) - off.wy;
         layer.panels.forEach(panel => {
             if (panel.hidden) return;
             const intersects = panel.x <= maxX && (panel.x + panel.width) >= minX &&

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2080,6 +2080,15 @@ class LEDRasterApp {
             document.getElementById('notes-panel-header').addEventListener('click', toggleNotes);
         }
 
+        // Help panel — same collapse pattern as Notes. Defaults to collapsed
+        // so the layer-groups list above gets the spare space; user can
+        // expand on demand via the header.
+        const helpPanel = document.getElementById('help-tooltip-panel');
+        const helpHeader = document.getElementById('help-tooltip-header');
+        if (helpPanel && helpHeader) {
+            helpHeader.addEventListener('click', () => helpPanel.classList.toggle('collapsed'));
+        }
+
         // View tabs
         document.querySelectorAll('.view-tab').forEach(tab => {
             tab.addEventListener('click', () => {

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7621,10 +7621,16 @@ class LEDRasterApp {
         sendClientLog('save_blob_browser_download', { filename });
     }
 
-    async saveBlobWithPicker(blob, filename, mimeType) {
+    async saveBlobWithPicker(blobOrFn, filename, mimeType) {
         // Sanitize so a project name with "/" or other illegal chars doesn't
         // get rejected by showSaveFilePicker / OS file APIs.
         filename = this.sanitizeFilename(filename);
+        // blobOrFn can be a Blob OR an async function returning one. Lazy-blob
+        // form lets the caller defer expensive serialization (e.g. stringifying
+        // a 1MB project) until AFTER showSaveFilePicker resolves — keeping the
+        // user-activation gesture fresh for createWritable. See bug fix for
+        // 0-byte JSON saves on large multi-canvas projects.
+        const resolveBlob = async () => (typeof blobOrFn === 'function' ? await blobOrFn() : blobOrFn);
         // 1. Try the File System Access API (Chrome/Edge on secure contexts)
         if (window.showSaveFilePicker) {
             try {
@@ -7634,6 +7640,7 @@ class LEDRasterApp {
                     suggestedName: filename,
                     types: [{ description: 'File', accept: { [mimeType]: [`.${ext}`] } }]
                 });
+                const blob = await resolveBlob();
                 const writable = await handle.createWritable();
                 await writable.write(blob);
                 await writable.close();
@@ -7641,7 +7648,18 @@ class LEDRasterApp {
                 return;
             } catch (err) {
                 if (err && err.name === 'AbortError') return;
-                throw err;
+                // NotAllowedError on createWritable: Chrome already created the
+                // empty file via the picker but lost the user-activation needed
+                // to write to it. Fall through to native/browser fallback so we
+                // don't leave the user with a 0-byte file and nothing else.
+                sendClientLog('save_blob_picker_failed', {
+                    filename,
+                    name: err && err.name,
+                    message: err && err.message
+                });
+                // Try native dialog (Mac/Win/Linux) — opens a fresh dialog so
+                // we get our own gesture-bound path. If unavailable, use
+                // browserDownload as last resort.
             }
         }
         // 2. Use native server-side dialog (opens on the host machine)
@@ -7652,6 +7670,7 @@ class LEDRasterApp {
                 return;
             }
             sendClientLog('save_blob_native_dialog_selected', { filename, savePath });
+            const blob = await resolveBlob();
             const ok = await this.nativeWriteFile(savePath, blob);
             if (ok) {
                 sendClientLog('save_blob_native_dialog_success', { filename, savePath });
@@ -7660,6 +7679,15 @@ class LEDRasterApp {
             sendClientLog('save_blob_native_dialog_write_failed', { filename, savePath });
         } catch (err) {
             sendClientLog('save_blob_native_dialog_error', { filename, message: err.message });
+        }
+        // 3. Last resort: trigger a normal browser download so the user always
+        // ends up with a file (even if both the picker and the native dialog
+        // failed). Better than silently leaving a 0-byte stub on disk.
+        try {
+            const blob = await resolveBlob();
+            this.browserDownload(blob, filename);
+        } catch (err) {
+            sendClientLog('save_blob_browser_download_error', { filename, message: err && err.message });
         }
     }
 
@@ -11056,9 +11084,19 @@ class LEDRasterApp {
             this._warnedNoFilePicker = true;
             sendClientLog('save_picker_apis_unavailable_warning', {});
         }
-        const projectData = JSON.stringify(this.project, null, 2);
-        const blob = new Blob([projectData], { type: 'application/json' });
-        await this.saveBlobWithPicker(blob, `${this.project.name}.json`, 'application/json');
+        // Pass a lazy blob factory so JSON.stringify (slow on large multi-canvas
+        // projects, ~1MB) runs AFTER showSaveFilePicker resolves. This keeps
+        // Chrome's user-activation token fresh for createWritable; otherwise
+        // Chrome rejects the write with NotAllowedError and leaves a 0-byte file.
+        const project = this.project;
+        await this.saveBlobWithPicker(
+            () => {
+                const projectData = JSON.stringify(project, null, 2);
+                return new Blob([projectData], { type: 'application/json' });
+            },
+            `${this.project.name}.json`,
+            'application/json'
+        );
 
         this.addToRecentFiles(this.project);
         document.getElementById('status-message').textContent = 'Project saved to file';

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5487,8 +5487,13 @@ class LEDRasterApp {
         if (!this.selectionAnchorLayerId) {
             this.selectionAnchorLayerId = layer.id;
         }
-        // Slice 4: auto-activate this layer's canvas (no-op if already active).
-        this._activateCanvasForLayer(this.currentLayer);
+        // Slice 4 + Slice 13: auto-activate this layer's canvas, but PRESERVE
+        // any existing cross-canvas multi-selection. Without this flag,
+        // setActiveCanvas would drop selected layers in other canvases - which
+        // breaks the "select layers across canvases and bulk-edit them" flow
+        // (e.g. shift-click SR in c1, then DJ in c2, then change panel size on
+        // both at once).
+        this._activateCanvasForLayer(this.currentLayer, { preserveSelection: true });
         this.renderLayers();
         this.loadLayerToInputs();
         window.canvasRenderer.render();
@@ -5509,8 +5514,11 @@ class LEDRasterApp {
         this.selectedLayerIds = new Set(rangeIds);
         this.currentLayer = layer;
         this.lastSelectedLayerId = layer.id;
-        // Slice 4: auto-activate the canvas of the new primary layer.
-        this._activateCanvasForLayer(layer);
+        // Slice 4 + Slice 13: same preserveSelection trick as
+        // toggleLayerSelection so a shift-click range selection that crosses
+        // canvas boundaries doesn't get its other-canvas members culled
+        // when the active canvas auto-switches.
+        this._activateCanvasForLayer(layer, { preserveSelection: true });
         this.renderLayers();
         this.loadLayerToInputs();
         window.canvasRenderer.render();
@@ -11064,7 +11072,13 @@ class LEDRasterApp {
         // the user's mental model consistent ("the active canvas is what
         // I'm working in") and prevents stale highlights on the inactive
         // canvas after a click.
-        if (Array.isArray(this.project.layers) && this.selectedLayerIds && this.selectedLayerIds.size > 0) {
+        // Slice 13 escape hatch: callers performing an explicit cross-canvas
+        // multi-select (shift-click toggle / shift-click range) pass
+        // preserveSelection:true to keep their full selection alive, so the
+        // user can bulk-edit screens across canvases at once.
+        if (!opts.preserveSelection
+                && Array.isArray(this.project.layers)
+                && this.selectedLayerIds && this.selectedLayerIds.size > 0) {
             const layerById = {};
             for (const l of this.project.layers) layerById[l.id] = l;
             const filtered = new Set();
@@ -11075,8 +11089,9 @@ class LEDRasterApp {
             }
             this.selectedLayerIds = filtered;
         }
-        if (this.currentLayer && this.currentLayer.canvas_id
-            && this.currentLayer.canvas_id !== canvasId) {
+        if (!opts.preserveSelection
+                && this.currentLayer && this.currentLayer.canvas_id
+                && this.currentLayer.canvas_id !== canvasId) {
             // Promote the most-recently-selected layer in the new active
             // canvas (if any) to currentLayer, otherwise null.
             let next = null;
@@ -11131,11 +11146,11 @@ class LEDRasterApp {
      * when already active, so we won't spam PUTs from re-selecting the same
      * layer or selecting siblings inside the already-active canvas.
      */
-    _activateCanvasForLayer(layer) {
+    _activateCanvasForLayer(layer, opts) {
         if (!layer || !layer.canvas_id) return;
         if (!this.project) return;
         if (layer.canvas_id === this.project.active_canvas_id) return;
-        this.setActiveCanvas(layer.canvas_id);
+        this.setActiveCanvas(layer.canvas_id, opts);
     }
 
     reorderCanvasBeforeTarget(draggedId, targetId) {

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5080,6 +5080,10 @@ class LEDRasterApp {
             { id: 'text-layer-show-circuits', prop: 'showCircuits', type: 'checkbox' },
             { id: 'text-layer-show-single-phase', prop: 'showSinglePhase', type: 'checkbox' },
             { id: 'text-layer-show-three-phase', prop: 'showThreePhase', type: 'checkbox' },
+            // Slice 10: scope dropdown for the dynamic data/power lines.
+            // 'canvas' = text layer's parent canvas, 'project' = all canvases,
+            // 'both' = render both lines per metric.
+            { id: 'text-layer-dynamic-info-scope', prop: 'dynamicInfoScope', type: 'select' },
             { id: 'text-layer-show-pixel-map', prop: 'showOnPixelMap', type: 'checkbox' },
             { id: 'text-layer-show-cabinet-id', prop: 'showOnCabinetId', type: 'checkbox' },
             { id: 'text-layer-show-data-flow', prop: 'showOnDataFlow', type: 'checkbox' },
@@ -5088,7 +5092,7 @@ class LEDRasterApp {
         fields.forEach(f => {
             const el = document.getElementById(f.id);
             if (!el) return;
-            const event = f.type === 'checkbox' ? 'change' : 'input';
+            const event = f.type === 'checkbox' ? 'change' : (f.type === 'select' ? 'change' : 'input');
             el.addEventListener(event, () => {
                 if (!this.currentLayer || (this.currentLayer.type || 'screen') !== 'text') return;
                 let val;
@@ -5193,6 +5197,8 @@ class LEDRasterApp {
         setChecked('text-layer-show-circuits', !!layer.showCircuits);
         setChecked('text-layer-show-single-phase', !!layer.showSinglePhase);
         setChecked('text-layer-show-three-phase', !!layer.showThreePhase);
+        const scopeSel = document.getElementById('text-layer-dynamic-info-scope');
+        if (scopeSel) scopeSel.value = layer.dynamicInfoScope || 'project';
 
         // Style toggle buttons
         const boldBtn = document.getElementById('text-layer-bold');

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -9846,6 +9846,39 @@ class LEDRasterApp {
         window.canvasRenderer.render();
     }
 
+    /**
+     * Find the OTHER port number (if any) that already owns this panel in
+     * the layer's custom data-flow paths. Returns the conflicting port's
+     * number, or null if the panel is unassigned (or only assigned to the
+     * caller-supplied excludePortNum, which we treat as "not a conflict").
+     */
+    _findPanelOwnerPort(layer, panel, excludePortNum) {
+        if (!layer || !layer.customPortPaths || !panel) return null;
+        const key = `${panel.row},${panel.col}`;
+        for (const portNumStr of Object.keys(layer.customPortPaths)) {
+            const portNum = Number(portNumStr) || portNumStr;
+            if (portNum === excludePortNum) continue;
+            const path = layer.customPortPaths[portNumStr] || [];
+            if (path.some(p => `${p.row},${p.col}` === key)) return portNum;
+        }
+        return null;
+    }
+
+    /**
+     * Same as _findPanelOwnerPort but for power circuits.
+     */
+    _findPanelOwnerCircuit(layer, panel, excludeCircuitNum) {
+        if (!layer || !layer.powerCustomPaths || !panel) return null;
+        const key = `${panel.row},${panel.col}`;
+        for (const circuitNumStr of Object.keys(layer.powerCustomPaths)) {
+            const circuitNum = Number(circuitNumStr) || circuitNumStr;
+            if (circuitNum === excludeCircuitNum) continue;
+            const path = layer.powerCustomPaths[circuitNumStr] || [];
+            if (path.some(p => `${p.row},${p.col}` === key)) return circuitNum;
+        }
+        return null;
+    }
+
     addPanelToCustomPath(panel) {
         if (!this.currentLayer || !panel || panel.hidden) return;
         if (!this.isCustomFlow(this.currentLayer)) return;
@@ -9855,16 +9888,25 @@ class LEDRasterApp {
         if (!this.currentLayer.customPortPaths[portNum]) this.currentLayer.customPortPaths[portNum] = [];
         const key = this.getPanelKey(panel);
         const exists = this.currentLayer.customPortPaths[portNum].some(p => `${p.row},${p.col}` === key);
-        if (!exists) {
-            this.currentLayer.customPortPaths[portNum].push({ row: panel.row, col: panel.col });
-            this.saveState('Custom Path Edit');
-            this.saveClientSideProperties();
-            if (this.customDebug) {
-                console.log('[CustomFlow] Add panel', { portNum, row: panel.row, col: panel.col });
+        if (exists) return;
+        // Reject if the panel already belongs to a different port — user
+        // must clear the existing assignment first. Avoids silent
+        // double-mapping that the user has to undo manually.
+        const conflict = this._findPanelOwnerPort(this.currentLayer, panel, portNum);
+        if (conflict !== null) {
+            if (typeof this._toast === 'function') {
+                this._toast(`Panel R${panel.row + 1}C${panel.col + 1} is already wired to port ${conflict}. Clear it from port ${conflict} first.`, true);
             }
-            this.updatePortLabelEditor();
-            window.canvasRenderer.render();
+            return;
         }
+        this.currentLayer.customPortPaths[portNum].push({ row: panel.row, col: panel.col });
+        this.saveState('Custom Path Edit');
+        this.saveClientSideProperties();
+        if (this.customDebug) {
+            console.log('[CustomFlow] Add panel', { portNum, row: panel.row, col: panel.col });
+        }
+        this.updatePortLabelEditor();
+        window.canvasRenderer.render();
     }
 
     addPanelToCustomPowerPath(panel) {
@@ -9876,15 +9918,21 @@ class LEDRasterApp {
         if (!this.currentLayer.powerCustomPaths[circuitNum]) this.currentLayer.powerCustomPaths[circuitNum] = [];
         const key = this.getPanelKey(panel);
         const exists = this.currentLayer.powerCustomPaths[circuitNum].some(p => `${p.row},${p.col}` === key);
-        if (!exists) {
-            this.currentLayer.powerCustomPaths[circuitNum].push({ row: panel.row, col: panel.col });
-            this.saveState('Power Custom Path Edit');
-            this.saveClientSideProperties();
-            if (this.powerCustomDebug) {
-                console.log('[CustomPower] Add panel', { circuitNum, row: panel.row, col: panel.col });
+        if (exists) return;
+        const conflict = this._findPanelOwnerCircuit(this.currentLayer, panel, circuitNum);
+        if (conflict !== null) {
+            if (typeof this._toast === 'function') {
+                this._toast(`Panel R${panel.row + 1}C${panel.col + 1} is already wired to circuit ${conflict}. Clear it from circuit ${conflict} first.`, true);
             }
-            window.canvasRenderer.render();
+            return;
         }
+        this.currentLayer.powerCustomPaths[circuitNum].push({ row: panel.row, col: panel.col });
+        this.saveState('Power Custom Path Edit');
+        this.saveClientSideProperties();
+        if (this.powerCustomDebug) {
+            console.log('[CustomPower] Add panel', { circuitNum, row: panel.row, col: panel.col });
+        }
+        window.canvasRenderer.render();
     }
 
     handleCustomArrowKey(e) {
@@ -9954,6 +10002,22 @@ class LEDRasterApp {
         if (ordered.length === 0) return;
 
         const portNum = this.currentLayer.customPortIndex || 1;
+        // Reject the entire pattern apply if any selected panel already
+        // belongs to a different port. Prevents silent double-mapping.
+        const conflicts = [];
+        for (const p of ordered) {
+            const owner = this._findPanelOwnerPort(this.currentLayer, p, portNum);
+            if (owner !== null) conflicts.push({ row: p.row, col: p.col, owner });
+        }
+        if (conflicts.length > 0) {
+            const sample = conflicts.slice(0, 3)
+                .map(c => `R${c.row + 1}C${c.col + 1}→port ${c.owner}`).join(', ');
+            const more = conflicts.length > 3 ? ` (+${conflicts.length - 3} more)` : '';
+            if (typeof this._toast === 'function') {
+                this._toast(`Cannot apply: ${conflicts.length} panel${conflicts.length === 1 ? '' : 's'} already wired to other ports — ${sample}${more}.`, true);
+            }
+            return;
+        }
         this.currentLayer.customPortPaths[portNum] = ordered.map(p => ({ row: p.row, col: p.col }));
         this.saveState('Custom Pattern Apply');
         this.saveClientSideProperties();
@@ -10000,6 +10064,22 @@ class LEDRasterApp {
         if (ordered.length === 0) return;
 
         const circuitNum = this.currentLayer.powerCustomIndex || 1;
+        // Reject if any selected panel already belongs to a different
+        // circuit — same policy as data-flow custom pattern apply.
+        const conflicts = [];
+        for (const p of ordered) {
+            const owner = this._findPanelOwnerCircuit(this.currentLayer, p, circuitNum);
+            if (owner !== null) conflicts.push({ row: p.row, col: p.col, owner });
+        }
+        if (conflicts.length > 0) {
+            const sample = conflicts.slice(0, 3)
+                .map(c => `R${c.row + 1}C${c.col + 1}→circuit ${c.owner}`).join(', ');
+            const more = conflicts.length > 3 ? ` (+${conflicts.length - 3} more)` : '';
+            if (typeof this._toast === 'function') {
+                this._toast(`Cannot apply: ${conflicts.length} panel${conflicts.length === 1 ? '' : 's'} already wired to other circuits — ${sample}${more}.`, true);
+            }
+            return;
+        }
         this.currentLayer.powerCustomPaths[circuitNum] = ordered.map(p => ({ row: p.row, col: p.col }));
         this.saveState('Power Custom Pattern Apply');
         this.saveClientSideProperties();

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10484,7 +10484,6 @@ class LEDRasterApp {
     }
 
     addCanvas() {
-        if (typeof this.saveState === 'function') this.saveState('Add Canvas');
         // Seed new canvases from the user's preferred default canvas size so
         // every "+ Add Canvas" click matches the same baseline as a brand-new
         // project, not whatever the currently active canvas happens to be.
@@ -10502,32 +10501,35 @@ class LEDRasterApp {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)
-        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+        }).then(r => r.json()).then(data => {
+            this._applyProjectUpdate(data);
+            // saveState AFTER mutation so the snapshot captures the new canvas.
+            // One Cmd+Z then reverts exactly this Add.
+            if (typeof this.saveState === 'function') this.saveState('Add Canvas');
+        });
     }
 
     // Canvas mutation routed through one helper so every mutating call
-    // gets an undo entry. Most callers don't pass `opts`; canvas-drag
-    // mouseup passes skipSaveState because a 'Move Canvas' snapshot was
-    // already taken at drag-start.
-    updateCanvas(canvasId, patch, opts) {
-        if (typeof this.saveState === 'function' && !(opts && opts.skipSaveState)) {
-            // Pick the most informative undo label from the patch keys.
-            const keys = patch ? Object.keys(patch) : [];
-            let label = 'Update Canvas';
-            if (keys.includes('name')) label = 'Rename Canvas';
-            else if (keys.includes('color')) label = 'Change Canvas Color';
-            else if (keys.includes('visible')) label = 'Toggle Canvas Visibility';
-            else if (keys.includes('workspace_x') || keys.includes('workspace_y')) label = 'Move Canvas';
-            else if (keys.includes('raster_width') || keys.includes('raster_height')
-                || keys.includes('show_raster_width') || keys.includes('show_raster_height')) label = 'Resize Canvas';
-            else if (keys.includes('data_flow_perspective') || keys.includes('power_perspective')) label = 'Change Perspective';
-            this.saveState(label);
-        }
+    // gets one (and only one) post-mutation undo entry.
+    updateCanvas(canvasId, patch) {
+        // Pick the most informative undo label from the patch keys.
+        const keys = patch ? Object.keys(patch) : [];
+        let label = 'Update Canvas';
+        if (keys.includes('name')) label = 'Rename Canvas';
+        else if (keys.includes('color')) label = 'Change Canvas Color';
+        else if (keys.includes('visible')) label = 'Toggle Canvas Visibility';
+        else if (keys.includes('workspace_x') || keys.includes('workspace_y')) label = 'Move Canvas';
+        else if (keys.includes('raster_width') || keys.includes('raster_height')
+            || keys.includes('show_raster_width') || keys.includes('show_raster_height')) label = 'Resize Canvas';
+        else if (keys.includes('data_flow_perspective') || keys.includes('power_perspective')) label = 'Change Perspective';
         return fetch(`/api/canvas/${canvasId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(patch || {})
-        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+        }).then(r => r.json()).then(data => {
+            this._applyProjectUpdate(data);
+            if (typeof this.saveState === 'function') this.saveState(label);
+        });
     }
 
     /**
@@ -10537,18 +10539,8 @@ class LEDRasterApp {
      * - "duplicate": new layer id appended in target canvas; original
      *   stays put and remains selected.
      */
-    moveLayerCrossCanvas(layerId, targetCanvasId, mode, opts) {
+    moveLayerCrossCanvas(layerId, targetCanvasId, mode) {
         const wantMove = (mode !== 'duplicate');
-        // Canvas-drag callers pass skipSaveState:true because the drag-start
-        // already pushed a 'Move Layers' snapshot. Without this option we'd
-        // capture a SECOND snapshot here mid-drag, which contains the
-        // dragged-but-not-yet-cross-canvas state (offset_x at the dragged
-        // position, layer still in source canvas) — so single undo flew
-        // the layer to weird intermediate coords instead of jumping back
-        // to pre-drag.
-        if (typeof this.saveState === 'function' && !(opts && opts.skipSaveState)) {
-            this.saveState(wantMove ? 'Move Layer to Canvas' : 'Duplicate Layer to Canvas');
-        }
         return fetch(`/api/layer/${layerId}/canvas`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
@@ -10568,6 +10560,12 @@ class LEDRasterApp {
                     }
                 }
             }
+            // saveState AFTER server applies the cross-canvas move so the
+            // snapshot includes the canvas_id swap + the snap-to-(0,0) offset
+            // reset. Single Cmd+Z reverts the whole operation.
+            if (typeof this.saveState === 'function') {
+                this.saveState(wantMove ? 'Move Layer to Canvas' : 'Duplicate Layer to Canvas');
+            }
             // For duplicate: leave selection on the original (default behavior).
             return data;
         });
@@ -10579,16 +10577,9 @@ class LEDRasterApp {
      * layers stay selected and the active canvas follows. Mode applies
      * to ALL layers in the batch (move OR duplicate, not mixed).
      */
-    async moveLayersCrossCanvas(layerIds, targetCanvasId, mode, opts) {
+    async moveLayersCrossCanvas(layerIds, targetCanvasId, mode) {
         const wantMove = (mode !== 'duplicate');
         if (!Array.isArray(layerIds) || layerIds.length === 0) return;
-        // Same skipSaveState convention as moveLayerCrossCanvas — canvas-drag
-        // callers already snapshotted pre-drag.
-        if (typeof this.saveState === 'function' && !(opts && opts.skipSaveState)) {
-            this.saveState(wantMove
-                ? `Move ${layerIds.length} Layers to Canvas`
-                : `Duplicate ${layerIds.length} Layers to Canvas`);
-        }
         let lastData = null;
         for (const id of layerIds) {
             const r = await fetch(`/api/layer/${id}/canvas`, {
@@ -10611,6 +10602,13 @@ class LEDRasterApp {
                 if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
                     window.canvasRenderer.render();
                 }
+            }
+            // saveState AFTER all PUTs settle so one Cmd+Z reverts the whole
+            // multi-layer cross-canvas move/duplicate.
+            if (typeof this.saveState === 'function') {
+                this.saveState(wantMove
+                    ? `Move ${layerIds.length} Layers to Canvas`
+                    : `Duplicate ${layerIds.length} Layers to Canvas`);
             }
         }
         return lastData;
@@ -10653,7 +10651,6 @@ class LEDRasterApp {
     }
 
     deleteCanvas(canvasId) {
-        if (typeof this.saveState === 'function') this.saveState('Delete Canvas');
         return fetch(`/api/canvas/${canvasId}`, { method: 'DELETE' })
             .then(r => r.json().then(body => ({ ok: r.ok, body })))
             .then(({ ok, body }) => {
@@ -10662,13 +10659,16 @@ class LEDRasterApp {
                     return;
                 }
                 this._applyProjectUpdate(body);
+                if (typeof this.saveState === 'function') this.saveState('Delete Canvas');
             });
     }
 
     duplicateCanvas(canvasId) {
-        if (typeof this.saveState === 'function') this.saveState('Duplicate Canvas');
         return fetch(`/api/canvas/${canvasId}/duplicate`, { method: 'POST' })
-            .then(r => r.json()).then(data => this._applyProjectUpdate(data));
+            .then(r => r.json()).then(data => {
+                this._applyProjectUpdate(data);
+                if (typeof this.saveState === 'function') this.saveState('Duplicate Canvas');
+            });
     }
 
     setActiveCanvas(canvasId, opts = {}) {
@@ -10764,23 +10764,27 @@ class LEDRasterApp {
         if (from < 0 || to < 0 || from === to) return;
         ids.splice(from, 1);
         ids.splice(ids.indexOf(targetId), 0, draggedId);
-        if (typeof this.saveState === 'function') this.saveState('Reorder Canvases');
         return fetch('/api/canvas/reorder', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ canvas_ids: ids })
-        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+        }).then(r => r.json()).then(data => {
+            this._applyProjectUpdate(data);
+            if (typeof this.saveState === 'function') this.saveState('Reorder Canvases');
+        });
     }
 
     moveLayerToCanvas(layerId, canvasId, mode = 'move') {
-        if (typeof this.saveState === 'function') {
-            this.saveState(mode === 'duplicate' ? 'Duplicate Layer to Canvas' : 'Move Layer to Canvas');
-        }
         return fetch(`/api/layer/${layerId}/canvas`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ canvas_id: canvasId, mode })
-        }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
+        }).then(r => r.json()).then(data => {
+            this._applyProjectUpdate(data);
+            if (typeof this.saveState === 'function') {
+                this.saveState(mode === 'duplicate' ? 'Duplicate Layer to Canvas' : 'Move Layer to Canvas');
+            }
+        });
     }
 
     // v0.8 Slice 2.5: per-canvas "+ Add" chooser (Screen / Image / Text).

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10455,6 +10455,43 @@ class LEDRasterApp {
             return Promise.resolve();
         }
         this.project.active_canvas_id = canvasId;
+        // Slice 5: active canvas constrains selection. Drop any selected
+        // layer ids that don't belong to the new active canvas, and clear
+        // currentLayer if it's now in a different canvas. Layers without a
+        // canvas_id (legacy / orphan) are kept on the safe side. This keeps
+        // the user's mental model consistent ("the active canvas is what
+        // I'm working in") and prevents stale highlights on the inactive
+        // canvas after a click.
+        if (Array.isArray(this.project.layers) && this.selectedLayerIds && this.selectedLayerIds.size > 0) {
+            const layerById = {};
+            for (const l of this.project.layers) layerById[l.id] = l;
+            const filtered = new Set();
+            for (const id of this.selectedLayerIds) {
+                const l = layerById[id];
+                if (!l) continue;
+                if (!l.canvas_id || l.canvas_id === canvasId) filtered.add(id);
+            }
+            this.selectedLayerIds = filtered;
+        }
+        if (this.currentLayer && this.currentLayer.canvas_id
+            && this.currentLayer.canvas_id !== canvasId) {
+            // Promote the most-recently-selected layer in the new active
+            // canvas (if any) to currentLayer, otherwise null.
+            let next = null;
+            if (this.selectedLayerIds && this.selectedLayerIds.size > 0
+                && Array.isArray(this.project.layers)) {
+                const lastId = this.lastSelectedLayerId;
+                if (lastId && this.selectedLayerIds.has(lastId)) {
+                    next = this.project.layers.find(l => l.id === lastId) || null;
+                }
+                if (!next) {
+                    const firstId = this.selectedLayerIds.values().next().value;
+                    next = this.project.layers.find(l => l.id === firstId) || null;
+                }
+            }
+            this.currentLayer = next;
+            if (!next) this.lastSelectedLayerId = null;
+        }
         // Slice 4: toolbar raster reflects the active canvas's raster.
         // Mirror the active canvas's raster_* into project root + renderer
         // so syncRasterFromProject populates the toolbar inputs correctly.

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -3583,6 +3583,12 @@ class LEDRasterApp {
                     }
                 }
                 renderer.rasterWidth = width;
+                // Slice 3 patch: the renderer now reads each canvas's own
+                // raster_* fields (per-canvas outlines). Mirror the toolbar
+                // edit onto the active canvas so the visual size actually
+                // changes. Slice 6 will switch source-of-truth fully and
+                // remove the project-root writes above.
+                this._mirrorRasterToActiveCanvas(isShow ? 'show' : 'pixel', width, null, wasLinked);
                 if (this.project) this.saveProject();
                 this.saveRasterSize();
                 if (typeof sendClientLog === 'function') {
@@ -3611,6 +3617,7 @@ class LEDRasterApp {
                     }
                 }
                 renderer.rasterHeight = height;
+                this._mirrorRasterToActiveCanvas(isShow ? 'show' : 'pixel', null, height, wasLinked);
                 if (this.project) this.saveProject();
                 this.saveRasterSize();
                 if (typeof sendClientLog === 'function') {
@@ -10721,6 +10728,30 @@ class LEDRasterApp {
         this.saveProject();
     }
     
+    // Slice 3 helper: mirror a toolbar raster edit onto the active canvas's
+    // raster_* / show_raster_* fields so the visual canvas-rect actually
+    // resizes. Called by the toolbar Raster width/height change handlers.
+    // `view` is 'show' or 'pixel'. Pass the new width OR height; pass null
+    // for whichever axis isn't being changed. `wasLinked` mirrors the
+    // pixel-map → show-look auto-sync behavior already present at the
+    // project root.
+    _mirrorRasterToActiveCanvas(view, width, height, wasLinked) {
+        if (!this.project || !this.project.canvases || !this.project.active_canvas_id) return;
+        const c = this.project.canvases.find(c => c.id === this.project.active_canvas_id);
+        if (!c) return;
+        if (view === 'show') {
+            if (width != null)  c.show_raster_width  = width;
+            if (height != null) c.show_raster_height = height;
+        } else {
+            if (width != null)  c.raster_width  = width;
+            if (height != null) c.raster_height = height;
+            if (wasLinked) {
+                if (width != null)  c.show_raster_width  = width;
+                if (height != null) c.show_raster_height = height;
+            }
+        }
+    }
+
     saveProject() {
         fetch('/api/project', {
             method: 'POST',

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7631,8 +7631,13 @@ class LEDRasterApp {
         // user-activation gesture fresh for createWritable. See bug fix for
         // 0-byte JSON saves on large multi-canvas projects.
         const resolveBlob = async () => (typeof blobOrFn === 'function' ? await blobOrFn() : blobOrFn);
-        // 1. Try the File System Access API (Chrome/Edge on secure contexts)
-        if (window.showSaveFilePicker) {
+        // 1. Try the File System Access API (Chrome/Edge on secure contexts).
+        //    Skip on localhost — we have a better server-side native dialog
+        //    available that doesn't break on cloud-synced folders (Nextcloud,
+        //    iCloud, Dropbox, OneDrive). Chrome's createWritable rejects with
+        //    NotAllowedError when the target lives under a sync agent's xattrs,
+        //    which produced 0-byte saves before this guard.
+        if (window.showSaveFilePicker && !this.isLocalConnection()) {
             try {
                 sendClientLog('save_blob_picker_start', { filename, mimeType });
                 const ext = filename.split('.').pop() || '';

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2220,9 +2220,17 @@ class LEDRasterApp {
             let value = zoomInput.value.replace('%', '').trim();
             let percent = parseFloat(value);
             if (!isNaN(percent) && percent > 0) {
-                window.canvasRenderer.setZoom(percent / 100);
+                // Convert displayed percent (1:1 device-pixel based) into the
+                // internal raster→CSS scale used by canvasRenderer.
+                const targetZoom = (typeof window.canvasRenderer._percentToZoom === 'function')
+                    ? window.canvasRenderer._percentToZoom(percent)
+                    : percent / 100;
+                window.canvasRenderer.setZoom(targetZoom);
             }
-            zoomInput.value = `${Math.round(window.canvasRenderer.zoom * 100)}%`;
+            const displayed = (typeof window.canvasRenderer._zoomToPercent === 'function')
+                ? window.canvasRenderer._zoomToPercent(window.canvasRenderer.zoom)
+                : Math.round(window.canvasRenderer.zoom * 100);
+            zoomInput.value = `${displayed}%`;
         });
         zoomInput.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
@@ -10451,6 +10459,20 @@ class LEDRasterApp {
             try { this.syncRasterFromProject(); } catch (_) {}
         }
         this.renderLayers();
+        // Rebind currentLayer to the fresh object in the new project payload
+        // (same id, new reference) and refresh the settings panel inputs so
+        // post-mutation values (offset_x snapped to 0,0 after a cross-canvas
+        // move, raster size after a resize, etc.) propagate without forcing
+        // the user to deselect+reselect to see the change.
+        if (this.currentLayer && data.layers) {
+            const refreshed = data.layers.find(l => l.id === this.currentLayer.id);
+            if (refreshed) {
+                this.currentLayer = refreshed;
+                if (typeof this.loadLayerToInputs === 'function') {
+                    try { this.loadLayerToInputs(); } catch (_) {}
+                }
+            }
+        }
         // Re-render the workspace canvas. The previous `if (this.render)`
         // check was always false (app has no .render method), so the
         // workspace pixels never refreshed after a canvas CRUD response —

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1008,7 +1008,7 @@ class LEDRasterApp {
                 // The CSS width transition runs ~180ms. Reposition the
                 // toggle and resize the canvas at multiple points during /
                 // after the animation so the canvas always fills the
-                // available wrapper width — otherwise the canvas keeps its
+                // available wrapper width, otherwise the canvas keeps its
                 // pre-collapse pixel dimensions and the user sees a black
                 // strip on the side where the sidebar used to be.
                 requestAnimationFrame(() => { positionToggle(); resizeCanvas(); });
@@ -1067,11 +1067,11 @@ class LEDRasterApp {
             const prefResp = await fetch('/api/preferences');
             const serverPrefs = await prefResp.json();
             if (serverPrefs && Object.keys(serverPrefs).length > 0) {
-                // Server has preferences — use them (overrides localStorage)
+                // Server has preferences, use them (overrides localStorage)
                 this._serverPreferences = serverPrefs;
                 console.log('Loaded server-side preferences:', Object.keys(serverPrefs));
             } else {
-                // No server prefs yet — seed from localStorage if available
+                // No server prefs yet, seed from localStorage if available
                 const localPrefs = this.getLocalPreferences();
                 if (Object.keys(localPrefs).length > 0) {
                     this._serverPreferences = localPrefs;
@@ -1139,7 +1139,7 @@ class LEDRasterApp {
             }
 
             // Restore client-side properties and layer defaults.
-            // On reconnect (after sleep), skip preference enforcement — the project
+            // On reconnect (after sleep), skip preference enforcement, the project
             // already has the correct state from before the disconnect.
             this.loadClientSideProperties({ skipPreferences: this._initialLoadComplete });
             
@@ -1326,7 +1326,7 @@ class LEDRasterApp {
                 // Save initial state for undo/redo
                 this.resetHistory('Initial State');
 
-                // Mark initial load complete — subsequent socket project_data
+                // Mark initial load complete, subsequent socket project_data
                 // events are reconnects and should not re-apply preferences.
                 this._initialLoadComplete = true;
 
@@ -1505,7 +1505,7 @@ class LEDRasterApp {
             if (layer.infoLabelSize === undefined) layer.infoLabelSize = 14;
             if (layer.showDataFlowPortInfo === undefined) layer.showDataFlowPortInfo = false;
             if (layer.showPowerCircuitInfo === undefined) layer.showPowerCircuitInfo = false;
-            // Show Look position — default to processor offset for older
+            // Show Look position, default to processor offset for older
             // projects so they open looking identical to before.
             if (layer.showOffsetX === undefined || layer.showOffsetX === null) {
                 layer.showOffsetX = layer.offset_x || 0;
@@ -1708,8 +1708,8 @@ class LEDRasterApp {
      * show_raster_* on the active canvas so older projects (where show
      * raster was never set) open with show = pixel.
      *
-     * Renderer fields are accessor-backed (Slice 6) — they read straight
-     * from the active canvas — so no per-renderer assignment is needed.
+     * Renderer fields are accessor-backed (Slice 6), they read straight
+     * from the active canvas, so no per-renderer assignment is needed.
      * Legacy fallback (no canvases array): seed the renderer's _fallback*
      * backing fields from the project root so single-canvas pre-Slice-1
      * projects still display.
@@ -1726,7 +1726,7 @@ class LEDRasterApp {
                 if (!c.show_raster_height) c.show_raster_height = c.raster_height;
             }
         } else {
-            // Pre-Slice-1 project — seed the renderer's fallback backing
+            // Pre-Slice-1 project, seed the renderer's fallback backing
             // fields so the legacy single-canvas getter path returns sane
             // values until the project gets migrated by the server.
             const pw = Number(this.project.raster_width) || 1920;
@@ -1746,7 +1746,7 @@ class LEDRasterApp {
     
     // Load raster size from localStorage (checks version first).
     //
-    // Slice 6: at boot the project hasn't loaded yet — the active canvas's
+    // Slice 6: at boot the project hasn't loaded yet, the active canvas's
     // raster is the source of truth and we must NOT clobber it with stale
     // localStorage. So we only seed the renderer's fallback backing fields
     // (used when no canvases array exists yet) and refresh the toolbar
@@ -1953,7 +1953,7 @@ class LEDRasterApp {
         this.renderLayers();
         this.loadTextLayerToInputs();
         // Slice 10: keep the Totals panels (Data Flow + Power tabs) in sync
-        // with whatever just changed. Always cheap — two aggregations over
+        // with whatever just changed. Always cheap, two aggregations over
         // the visible screen layers, plus a handful of textContent writes.
         if (typeof this.refreshTotalsSidebar === 'function') {
             try { this.refreshTotalsSidebar(); } catch (_) {}
@@ -2073,7 +2073,7 @@ class LEDRasterApp {
      * v0.8 Slice 10: paint the Totals panels on the Data Flow + Power tabs.
      * Two columns each: active canvas + project-wide. Numbers come from
      * getPortCounts/getPowerCounts which already exclude hidden canvases.
-     * Cheap to call on every updateUI — the Totals panels are display:none
+     * Cheap to call on every updateUI, the Totals panels are display:none
      * unless the user is on the relevant tab.
      */
     refreshTotalsSidebar() {
@@ -2092,7 +2092,7 @@ class LEDRasterApp {
         setText('data-totals-canvas-backup', dataCanvas.backup);
         setText('data-totals-project-primary', dataProject.primary);
         setText('data-totals-project-backup', dataProject.backup);
-        // Power totals — show "0" cleanly when there's no active canvas / no
+        // Power totals, show "0" cleanly when there's no active canvas / no
         // load yet. Amps formatted to 2 decimals to match the per-layer
         // capacity readout.
         const pwrCanvas = activeId ? this.getPowerCounts(activeId)
@@ -2181,7 +2181,7 @@ class LEDRasterApp {
             document.getElementById('notes-panel-header').addEventListener('click', toggleNotes);
         }
 
-        // Help panel — same collapse pattern as Notes. Defaults to collapsed
+        // Help panel, same collapse pattern as Notes. Defaults to collapsed
         // so the layer-groups list above gets the spare space; user can
         // expand on demand via the header.
         const helpPanel = document.getElementById('help-tooltip-panel');
@@ -2613,7 +2613,7 @@ class LEDRasterApp {
             }
         });
         
-        // Screen Name checkboxes on other tabs — each writes its own per-tab property
+        // Screen Name checkboxes on other tabs, each writes its own per-tab property
         const tabLabelMap = {
             'show-label-name-cabinet': 'showLabelNameCabinet',
             'show-label-name-data': 'showLabelNameDataFlow',
@@ -3687,11 +3687,11 @@ class LEDRasterApp {
                 // Slice 6: the toolbar Raster: W x H field is the active
                 // canvas's raster (Pixel Map raster on pixel-map / cabinet-id;
                 // Show Look raster on show-look / data / power). Writes go
-                // straight to the active canvas via PUT /api/canvas/<id> —
+                // straight to the active canvas via PUT /api/canvas/<id>,
                 // no project-root mirror, no _mirrorRasterToActiveCanvas hack.
                 //
                 // While show raster equals pixel raster ("linked"), changing
-                // the pixel raster also updates the show raster — Show Look
+                // the pixel raster also updates the show raster, Show Look
                 // tracks Pixel Map by default until the user splits them.
                 const renderer = window.canvasRenderer;
                 const isShow = renderer.isShowLookView();
@@ -3773,7 +3773,7 @@ class LEDRasterApp {
                 format
             });
             
-            // Resolume XML export — no views needed, just geometry
+            // Resolume XML export, no views needed, just geometry
             if (format === 'resolume-xml') {
                 document.getElementById('export-modal').style.display = 'none';
                 document.getElementById('status-message').textContent = 'Exporting Resolume XML...';
@@ -3805,7 +3805,7 @@ class LEDRasterApp {
             // Slice 11: collect selected canvas IDs from the dynamic
             // checklist. If the project has no canvases array (legacy /
             // pre-Slice-1 fallback), pass [null] so performExport treats it
-            // as a single synthetic canvas using project-root raster dims —
+            // as a single synthetic canvas using project-root raster dims,
             // matching v0.7 export behaviour exactly.
             const canvasIds = this.getSelectedExportCanvasIds();
             if (canvasIds.length === 0) {
@@ -4110,7 +4110,7 @@ class LEDRasterApp {
         if (!modal || !list) return;
         list.innerHTML = '<div style="padding: 12px; color: #888; font-size: 12px;">Loading…</div>';
         modal.style.display = 'block';
-        // Selection model: { type: 'preset'|'panel', key } — default preset is always '__default__'
+        // Selection model: { type: 'preset'|'panel', key }, default preset is always '__default__'
         this._pickerSelection = { type: 'preset', key: '__default__' };
         this._updatePickerSummary();
         this._renderPresetPickerLeftColumn();
@@ -4174,7 +4174,7 @@ class LEDRasterApp {
                 item.dataset.kind = row.kind;
                 item.dataset.id = row.id;
                 item.style.cssText = 'padding: 10px 12px; border-radius: 4px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; gap: 8px;';
-                // Default + non-default rows get drag enabled (except default — it stays pinned)
+                // Default + non-default rows get drag enabled (except default, it stays pinned)
                 if (row.kind !== 'default') {
                     item.draggable = true;
                     this._wirePresetRowDrag(item);
@@ -4184,7 +4184,7 @@ class LEDRasterApp {
                 leftCol.style.cssText = 'flex: 1; min-width: 0; overflow: hidden;';
                 leftCol.innerHTML = `<div style="color:#fff; font-size:13px; font-weight:500; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${this.escapeHtml(row.label)}</div><div style="color:#888; font-size:11px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${row.sublabel}</div>`;
                 item.appendChild(leftCol);
-                // Heart on favorite rows (always filled — clicking removes from favorites)
+                // Heart on favorite rows (always filled, clicking removes from favorites)
                 if (row.kind === 'favorite') {
                     const heartBtn = document.createElement('button');
                     heartBtn.className = 'btn';
@@ -4366,7 +4366,7 @@ class LEDRasterApp {
         });
     }
 
-    // Background check on app boot — fetches the upstream catalog SHA and
+    // Background check on app boot, fetches the upstream catalog SHA and
     // stashes the fresh catalog in localStorage if it differs from what the
     // user currently has loaded. Sets `_catalogUpdateAvailable` so the picker
     // can show an "Update available" badge next time it's opened.
@@ -4396,7 +4396,7 @@ class LEDRasterApp {
             }).catch(() => ({}));
         infoFetch.then(() => fetch('/api/panel-catalog/refresh').then(r => r.ok ? r.json() : Promise.reject(r)))
             .then(apply)
-            .catch(() => { /* offline / blocked — silently keep current */ });
+            .catch(() => { /* offline / blocked, silently keep current */ });
     }
 
     // Manual user-triggered refresh from the button in the catalog header.
@@ -4433,13 +4433,13 @@ class LEDRasterApp {
                 this._renderCatalogSourceTag();
                 if (!opts.silent) {
                     const count = payload.panelCount || 0;
-                    this._toast(`Catalog refreshed — ${count.toLocaleString()} panels`);
+                    this._toast(`Catalog refreshed, ${count.toLocaleString()} panels`);
                 }
             })
             .catch((err) => {
                 if (!opts.silent) {
                     const detail = err && err.error ? ` (${err.error})` : '';
-                    this._toast(`Couldn’t reach GitHub — keeping current catalog${detail}`, true);
+                    this._toast(`Couldn’t reach GitHub, keeping current catalog${detail}`, true);
                 }
             })
             .finally(() => {
@@ -4478,7 +4478,7 @@ class LEDRasterApp {
                     this._loadPanelCatalog();
                     this._toast('Catalog updated');
                 } else {
-                    // Pending data wasn't stashed (boot check failed?) — fall back to a fresh refresh
+                    // Pending data wasn't stashed (boot check failed?), fall back to a fresh refresh
                     this.refreshPanelCatalogNow();
                 }
             };
@@ -4529,7 +4529,7 @@ class LEDRasterApp {
         // source string mentions an authoritative site.
         if (/\b(est|estimated|derived|same as|inferred|approx)\b/.test(s)) return false;
         if (/\+\s*(frame|air frame|t4|ladder|windbrace|spotlight)/.test(s)) return false;
-        // Trusted sources — manufacturer's own site / PDF, or a reputable
+        // Trusted sources, manufacturer's own site / PDF, or a reputable
         // third-party dealer that publishes the full datasheet.
         if (s.startsWith('official:')) return true;
         if (s.startsWith('roevisual')) return true;          // roevisual.com (ROE)
@@ -4641,11 +4641,11 @@ class LEDRasterApp {
             if (p.pixels_w != null) parts.push(`${p.pixels_w}×${p.pixels_h}px`);
             if (p.weight_kg != null) parts.push(`${p.weight_kg}kg`);
             if (p.watts_max != null) parts.push(`${p.watts_max}W`);
-            summary.textContent = `Panel: ${sel.label} — ${parts.join(' · ')}`;
+            summary.textContent = `Panel: ${sel.label}, ${parts.join(' · ')}`;
         } else if (sel.type === 'preset' && sel.key && sel.key !== '__default__') {
             summary.textContent = `Preset: ${sel.label || sel.key}`;
         } else {
-            summary.textContent = 'Default — uses your Preferences values.';
+            summary.textContent = 'Default, uses your Preferences values.';
         }
     }
 
@@ -4747,8 +4747,8 @@ class LEDRasterApp {
         }
 
         const notesPrompt = (mode === 'fix')
-            ? `What's wrong with "${panelRef}"?\n\nDescribe the discrepancy. After you click OK we'll open a GitHub issue — drag any spec sheet PDF or a photo of the panel back into the comment box there to attach it.`
-            : `Tell us about "${panelRef}" — paste any specs you have (cabinet mm, pixels, weight, max watts).\n\nAfter you click OK we'll open a GitHub issue — drag the official spec sheet PDF or a photo of the panel back into the comment box to attach it.`;
+            ? `What's wrong with "${panelRef}"?\n\nDescribe the discrepancy. After you click OK we'll open a GitHub issue, drag any spec sheet PDF or a photo of the panel back into the comment box there to attach it.`
+            : `Tell us about "${panelRef}", paste any specs you have (cabinet mm, pixels, weight, max watts).\n\nAfter you click OK we'll open a GitHub issue, drag the official spec sheet PDF or a photo of the panel back into the comment box to attach it.`;
         const notes = window.prompt(notesPrompt, '');
         if (notes === null) return;  // cancelled
 
@@ -4759,7 +4759,7 @@ class LEDRasterApp {
             `**Panel:** ${panelRef}`,
             '',
             '**Current catalog values:**',
-            currentValues || '_(no panel selected — please paste the catalog values you saw)_',
+            currentValues || '_(no panel selected, please paste the catalog values you saw)_',
             '',
             '**What\'s wrong:**',
             notes || '_(left blank)_',
@@ -4789,7 +4789,7 @@ class LEDRasterApp {
             body: bodyLines.join('\n'),
         });
         const url = `https://github.com/kman1898/LED-Raster-Designer/issues/new?${params.toString()}`;
-        // Make sure the user knows the GitHub tab is the actual submission —
+        // Make sure the user knows the GitHub tab is the actual submission,
         // we've had submissions get lost because the user filled out the
         // app-side prompts and assumed that was enough.
         const ok = confirm(
@@ -5780,7 +5780,7 @@ class LEDRasterApp {
         this.selectedLayerIds = new Set([layer.id]);
         this.lastSelectedLayerId = layer.id;
         this.selectionAnchorLayerId = layer.id;
-        // Slice 4: auto-activate this layer's canvas. Idempotent — short-
+        // Slice 4: auto-activate this layer's canvas. Idempotent, short-
         // circuits when already active so programmatic selectLayer calls
         // (post-load, post-create, post-delete) don't fire spurious PUTs.
         this._activateCanvasForLayer(layer);
@@ -5904,7 +5904,7 @@ class LEDRasterApp {
         // Repopulate the active view's per-layer label editor so the port-rename
         // (data-flow view) or circuit-rename (power view) sidebar reflects the
         // newly selected layer immediately. Without this, the editor only
-        // refreshed the next time something else nudged it — which made the
+        // refreshed the next time something else nudged it, which made the
         // first click after a layer-change appear empty until a second click.
         const viewMode = window.canvasRenderer && window.canvasRenderer.viewMode;
         if (viewMode === 'data-flow') {
@@ -6205,7 +6205,7 @@ class LEDRasterApp {
 
         const requests = layers.map(layer => {
             const preservedProps = {
-                // Show Look position — keep in sync across the server
+                // Show Look position, keep in sync across the server
                 // round-trip (server whitelists the field, but echoing the
                 // same value is safer than dropping it).
                 showOffsetX: layer.showOffsetX,
@@ -6274,7 +6274,7 @@ class LEDRasterApp {
                 _powerTotalAmps3: layer._powerTotalAmps3,
                 _powerCircuitsRequired: layer._powerCircuitsRequired,
                 // Preserve client-computed port counts across the server
-                // roundtrip — server doesn't whitelist these fields, so its
+                // roundtrip, server doesn't whitelist these fields, so its
                 // echo carries stale values that would otherwise overwrite
                 // the freshly recomputed numbers (causes ports-required and
                 // the port-rename editor to show too few ports in custom
@@ -6584,7 +6584,7 @@ class LEDRasterApp {
             if (!el) return;
             if (common.mixed) {
                 el.value = '';
-                el.placeholder = '—';
+                el.placeholder = '-';
             } else {
                 el.value = common.value;
                 el.placeholder = '';
@@ -6604,7 +6604,7 @@ class LEDRasterApp {
 
         setTextInput('offset-x', getCommon(l => l.offset_x));
         setTextInput('offset-y', getCommon(l => l.offset_y));
-        // Show Look offsets — separate from processor offsets (Pixel Map).
+        // Show Look offsets, separate from processor offsets (Pixel Map).
         setTextInput('show-offset-x', getCommon(l => (l.showOffsetX ?? l.offset_x) || 0));
         setTextInput('show-offset-y', getCommon(l => (l.showOffsetY ?? l.offset_y) || 0));
 
@@ -6616,7 +6616,7 @@ class LEDRasterApp {
             const scaleCommon = getCommon(l => Math.round((l.imageScale || 1) * 100));
             if (imageScaleEl) {
                 imageScaleEl.value = scaleCommon.mixed ? '' : scaleCommon.value;
-                imageScaleEl.placeholder = scaleCommon.mixed ? '—' : '';
+                imageScaleEl.placeholder = scaleCommon.mixed ? '-' : '';
             }
             if (imageScaleRangeEl) {
                 imageScaleRangeEl.value = scaleCommon.mixed ? '100' : String(scaleCommon.value);
@@ -6635,7 +6635,7 @@ class LEDRasterApp {
                 imageScaleRangeEl.value = '100';
             }
             if (imageSizeEl) {
-                imageSizeEl.textContent = '—';
+                imageSizeEl.textContent = '-';
             }
         }
         setTextInput('cabinet-width', getCommon(l => l.cabinet_width));
@@ -6702,7 +6702,7 @@ class LEDRasterApp {
             if (hex) {
                 if (common.mixed) {
                     hex.value = '';
-                    hex.placeholder = '—';
+                    hex.placeholder = '-';
                 } else {
                     hex.value = value.toUpperCase();
                     hex.placeholder = '';
@@ -6756,7 +6756,7 @@ class LEDRasterApp {
         setCheckbox('show-offset-bl', getCommon(l => l.showOffsetBL || false));
         setCheckbox('show-offset-br', getCommon(l => l.showOffsetBR || false));
         
-        // Update Screen Name checkboxes on other tabs — each reads its own per-tab property
+        // Update Screen Name checkboxes on other tabs, each reads its own per-tab property
         // with fallback to global showLabelName → true (backwards compat with old project files)
         if (document.getElementById('show-label-name-cabinet')) {
             setCheckbox('show-label-name-cabinet', getCommon(l => _tabLabel(l, 'showLabelNameCabinet')));
@@ -7358,7 +7358,7 @@ class LEDRasterApp {
                 const candidateLoad = calcBoundingRectLoad(candidateIndices);
 
                 if (current.unitIndices.length > 0 && candidateLoad > portCapacity) {
-                    // Adding this unit would exceed capacity — start new port
+                    // Adding this unit would exceed capacity, start new port
                     current.load = calcBoundingRectLoad(current.unitIndices);
                     ports.push(current);
                     current = { unitIndices: [unitIdx], load: singleUnitLoad };
@@ -7601,7 +7601,7 @@ class LEDRasterApp {
             // placeholder so the user understands what's being exported.
             const note = document.createElement('div');
             note.style.cssText = 'font-size:11px;color:#888;padding:6px 0;';
-            note.textContent = 'Single-canvas project — entire workspace will be exported.';
+            note.textContent = 'Single-canvas project, entire workspace will be exported.';
             list.appendChild(note);
             return;
         }
@@ -7739,7 +7739,7 @@ class LEDRasterApp {
                         : `${projectName} ${suffix}`;
                     // PDF page label includes canvas + view when multi.
                     const pdfLabel = (multiCanvas && canvasName)
-                        ? `${canvasName} — ${suffix}`
+                        ? `${canvasName}, ${suffix}`
                         : suffix;
                     renderedItems.push({
                         canvasId: cid,
@@ -7773,7 +7773,7 @@ class LEDRasterApp {
         }
 
         // Dispatch to format-specific writer. Multi-canvas just means
-        // more items — each writer already loops over them.
+        // more items, each writer already loops over them.
         if (format === 'png') {
             await this.downloadRenderedPNGs(renderedItems);
         } else if (format === 'pdf') {
@@ -7876,12 +7876,12 @@ class LEDRasterApp {
         filename = this.sanitizeFilename(filename);
         // blobOrFn can be a Blob OR an async function returning one. Lazy-blob
         // form lets the caller defer expensive serialization (e.g. stringifying
-        // a 1MB project) until AFTER showSaveFilePicker resolves — keeping the
+        // a 1MB project) until AFTER showSaveFilePicker resolves, keeping the
         // user-activation gesture fresh for createWritable. See bug fix for
         // 0-byte JSON saves on large multi-canvas projects.
         const resolveBlob = async () => (typeof blobOrFn === 'function' ? await blobOrFn() : blobOrFn);
         // 1. Try the File System Access API (Chrome/Edge on secure contexts).
-        //    Skip on localhost — we have a better server-side native dialog
+        //    Skip on localhost, we have a better server-side native dialog
         //    available that doesn't break on cloud-synced folders (Nextcloud,
         //    iCloud, Dropbox, OneDrive). Chrome's createWritable rejects with
         //    NotAllowedError when the target lives under a sync agent's xattrs,
@@ -7911,7 +7911,7 @@ class LEDRasterApp {
                     name: err && err.name,
                     message: err && err.message
                 });
-                // Try native dialog (Mac/Win/Linux) — opens a fresh dialog so
+                // Try native dialog (Mac/Win/Linux), opens a fresh dialog so
                 // we get our own gesture-bound path. If unavailable, use
                 // browserDownload as last resort.
             }
@@ -7965,7 +7965,7 @@ class LEDRasterApp {
             hasDirectoryPicker: !!window.showDirectoryPicker,
             hasSaveFilePicker: !!window.showSaveFilePicker
         });
-        // v0.8: same Chrome activation issue we hit on JSON saves — when
+        // v0.8: same Chrome activation issue we hit on JSON saves, when
         // the user is on localhost (this Flask app), the multi-canvas export
         // burns the user-gesture token rendering all the canvases between
         // showDirectoryPicker resolving and the per-file getFileHandle/
@@ -8072,7 +8072,7 @@ class LEDRasterApp {
         const files = [];
         for (const view of renderedViews) {
             // Slice 11: when exporting per-canvas, only include layers from
-            // that canvas in the PSD layer list — otherwise the PSD reports
+            // that canvas in the PSD layer list, otherwise the PSD reports
             // sibling canvases' layers as if they were in this image.
             // Legacy / single-canvas: include every layer (canvasId is null).
             const psdLayers = this.project.layers.filter(l => {
@@ -8531,7 +8531,7 @@ class LEDRasterApp {
     updateShortcutLabels() {
         const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform) || /Mac/.test(navigator.userAgent);
         document.querySelectorAll('.menu-option[data-label]').forEach(option => {
-            // Skip options with submenus — they manage their own content
+            // Skip options with submenus, they manage their own content
             if (option.classList.contains('menu-has-submenu')) return;
             const label = option.getAttribute('data-label') || '';
             const shortcut = isMac ? option.getAttribute('data-shortcut-mac') : option.getAttribute('data-shortcut-win');
@@ -9176,9 +9176,9 @@ class LEDRasterApp {
             const capacityEl = document.getElementById('port-capacity');
             const panelsPerPortEl = document.getElementById('panels-per-port');
             const portsRequiredEl = document.getElementById('ports-required');
-            if (capacityEl) capacityEl.textContent = '—';
-            if (panelsPerPortEl) panelsPerPortEl.textContent = '—';
-            if (portsRequiredEl) portsRequiredEl.textContent = '—';
+            if (capacityEl) capacityEl.textContent = '-';
+            if (panelsPerPortEl) panelsPerPortEl.textContent = '-';
+            if (portsRequiredEl) portsRequiredEl.textContent = '-';
             return;
         }
         
@@ -9303,11 +9303,11 @@ class LEDRasterApp {
             const circuitsEl = document.getElementById('power-circuits-required');
             const amps1El = document.getElementById('power-total-amps-1ph');
             const amps3El = document.getElementById('power-total-amps-3ph');
-            if (wattsEl) wattsEl.textContent = '—';
-            if (panelsEl) panelsEl.textContent = '—';
-            if (circuitsEl) circuitsEl.textContent = '—';
-            if (amps1El) amps1El.textContent = '—';
-            if (amps3El) amps3El.textContent = '—';
+            if (wattsEl) wattsEl.textContent = '-';
+            if (panelsEl) panelsEl.textContent = '-';
+            if (circuitsEl) circuitsEl.textContent = '-';
+            if (amps1El) amps1El.textContent = '-';
+            if (amps3El) amps3El.textContent = '-';
             return;
         }
         const layer = this.currentLayer;
@@ -9437,7 +9437,7 @@ class LEDRasterApp {
         if (overrides && overrides[circuitNum]) return overrides[circuitNum];
         // A multi/soca has 6 ports, so labels wrap every 6 circuits and the
         // soca number in the template increments. Works for any template
-        // shaped like <prefix><number><separator># — e.g. S1-#, S2-#, MULTI3-#.
+        // shaped like <prefix><number><separator>#, e.g. S1-#, S2-#, MULTI3-#.
         const m = String(template).match(/^(.*?)(\d+)([^#\d]*)#(.*)$/);
         if (m) {
             const prefix = m[1];
@@ -9905,7 +9905,7 @@ class LEDRasterApp {
     selectPixelMapPanelsInRect(layer, rect) {
         if (!layer || !rect) return;
         this.pixelMapSelection.clear();
-        // rect is in workspace coords; panel coords are canvas-relative —
+        // rect is in workspace coords; panel coords are canvas-relative,
         // shift by the layer's parent canvas's workspace offset before
         // comparing. (No-op for single-canvas projects.)
         const off = this._getLayerWorkspaceOffset(layer);
@@ -9970,7 +9970,7 @@ class LEDRasterApp {
         const horizontalEdge = !hasLeft || !hasRight;
         if (verticalEdge && !horizontalEdge) return 'height';
         if (horizontalEdge && !verticalEdge) return 'width';
-        // Corner or interior — default to 'height' (top/bottom edges are the common case).
+        // Corner or interior, default to 'height' (top/bottom edges are the common case).
         return 'height';
     }
 
@@ -10019,7 +10019,7 @@ class LEDRasterApp {
     }
 
     /**
-     * Bulk hide/show panels — what the UI calls "Set Blank" (matching the
+     * Bulk hide/show panels, what the UI calls "Set Blank" (matching the
      * Alt+click behaviour, which toggles the per-panel `hidden` flag so the
      * cabinet disappears from the wall layout).
      */
@@ -10132,7 +10132,7 @@ class LEDRasterApp {
         const key = this.getPanelKey(panel);
         const exists = this.currentLayer.customPortPaths[portNum].some(p => `${p.row},${p.col}` === key);
         if (exists) return;
-        // Reject if the panel already belongs to a different port — user
+        // Reject if the panel already belongs to a different port, user
         // must clear the existing assignment first. Avoids silent
         // double-mapping that the user has to undo manually.
         const conflict = this._findPanelOwnerPort(this.currentLayer, panel, portNum);
@@ -10257,7 +10257,7 @@ class LEDRasterApp {
                 .map(c => `R${c.row + 1}C${c.col + 1}→port ${c.owner}`).join(', ');
             const more = conflicts.length > 3 ? ` (+${conflicts.length - 3} more)` : '';
             if (typeof this._toast === 'function') {
-                this._toast(`Cannot apply: ${conflicts.length} panel${conflicts.length === 1 ? '' : 's'} already wired to other ports — ${sample}${more}.`, true);
+                this._toast(`Cannot apply: ${conflicts.length} panel${conflicts.length === 1 ? '' : 's'} already wired to other ports, ${sample}${more}.`, true);
             }
             return;
         }
@@ -10308,7 +10308,7 @@ class LEDRasterApp {
 
         const circuitNum = this.currentLayer.powerCustomIndex || 1;
         // Reject if any selected panel already belongs to a different
-        // circuit — same policy as data-flow custom pattern apply.
+        // circuit, same policy as data-flow custom pattern apply.
         const conflicts = [];
         for (const p of ordered) {
             const owner = this._findPanelOwnerCircuit(this.currentLayer, p, circuitNum);
@@ -10319,7 +10319,7 @@ class LEDRasterApp {
                 .map(c => `R${c.row + 1}C${c.col + 1}→circuit ${c.owner}`).join(', ');
             const more = conflicts.length > 3 ? ` (+${conflicts.length - 3} more)` : '';
             if (typeof this._toast === 'function') {
-                this._toast(`Cannot apply: ${conflicts.length} panel${conflicts.length === 1 ? '' : 's'} already wired to other circuits — ${sample}${more}.`, true);
+                this._toast(`Cannot apply: ${conflicts.length} panel${conflicts.length === 1 ? '' : 's'} already wired to other circuits, ${sample}${more}.`, true);
             }
             return;
         }
@@ -10611,7 +10611,7 @@ class LEDRasterApp {
         });
 
         // v0.8 Slice 2: regroup the flat layer list by canvas. The existing
-        // layer items above are preserved as-is — we just lift them into
+        // layer items above are preserved as-is, we just lift them into
         // per-canvas group containers and add canvas headers + per-canvas
         // "+ Add Screen" buttons + cross-canvas drag/drop.
         this.regroupLayersByCanvas(container);
@@ -10620,7 +10620,7 @@ class LEDRasterApp {
     }
 
     // -------------------------------------------------------------------
-    // Multi-canvas (v0.8 Slice 2) — sidebar canvas grouping.
+    // Multi-canvas (v0.8 Slice 2), sidebar canvas grouping.
     //
     // Slice 2 keeps workspace rendering unchanged; the sidebar restructure
     // is the entire visible deliverable. Each canvas gets a header row
@@ -10645,7 +10645,7 @@ class LEDRasterApp {
         container.innerHTML = '';
 
         // Sidebar shows canvases in array order, with each canvas's
-        // (reverse-ordered) layers underneath — matches the existing
+        // (reverse-ordered) layers underneath, matches the existing
         // newest-on-top convention.
         project.canvases.forEach(canvas => {
             const group = this.buildCanvasGroupEl(canvas, activeId === canvas.id);
@@ -10653,7 +10653,7 @@ class LEDRasterApp {
             const body = group.querySelector('.canvas-group-body');
 
             // Append matching layer nodes in reverse render order
-            // (Photoshop style — newest on top).
+            // (Photoshop style, newest on top).
             const reversed = [...project.layers].reverse();
             reversed.forEach(layer => {
                 if (layer.canvas_id !== canvas.id) return;
@@ -10786,7 +10786,7 @@ class LEDRasterApp {
             }
             // Cross-canvas layer drop?
             // Only handle when the drop landed on the canvas header / footer
-            // (not on an existing layer-item inside this canvas) — otherwise
+            // (not on an existing layer-item inside this canvas), otherwise
             // we would double-fire alongside the within-list reorder handler.
             if (this.dragLayerId != null) {
                 const onLayerItem = e.target.closest && e.target.closest('.layer-item');
@@ -10823,7 +10823,7 @@ class LEDRasterApp {
             try { this.loadClientSideProperties && this.loadClientSideProperties({ skipPreferences: true }); } catch (_) {}
         }
         // If the active canvas's properties changed, sync raster size for
-        // the workspace toolbar (Slice 4 will deepen this — Slice 2 just
+        // the workspace toolbar (Slice 4 will deepen this, Slice 2 just
         // keeps the sidebar consistent).
         if (data.raster_width && data.raster_height && this.syncRasterFromProject) {
             try { this.syncRasterFromProject(); } catch (_) {}
@@ -10851,7 +10851,7 @@ class LEDRasterApp {
         }
         // Re-render the workspace canvas. The previous `if (this.render)`
         // check was always false (app has no .render method), so the
-        // workspace pixels never refreshed after a canvas CRUD response —
+        // workspace pixels never refreshed after a canvas CRUD response,
         // most visibly: toggling a canvas's visibility updated state but
         // never repainted the workspace, so the canvas appeared not to hide.
         if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
@@ -10993,7 +10993,7 @@ class LEDRasterApp {
     /**
      * Slice 5: after a canvas-drag drop, warn (non-blocking) if the
      * dragged canvas's workspace bounds intersect any other visible
-     * canvas's bounds. Does NOT auto-snap or reject — just toasts.
+     * canvas's bounds. Does NOT auto-snap or reject, just toasts.
      * Bounds use the active view's raster (pixel-map vs show-look),
      * matching what the user sees in `_drawCanvasOutline`.
      */
@@ -11020,7 +11020,7 @@ class LEDRasterApp {
             const b = bounds(other);
             if (b.w <= 0 || b.h <= 0) continue;
             if (intersects(a, b)) {
-                this._toast('Canvases overlapping — visual rendering may be confusing.', true);
+                this._toast('Canvases overlapping, visual rendering may be confusing.', true);
                 return;
             }
         }
@@ -11098,7 +11098,7 @@ class LEDRasterApp {
         // syncRasterFromProject reads straight from the active canvas now,
         // so no project-root mirror needed.
         try { this.syncRasterFromProject(); } catch (_) {}
-        // Slice 8: per-canvas perspective — sync the Front/Back toggle state
+        // Slice 8: per-canvas perspective, sync the Front/Back toggle state
         // when the active canvas changes so the sidebar reflects the canvas
         // the user is now editing.
         if (typeof this.refreshPerspectiveButtons === 'function') {
@@ -11116,18 +11116,18 @@ class LEDRasterApp {
     }
 
     /**
-     * Slice 6: deprecated — kept as a no-op so any lingering callers don't
+     * Slice 6: deprecated, kept as a no-op so any lingering callers don't
      * crash during the deprecation window. The renderer reads straight from
      * the active canvas via accessors now, so there is no project-root copy
      * to keep in sync.
      */
     _syncRootRasterFromActiveCanvas() {
-        // intentionally empty — see syncRasterFromProject().
+        // intentionally empty, see syncRasterFromProject().
     }
 
     /**
      * Slice 4: when a layer becomes the user-selected layer, also activate
-     * its canvas (if different). Idempotent — setActiveCanvas short-circuits
+     * its canvas (if different). Idempotent, setActiveCanvas short-circuits
      * when already active, so we won't spam PUTs from re-selecting the same
      * layer or selecting siblings inside the already-active canvas.
      */
@@ -11172,7 +11172,7 @@ class LEDRasterApp {
     // v0.8 Slice 2.5: per-canvas "+ Add" chooser (Screen / Image / Text).
     // Routes to the existing add flows after activating the target canvas
     // so the new layer always lands in the canvas whose "+ Add" was clicked
-    // (mirrors the Slice 2 add-screen pattern — server uses active_canvas_id
+    // (mirrors the Slice 2 add-screen pattern, server uses active_canvas_id
     // when assigning new layers).
     openCanvasAddMenu(canvas, anchor) {
         document.querySelectorAll('.canvas-add-popup, .canvas-menu-popup, .canvas-color-popup').forEach(el => el.remove());
@@ -11347,7 +11347,7 @@ class LEDRasterApp {
         // top-most layer of each canvas group, the down arrow on the
         // bottom-most. Display order in the sidebar is reverse of the layer
         // array (newest on top), so within a canvas the FIRST displayed
-        // layer is the LAST one in the array — the up arrow on that one is
+        // layer is the LAST one in the array, the up arrow on that one is
         // disabled, etc.
         if (!this.project || !this.project.canvases) return;
         // Group layer ids by canvas, in display order (reverse-array).
@@ -11434,7 +11434,7 @@ class LEDRasterApp {
     
     /**
      * Slice 6: write a toolbar Raster: W x H change to the active canvas via
-     * PUT /api/canvas/<id>. Source-of-truth lives on the canvas object — no
+     * PUT /api/canvas/<id>. Source-of-truth lives on the canvas object, no
      * project-root mirror. `axis` is 'width' or 'height'; `value` is the new
      * dimension; `isShow` selects show_raster_* vs raster_*.
      *
@@ -12494,7 +12494,7 @@ class LEDRasterApp {
         // Reject dangerous patterns (consecutive operators other than a leading unary minus in a sub-expr)
         if (/[*/]{2,}|\+{2,}|-{3,}|[-+*/]$|^[*/]/.test(cleaned)) return null;
         try {
-            // Function constructor with no scope access — still safer than eval(),
+            // Function constructor with no scope access, still safer than eval(),
             // and the regex above guarantees only arithmetic characters are present.
             // eslint-disable-next-line no-new-func
             const result = Function('"use strict"; return (' + cleaned + ');')();

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1702,35 +1702,41 @@ class LEDRasterApp {
     }
 
     /**
-     * Sync the canvas renderer's pixel/show raster backing fields from the
-     * loaded project. Older projects pre-date the show raster, so default
-     * the show fields to the pixel fields when missing. Also refresh the
-     * toolbar input to match the currently active view's raster.
+     * Slice 6: refresh the toolbar Raster: W x H inputs from the active
+     * canvas's raster (Pixel Map raster on pixel-map / cabinet-id, Show
+     * Look raster on show-look / data / power). Also seeds any missing
+     * show_raster_* on the active canvas so older projects (where show
+     * raster was never set) open with show = pixel.
+     *
+     * Renderer fields are accessor-backed (Slice 6) — they read straight
+     * from the active canvas — so no per-renderer assignment is needed.
+     * Legacy fallback (no canvases array): seed the renderer's _fallback*
+     * backing fields from the project root so single-canvas pre-Slice-1
+     * projects still display.
      */
     syncRasterFromProject() {
         if (!this.project) return;
         const r = window.canvasRenderer;
         if (!r) return;
-        const pw = Number(this.project.raster_width) || r.pixelRasterWidth || 1920;
-        const ph = Number(this.project.raster_height) || r.pixelRasterHeight || 1080;
-        const sw = Number(this.project.show_raster_width) || pw;
-        const sh = Number(this.project.show_raster_height) || ph;
-        r.pixelRasterWidth = pw;
-        r.pixelRasterHeight = ph;
-        r.showRasterWidth = sw;
-        r.showRasterHeight = sh;
-        // Make sure the project dict carries both — older projects may have
-        // been opened without going through the server migration.
-        this.project.raster_width = pw;
-        this.project.raster_height = ph;
-        this.project.show_raster_width = sw;
-        this.project.show_raster_height = sh;
-        if (r.isShowLookView()) {
-            r.rasterWidth = sw;
-            r.rasterHeight = sh;
+        const canvases = Array.isArray(this.project.canvases) ? this.project.canvases : [];
+        if (canvases.length > 0) {
+            const c = canvases.find(x => x.id === this.project.active_canvas_id) || canvases[0];
+            if (c) {
+                if (!c.show_raster_width)  c.show_raster_width  = c.raster_width;
+                if (!c.show_raster_height) c.show_raster_height = c.raster_height;
+            }
         } else {
-            r.rasterWidth = pw;
-            r.rasterHeight = ph;
+            // Pre-Slice-1 project — seed the renderer's fallback backing
+            // fields so the legacy single-canvas getter path returns sane
+            // values until the project gets migrated by the server.
+            const pw = Number(this.project.raster_width) || 1920;
+            const ph = Number(this.project.raster_height) || 1080;
+            const sw = Number(this.project.show_raster_width) || pw;
+            const sh = Number(this.project.show_raster_height) || ph;
+            r._fallbackPixelRasterWidth = pw;
+            r._fallbackPixelRasterHeight = ph;
+            r._fallbackShowRasterWidth = sw;
+            r._fallbackShowRasterHeight = sh;
         }
         const rwIn = document.getElementById('toolbar-raster-width');
         const rhIn = document.getElementById('toolbar-raster-height');
@@ -1738,45 +1744,53 @@ class LEDRasterApp {
         if (rhIn) rhIn.value = r.rasterHeight;
     }
     
-    // Load raster size from localStorage (checks version first)
+    // Load raster size from localStorage (checks version first).
+    //
+    // Slice 6: at boot the project hasn't loaded yet — the active canvas's
+    // raster is the source of truth and we must NOT clobber it with stale
+    // localStorage. So we only seed the renderer's fallback backing fields
+    // (used when no canvases array exists yet) and refresh the toolbar
+    // inputs. Once loadProject() runs, syncRasterFromProject() takes over
+    // and the toolbar reflects the active canvas.
     loadRasterSize() {
-        // Check version first - if mismatch, clear all saved settings including raster size
         const savedVersion = localStorage.getItem('ledRasterPropsVersion');
-        const currentVersion = '0.4.7'; // Must match version in loadClientSideProperties
-        
+        const currentVersion = '0.4.7';
+
+        const seed = (w, h) => {
+            const r = window.canvasRenderer;
+            if (!r) return;
+            r._fallbackPixelRasterWidth = w;
+            r._fallbackPixelRasterHeight = h;
+            r._fallbackShowRasterWidth = w;
+            r._fallbackShowRasterHeight = h;
+            const wIn = document.getElementById('toolbar-raster-width');
+            const hIn = document.getElementById('toolbar-raster-height');
+            if (wIn) wIn.value = w;
+            if (hIn) hIn.value = h;
+        };
+
         if (savedVersion !== currentVersion) {
             console.log('Version mismatch in loadRasterSize - clearing ALL localStorage');
             localStorage.removeItem('ledRasterSize');
             localStorage.removeItem('ledRasterClientProps');
             localStorage.setItem('ledRasterPropsVersion', currentVersion);
             const prefs = this.getPreferences();
-            window.canvasRenderer.rasterWidth = prefs.rasterWidth;
-            window.canvasRenderer.rasterHeight = prefs.rasterHeight;
-            document.getElementById('toolbar-raster-width').value = prefs.rasterWidth;
-            document.getElementById('toolbar-raster-height').value = prefs.rasterHeight;
+            seed(prefs.rasterWidth, prefs.rasterHeight);
             this.saveRasterSize();
             return;
         }
-        
+
         const saved = localStorage.getItem('ledRasterSize');
         if (saved) {
             try {
                 const size = JSON.parse(saved);
-                if (size.width && size.height) {
-                    window.canvasRenderer.rasterWidth = size.width;
-                    window.canvasRenderer.rasterHeight = size.height;
-                    document.getElementById('toolbar-raster-width').value = size.width;
-                    document.getElementById('toolbar-raster-height').value = size.height;
-                }
+                if (size.width && size.height) seed(size.width, size.height);
             } catch (e) {
                 console.error('Error loading raster size:', e);
             }
         } else {
             const prefs = this.getPreferences();
-            window.canvasRenderer.rasterWidth = prefs.rasterWidth;
-            window.canvasRenderer.rasterHeight = prefs.rasterHeight;
-            document.getElementById('toolbar-raster-width').value = prefs.rasterWidth;
-            document.getElementById('toolbar-raster-height').value = prefs.rasterHeight;
+            seed(prefs.rasterWidth, prefs.rasterHeight);
             this.saveRasterSize();
         }
     }
@@ -3575,40 +3589,18 @@ class LEDRasterApp {
             rasterWidthInput.addEventListener('change', () => {
                 const width = evaluateMathExpression(rasterWidthInput.value) || 1920;
                 rasterWidthInput.value = width;
-                // The toolbar edits the raster for the *current* view: pixel-map
-                // / cabinet-id edit the processor raster, show-look / data /
-                // power edit the show raster.
+                // Slice 6: the toolbar Raster: W x H field is the active
+                // canvas's raster (Pixel Map raster on pixel-map / cabinet-id;
+                // Show Look raster on show-look / data / power). Writes go
+                // straight to the active canvas via PUT /api/canvas/<id> —
+                // no project-root mirror, no _mirrorRasterToActiveCanvas hack.
                 //
                 // While show raster equals pixel raster ("linked"), changing
                 // the pixel raster also updates the show raster — Show Look
-                // tracks Pixel Map by default. Once they're set to different
-                // values they stay independent.
+                // tracks Pixel Map by default until the user splits them.
                 const renderer = window.canvasRenderer;
                 const isShow = renderer.isShowLookView();
-                const wasLinked = renderer.pixelRasterWidth === renderer.showRasterWidth;
-                if (isShow) {
-                    renderer.showRasterWidth = width;
-                    if (this.project) this.project.show_raster_width = width;
-                } else {
-                    renderer.pixelRasterWidth = width;
-                    if (this.project) this.project.raster_width = width;
-                    if (wasLinked) {
-                        renderer.showRasterWidth = width;
-                        if (this.project) this.project.show_raster_width = width;
-                    }
-                }
-                renderer.rasterWidth = width;
-                // Slice 3 patch: the renderer now reads each canvas's own
-                // raster_* fields (per-canvas outlines). Mirror the toolbar
-                // edit onto the active canvas so the visual size actually
-                // changes. Slice 6 will switch source-of-truth fully and
-                // remove the project-root writes above.
-                this._mirrorRasterToActiveCanvas(isShow ? 'show' : 'pixel', width, null, wasLinked);
-                if (this.project) this.saveProject();
-                this.saveRasterSize();
-                if (typeof sendClientLog === 'function') {
-                    sendClientLog('raster_change', { width, height: renderer.rasterHeight, source: 'toolbar-width', view: renderer.viewMode, autoSyncedShow: !isShow && wasLinked });
-                }
+                this._writeToolbarRasterToActiveCanvas('width', width, isShow);
                 renderer.render();
             });
         }
@@ -3619,25 +3611,7 @@ class LEDRasterApp {
                 rasterHeightInput.value = height;
                 const renderer = window.canvasRenderer;
                 const isShow = renderer.isShowLookView();
-                const wasLinked = renderer.pixelRasterHeight === renderer.showRasterHeight;
-                if (isShow) {
-                    renderer.showRasterHeight = height;
-                    if (this.project) this.project.show_raster_height = height;
-                } else {
-                    renderer.pixelRasterHeight = height;
-                    if (this.project) this.project.raster_height = height;
-                    if (wasLinked) {
-                        renderer.showRasterHeight = height;
-                        if (this.project) this.project.show_raster_height = height;
-                    }
-                }
-                renderer.rasterHeight = height;
-                this._mirrorRasterToActiveCanvas(isShow ? 'show' : 'pixel', null, height, wasLinked);
-                if (this.project) this.saveProject();
-                this.saveRasterSize();
-                if (typeof sendClientLog === 'function') {
-                    sendClientLog('raster_change', { width: renderer.rasterWidth, height, source: 'toolbar-height', view: renderer.viewMode, autoSyncedShow: !isShow && wasLinked });
-                }
+                this._writeToolbarRasterToActiveCanvas('height', height, isShow);
                 renderer.render();
             });
         }
@@ -10606,10 +10580,9 @@ class LEDRasterApp {
             this.currentLayer = next;
             if (!next) this.lastSelectedLayerId = null;
         }
-        // Slice 4: toolbar raster reflects the active canvas's raster.
-        // Mirror the active canvas's raster_* into project root + renderer
-        // so syncRasterFromProject populates the toolbar inputs correctly.
-        this._syncRootRasterFromActiveCanvas();
+        // Slice 6: toolbar raster reflects the active canvas's raster.
+        // syncRasterFromProject reads straight from the active canvas now,
+        // so no project-root mirror needed.
         try { this.syncRasterFromProject(); } catch (_) {}
         if (!opts.silent) {
             this.renderLayers();
@@ -10623,19 +10596,13 @@ class LEDRasterApp {
     }
 
     /**
-     * Slice 4: copy the active canvas's raster_* fields into the project
-     * root so syncRasterFromProject (which reads project root) picks up the
-     * right values. Slice 6 will switch the renderer to read straight from
-     * the canvas object and this helper goes away.
+     * Slice 6: deprecated — kept as a no-op so any lingering callers don't
+     * crash during the deprecation window. The renderer reads straight from
+     * the active canvas via accessors now, so there is no project-root copy
+     * to keep in sync.
      */
     _syncRootRasterFromActiveCanvas() {
-        if (!this.project || !this.project.canvases) return;
-        const c = this.project.canvases.find(c => c.id === this.project.active_canvas_id);
-        if (!c) return;
-        if (c.raster_width)        this.project.raster_width = c.raster_width;
-        if (c.raster_height)       this.project.raster_height = c.raster_height;
-        if (c.show_raster_width)   this.project.show_raster_width = c.show_raster_width;
-        if (c.show_raster_height)  this.project.show_raster_height = c.show_raster_height;
+        // intentionally empty — see syncRasterFromProject().
     }
 
     /**
@@ -10937,27 +10904,54 @@ class LEDRasterApp {
         this.saveProject();
     }
     
-    // Slice 3 helper: mirror a toolbar raster edit onto the active canvas's
-    // raster_* / show_raster_* fields so the visual canvas-rect actually
-    // resizes. Called by the toolbar Raster width/height change handlers.
-    // `view` is 'show' or 'pixel'. Pass the new width OR height; pass null
-    // for whichever axis isn't being changed. `wasLinked` mirrors the
-    // pixel-map → show-look auto-sync behavior already present at the
-    // project root.
-    _mirrorRasterToActiveCanvas(view, width, height, wasLinked) {
-        if (!this.project || !this.project.canvases || !this.project.active_canvas_id) return;
-        const c = this.project.canvases.find(c => c.id === this.project.active_canvas_id);
+    /**
+     * Slice 6: write a toolbar Raster: W x H change to the active canvas via
+     * PUT /api/canvas/<id>. Source-of-truth lives on the canvas object — no
+     * project-root mirror. `axis` is 'width' or 'height'; `value` is the new
+     * dimension; `isShow` selects show_raster_* vs raster_*.
+     *
+     * Auto-link behaviour: when the pixel and show rasters were equal
+     * before this change ("linked"), a pixel-raster edit also updates the
+     * show raster on the same axis so Show Look keeps tracking Pixel Map
+     * until the user explicitly splits them.
+     */
+    _writeToolbarRasterToActiveCanvas(axis, value, isShow) {
+        if (!this.project || !Array.isArray(this.project.canvases)) return;
+        const canvasId = this.project.active_canvas_id;
+        const c = this.project.canvases.find(x => x.id === canvasId);
         if (!c) return;
-        if (view === 'show') {
-            if (width != null)  c.show_raster_width  = width;
-            if (height != null) c.show_raster_height = height;
+        const patch = {};
+        if (isShow) {
+            if (axis === 'width')  patch.show_raster_width  = value;
+            if (axis === 'height') patch.show_raster_height = value;
         } else {
-            if (width != null)  c.raster_width  = width;
-            if (height != null) c.raster_height = height;
-            if (wasLinked) {
-                if (width != null)  c.show_raster_width  = width;
-                if (height != null) c.show_raster_height = height;
+            // Detect linked-state on the *active canvas* before mutating it.
+            const wasLinked = (axis === 'width')
+                ? ((Number(c.raster_width) || 0) === (Number(c.show_raster_width) || 0))
+                : ((Number(c.raster_height) || 0) === (Number(c.show_raster_height) || 0));
+            if (axis === 'width') {
+                patch.raster_width = value;
+                if (wasLinked) patch.show_raster_width = value;
+            } else {
+                patch.raster_height = value;
+                if (wasLinked) patch.show_raster_height = value;
             }
+        }
+        // Optimistic local update so the renderer (which reads from the
+        // canvas object via getters) repaints immediately, before the PUT
+        // round-trip. The server response will overwrite this with the
+        // canonical state.
+        Object.assign(c, patch);
+        this.saveRasterSize();
+        if (typeof sendClientLog === 'function') {
+            sendClientLog('raster_change', {
+                axis, value, isShow,
+                view: window.canvasRenderer && window.canvasRenderer.viewMode,
+                canvas_id: canvasId,
+            });
+        }
+        if (typeof this.updateCanvas === 'function') {
+            this.updateCanvas(canvasId, patch);
         }
     }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2013,13 +2013,26 @@ class LEDRasterApp {
                 const target = btn.getAttribute('data-target');
                 const value = btn.getAttribute('data-perspective');
                 if (!target || !value || !this.project) return;
-                if (this.project[target] === value) return;
+                // v0.8 Slice 8: perspective is per-canvas. Write to the active
+                // canvas (which routes through updateCanvas → server PUT, undo
+                // entry, and a re-render via _applyProjectUpdate). Mirror
+                // project-root field too so legacy code paths keep working
+                // until they're all migrated to read from active canvas.
+                const active = this._activeCanvas();
+                const currentVal = (active && active[target]) || this.project[target] || 'front';
+                if (currentVal === value) return;
                 this.project[target] = value;
-                this.refreshPerspectiveButtons();
-                this.saveProject();
-                if (window.canvasRenderer) window.canvasRenderer.render();
+                if (active && typeof this.updateCanvas === 'function') {
+                    this.updateCanvas(active.id, { [target]: value });
+                } else {
+                    this.refreshPerspectiveButtons();
+                    this.saveProject();
+                    if (window.canvasRenderer) window.canvasRenderer.render();
+                }
                 if (typeof sendClientLog === 'function') {
-                    sendClientLog('perspective_change', { target, value });
+                    sendClientLog('perspective_change', {
+                        target, value, canvasId: active && active.id
+                    });
                 }
             });
         });
@@ -2027,17 +2040,29 @@ class LEDRasterApp {
     }
 
     /**
-     * Reflect the project's current perspective values on the toggle
-     * buttons (active state). Called after the project loads or the user
-     * toggles.
+     * Find the active canvas object, or null. v0.8 Slice 8 helper.
+     */
+    _activeCanvas() {
+        if (!this.project || !Array.isArray(this.project.canvases)) return null;
+        const id = this.project.active_canvas_id;
+        if (!id) return this.project.canvases[0] || null;
+        return this.project.canvases.find(c => c && c.id === id) || null;
+    }
+
+    /**
+     * Reflect the active canvas's perspective values on the toggle buttons.
+     * Falls back to the project root for pre-Slice-1 / legacy projects that
+     * have no canvas list yet. Called on project load and on every active-
+     * canvas switch.
      */
     refreshPerspectiveButtons() {
         if (!this.project) return;
+        const active = this._activeCanvas();
         document.querySelectorAll('.perspective-btn').forEach(btn => {
             const target = btn.getAttribute('data-target');
             const value = btn.getAttribute('data-perspective');
             if (!target || !value) return;
-            const current = this.project[target] || 'front';
+            const current = (active && active[target]) || this.project[target] || 'front';
             btn.classList.toggle('active', current === value);
         });
     }
@@ -10473,6 +10498,12 @@ class LEDRasterApp {
                 }
             }
         }
+        // Slice 8: re-sync perspective toggles after any canvas mutation
+        // (perspective edited on a sibling canvas, active canvas swapped on
+        // server, etc.).
+        if (typeof this.refreshPerspectiveButtons === 'function') {
+            try { this.refreshPerspectiveButtons(); } catch (_) {}
+        }
         // Re-render the workspace canvas. The previous `if (this.render)`
         // check was always false (app has no .render method), so the
         // workspace pixels never refreshed after a canvas CRUD response —
@@ -10722,6 +10753,12 @@ class LEDRasterApp {
         // syncRasterFromProject reads straight from the active canvas now,
         // so no project-root mirror needed.
         try { this.syncRasterFromProject(); } catch (_) {}
+        // Slice 8: per-canvas perspective — sync the Front/Back toggle state
+        // when the active canvas changes so the sidebar reflects the canvas
+        // the user is now editing.
+        if (typeof this.refreshPerspectiveButtons === 'function') {
+            try { this.refreshPerspectiveButtons(); } catch (_) {}
+        }
         if (!opts.silent) {
             this.renderLayers();
             if (window.canvasRenderer) window.canvasRenderer.render();

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1952,6 +1952,12 @@ class LEDRasterApp {
 
         this.renderLayers();
         this.loadTextLayerToInputs();
+        // Slice 10: keep the Totals panels (Data Flow + Power tabs) in sync
+        // with whatever just changed. Always cheap — two aggregations over
+        // the visible screen layers, plus a handful of textContent writes.
+        if (typeof this.refreshTotalsSidebar === 'function') {
+            try { this.refreshTotalsSidebar(); } catch (_) {}
+        }
 
         if (window.canvasRenderer) {
             if (window.canvasRenderer.viewMode === 'data-flow' && this.currentLayer) {
@@ -2061,6 +2067,48 @@ class LEDRasterApp {
             if (c && c.visible === false && c.id) set.add(c.id);
         });
         return set;
+    }
+
+    /**
+     * v0.8 Slice 10: paint the Totals panels on the Data Flow + Power tabs.
+     * Two columns each: active canvas + project-wide. Numbers come from
+     * getPortCounts/getPowerCounts which already exclude hidden canvases.
+     * Cheap to call on every updateUI — the Totals panels are display:none
+     * unless the user is on the relevant tab.
+     */
+    refreshTotalsSidebar() {
+        const setText = (id, value) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = value;
+        };
+        const active = (typeof this._activeCanvas === 'function') ? this._activeCanvas() : null;
+        const activeId = active ? active.id : null;
+        const activeName = active ? `(${active.name || 'Canvas'})` : '(no active canvas)';
+        // Data Flow totals
+        const dataCanvas = activeId ? this.getPortCounts(activeId) : { primary: 0, backup: 0 };
+        const dataProject = this.getPortCounts();
+        setText('data-totals-canvas-name', activeName);
+        setText('data-totals-canvas-primary', dataCanvas.primary);
+        setText('data-totals-canvas-backup', dataCanvas.backup);
+        setText('data-totals-project-primary', dataProject.primary);
+        setText('data-totals-project-backup', dataProject.backup);
+        // Power totals — show "0" cleanly when there's no active canvas / no
+        // load yet. Amps formatted to 2 decimals to match the per-layer
+        // capacity readout.
+        const pwrCanvas = activeId ? this.getPowerCounts(activeId)
+            : { circuits: 0, totalWatts: 0, singlePhaseAmps: 0, threePhaseAmps: 0 };
+        const pwrProject = this.getPowerCounts();
+        const fmtAmps = (a) => (a > 0) ? `${a.toFixed(2)} A` : '0';
+        const fmtWatts = (w) => (w > 0) ? `${Math.round(w).toLocaleString()} W` : '0';
+        setText('power-totals-canvas-name', activeName);
+        setText('power-totals-canvas-watts', fmtWatts(pwrCanvas.totalWatts));
+        setText('power-totals-canvas-circuits', pwrCanvas.circuits);
+        setText('power-totals-canvas-1ph', fmtAmps(pwrCanvas.singlePhaseAmps));
+        setText('power-totals-canvas-3ph', fmtAmps(pwrCanvas.threePhaseAmps));
+        setText('power-totals-project-watts', fmtWatts(pwrProject.totalWatts));
+        setText('power-totals-project-circuits', pwrProject.circuits);
+        setText('power-totals-project-1ph', fmtAmps(pwrProject.singlePhaseAmps));
+        setText('power-totals-project-3ph', fmtAmps(pwrProject.threePhaseAmps));
     }
 
     /**
@@ -5156,9 +5204,9 @@ class LEDRasterApp {
     }
 
     // Aggregate data port counts across all visible screen layers.
-    // Slice 9: exclude layers whose canvas is hidden — totals should match
-    // what's drawn on screen and what the user expects to ship.
-    getPortCounts() {
+    // Slice 9: exclude layers whose canvas is hidden.
+    // Slice 10: optional onlyCanvasId filter for per-canvas sidebar totals.
+    getPortCounts(onlyCanvasId) {
         if (!this.project || !this.project.layers) return { primary: 0, backup: 0 };
         let totalPrimary = 0;
         const hiddenCanvasIds = this._hiddenCanvasIdSet();
@@ -5166,6 +5214,7 @@ class LEDRasterApp {
             if ((layer.type || 'screen') !== 'screen') return;
             if (!layer.visible) return;
             if (layer.canvas_id && hiddenCanvasIds.has(layer.canvas_id)) return;
+            if (onlyCanvasId && layer.canvas_id !== onlyCanvasId) return;
             const activePanels = (layer.panels || []).filter(p => !p.blank && !p.hidden);
             if (activePanels.length === 0) return;
             const assignments = this.calculatePortAssignments(layer);
@@ -5181,9 +5230,9 @@ class LEDRasterApp {
     }
 
     // Aggregate power stats across all visible screen layers.
-    // Slice 9: exclude layers whose canvas is hidden so totals match the
-    // visible workspace.
-    getPowerCounts() {
+    // Slice 9: exclude layers whose canvas is hidden.
+    // Slice 10: optional onlyCanvasId filter for per-canvas sidebar totals.
+    getPowerCounts(onlyCanvasId) {
         if (!this.project || !this.project.layers) return { circuits: 0, totalWatts: 0, singlePhaseAmps: 0, threePhaseAmps: 0, voltage: 0 };
         let totalCircuits = 0;
         let totalWattsAll = 0;
@@ -5193,6 +5242,7 @@ class LEDRasterApp {
             if ((layer.type || 'screen') !== 'screen') return;
             if (!layer.visible) return;
             if (layer.canvas_id && hiddenCanvasIds.has(layer.canvas_id)) return;
+            if (onlyCanvasId && layer.canvas_id !== onlyCanvasId) return;
             const activePanels = (layer.panels || []).filter(p => !p.blank && !p.hidden);
             if (activePanels.length === 0) return;
             const voltage = Number(layer.powerVoltage) || 110;

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7801,7 +7801,8 @@ class LEDRasterApp {
             frameRate: 60,
             powerVoltage: 110,
             powerAmperage: 15,
-            powerWatts: 200
+            powerWatts: 200,
+            canvasGap: 50
         };
     }
 
@@ -8043,6 +8044,7 @@ class LEDRasterApp {
             amperageCustom.style.display = (!amperageSelect || amperageSelect.value === 'custom') ? 'inline-block' : 'none';
         }
         setVal('pref-power-watts', prefs.powerWatts);
+        setVal('pref-canvas-gap', prefs.canvasGap);
         const modal = document.getElementById('preferences-modal');
         if (modal) modal.style.display = 'block';
     }
@@ -8096,7 +8098,8 @@ class LEDRasterApp {
             frameRate: readNum('pref-frame-rate', defaults.frameRate),
             powerVoltage: Number.isFinite(voltageVal) && voltageVal > 0 ? voltageVal : defaults.powerVoltage,
             powerAmperage: Number.isFinite(amperageVal) && amperageVal > 0 ? amperageVal : defaults.powerAmperage,
-            powerWatts: readNum('pref-power-watts', defaults.powerWatts)
+            powerWatts: readNum('pref-power-watts', defaults.powerWatts),
+            canvasGap: readNum('pref-canvas-gap', defaults.canvasGap)
         };
     }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10463,10 +10463,23 @@ class LEDRasterApp {
 
     addCanvas() {
         if (typeof this.saveState === 'function') this.saveState('Add Canvas');
+        // Seed new canvases from the user's preferred default canvas size so
+        // every "+ Add Canvas" click matches the same baseline as a brand-new
+        // project, not whatever the currently active canvas happens to be.
+        const prefs = (typeof this.getPreferences === 'function') ? this.getPreferences() : null;
+        const body = {};
+        if (prefs && Number.isFinite(prefs.rasterWidth) && prefs.rasterWidth > 0) {
+            body.raster_width = prefs.rasterWidth;
+            body.show_raster_width = prefs.rasterWidth;
+        }
+        if (prefs && Number.isFinite(prefs.rasterHeight) && prefs.rasterHeight > 0) {
+            body.raster_height = prefs.rasterHeight;
+            body.show_raster_height = prefs.rasterHeight;
+        }
         return fetch('/api/canvas', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({})
+            body: JSON.stringify(body)
         }).then(r => r.json()).then(data => this._applyProjectUpdate(data));
     }
 

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3764,10 +3764,14 @@ class CanvasRenderer {
         const selection = window.app.pixelMapSelection;
         if (!selection || selection.size === 0) return;
         const layer = window.app.currentLayer;
+        // v0.8 multi-canvas: panels are drawn at canvas-relative coords; the
+        // workspace position of the layer's parent canvas needs to be applied
+        // so the overlay lands ON the layer the user is editing instead of
+        // at workspace (0,0) where it visually overlapped Canvas 1's panels.
+        const wsOff = (typeof window.app._getLayerWorkspaceOffset === 'function')
+            ? window.app._getLayerWorkspaceOffset(layer) : { wx: 0, wy: 0 };
         this.ctx.save();
-        this.ctx.beginPath();
-        this.ctx.rect(0, 0, this.rasterWidth, this.rasterHeight);
-        this.ctx.clip();
+        if (wsOff.wx || wsOff.wy) this.ctx.translate(wsOff.wx, wsOff.wy);
         this.ctx.lineWidth = 2 / this.zoom;
         selection.forEach(key => {
             const [row, col] = key.split(',').map(n => parseInt(n, 10));

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -659,7 +659,18 @@ class CanvasRenderer {
             // is the only way to bulk-restore via the sidebar buttons.
             const onCurrentLayer = startPanel
                 && startPanel.layerId === window.app.currentLayer.id;
-            if (onCurrentLayer) {
+            // Don't capture the click for panel-select if there's a HIGHER-Z
+            // layer (image / text / another screen later in project.layers)
+            // sitting on top of the current layer at this point — the user is
+            // clicking the visible top layer, not the panel buried beneath it.
+            // Bug: with a text layer over a selected screen, clicks on text
+            // were grabbed by the screen's panel-select instead of selecting
+            // the text layer.
+            const topLayer = this.getLayerAt(worldX, worldY);
+            const topIsHigher = topLayer && window.app.project
+                && window.app.project.layers.indexOf(topLayer)
+                    > window.app.project.layers.indexOf(window.app.currentLayer);
+            if (onCurrentLayer && !topIsHigher) {
                 this.isSelectingPixelMapPanels = true;
                 this.selectionRect = { x1: worldX, y1: worldY, x2: worldX, y2: worldY };
                 if (typeof sendClientLog === 'function') {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -367,12 +367,82 @@ class CanvasRenderer {
         return null;
     }
 
+    /**
+     * Slice 5: hit-test a workspace point against the dashed outline edges
+     * of visible canvases. Returns the first canvas whose outline edge is
+     * within EDGE_HIT_PX (screen pixels, converted to world units via
+     * /this.zoom) of (worldX, worldY), or null.
+     *
+     * "Edge" = within `tol` of any of the four edges of the canvas rect,
+     * but the point must also be inside the rect-with-tolerance overall
+     * (so corners count). Inside the canvas body (more than `tol` away
+     * from every edge) does NOT count — that's reserved for body-click
+     * activate / panel selection.
+     */
+    _canvasEdgeAtPoint(worldX, worldY) {
+        if (!window.app || !window.app.project) return null;
+        const arr = window.app.project.canvases;
+        if (!Array.isArray(arr) || arr.length === 0) return null;
+        const EDGE_HIT_PX = 6;
+        const tol = EDGE_HIT_PX / Math.max(this.zoom, 0.0001);
+        const useShow = this.isShowLookView();
+        for (const c of arr) {
+            if (!c || c.visible === false) continue;
+            const w = (useShow && c.show_raster_width) || c.raster_width || 0;
+            const h = (useShow && c.show_raster_height) || c.raster_height || 0;
+            if (w <= 0 || h <= 0) continue;
+            const x = c.workspace_x || 0;
+            const y = c.workspace_y || 0;
+            // Outer bounds (rect + tol on every side)
+            if (worldX < x - tol || worldX > x + w + tol) continue;
+            if (worldY < y - tol || worldY > y + h + tol) continue;
+            // Inside any of the four edge bands?
+            const nearLeft   = Math.abs(worldX - x)       <= tol;
+            const nearRight  = Math.abs(worldX - (x + w)) <= tol;
+            const nearTop    = Math.abs(worldY - y)       <= tol;
+            const nearBottom = Math.abs(worldY - (y + h)) <= tol;
+            if (nearLeft || nearRight || nearTop || nearBottom) {
+                return c;
+            }
+        }
+        return null;
+    }
+
     handleMouseDown(e) {
         const rect = this.canvas.getBoundingClientRect();
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
         const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
+
+        // Slice 5: dragging a canvas's dashed outline edge repositions
+        // the canvas in the workspace. Must be checked BEFORE the Slice 4
+        // panel/canvas-activate block so edge-drag wins over body-click
+        // activation. Skipped for pan (space), shift, and alt — those are
+        // existing drag/paint behaviors. Inside the canvas body still
+        // falls through to Slice 4.
+        if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
+            const edgeCanvas = this._canvasEdgeAtPoint(worldX, worldY);
+            if (edgeCanvas) {
+                this.isDraggingCanvas = true;
+                this.draggingCanvasId = edgeCanvas.id;
+                this.canvasDragStartX = worldX;
+                this.canvasDragStartY = worldY;
+                this.canvasDragStartWX = edgeCanvas.workspace_x || 0;
+                this.canvasDragStartWY = edgeCanvas.workspace_y || 0;
+                // Activate the dragged canvas so the sidebar reflects it.
+                if (window.app && window.app.project
+                    && window.app.project.active_canvas_id !== edgeCanvas.id
+                    && typeof window.app.setActiveCanvas === 'function') {
+                    window.app.setActiveCanvas(edgeCanvas.id);
+                }
+                this.canvas.style.cursor = 'grabbing';
+                if (typeof sendClientLog === 'function') {
+                    sendClientLog('canvas_drag_start', { canvasId: edgeCanvas.id });
+                }
+                return;
+            }
+        }
 
         // Slice 4 (+ multi-canvas hit-test fix): every left click in the
         // workspace either:
@@ -712,6 +782,22 @@ class CanvasRenderer {
         const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
 
+        // Slice 5: live canvas-drag — update workspace_x/y on every move,
+        // but only PUT to the server on mouseup (avoid flooding).
+        if (this.isDraggingCanvas && this.draggingCanvasId) {
+            if (window.app && window.app.project) {
+                const c = window.app.project.canvases.find(c => c.id === this.draggingCanvasId);
+                if (c) {
+                    const dx = worldX - this.canvasDragStartX;
+                    const dy = worldY - this.canvasDragStartY;
+                    c.workspace_x = this.canvasDragStartWX + dx;
+                    c.workspace_y = this.canvasDragStartWY + dy;
+                    this.render();
+                }
+            }
+            return;
+        }
+
         if (this.isAltPainting) {
             const clickedPanel = this.getPanelAt(worldX, worldY);
             if (clickedPanel && clickedPanel.layerId === this.altPaintLayerId && !this.altPaintedPanelIds.has(clickedPanel.panel.id)) {
@@ -879,12 +965,50 @@ class CanvasRenderer {
         
         if (this.spacePressed && !this.isDragging) {
             this.canvas.style.cursor = 'grab';
-        } else if (!this.isDragging && !this.isDraggingLayer && !this.isDraggingScreenName) {
-            this.canvas.style.cursor = 'default';
+        } else if (!this.isDragging && !this.isDraggingLayer && !this.isDraggingScreenName && !this.isDraggingCanvas) {
+            // Slice 5: hovering a canvas's outline edge → show 'move' so
+            // the user knows they can grab it. Skip when a modifier is
+            // held (other actions own those gestures).
+            if (!e.shiftKey && !e.altKey && !this.isSelectingPanels && !this.isSelectingLayers
+                && this._canvasEdgeAtPoint(worldX, worldY)) {
+                this.canvas.style.cursor = 'move';
+            } else {
+                this.canvas.style.cursor = 'default';
+            }
         }
     }
     
     handleMouseUp(e) {
+        // Slice 5: commit canvas-drag drop. Live updates already happened
+        // during mousemove; here we round to integer (avoid sub-pixel
+        // drift), persist with a single PUT, and run an overlap check.
+        if (this.isDraggingCanvas) {
+            this.isDraggingCanvas = false;
+            const id = this.draggingCanvasId;
+            this.draggingCanvasId = null;
+            this.canvas.style.cursor = 'default';
+            if (window.app && window.app.project) {
+                const c = window.app.project.canvases.find(c => c.id === id);
+                if (c) {
+                    const wx = Math.round(c.workspace_x || 0);
+                    const wy = Math.round(c.workspace_y || 0);
+                    c.workspace_x = wx;
+                    c.workspace_y = wy;
+                    if (typeof window.app.updateCanvas === 'function') {
+                        window.app.updateCanvas(id, { workspace_x: wx, workspace_y: wy });
+                    }
+                    if (typeof window.app._checkCanvasOverlapAndToast === 'function') {
+                        window.app._checkCanvasOverlapAndToast(id);
+                    }
+                }
+            }
+            this.render();
+            if (typeof sendClientLog === 'function') {
+                sendClientLog('canvas_drag_end', { canvasId: id });
+            }
+            return;
+        }
+
         if (this.isAltPainting) {
             this.isAltPainting = false;
             if (window.app && this.altPaintedPanelIds && this.altPaintedPanelIds.size > 0) {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -495,13 +495,9 @@ class CanvasRenderer {
                 this.canvasDragStartY = worldY;
                 this.canvasDragStartWX = edgeCanvas.workspace_x || 0;
                 this.canvasDragStartWY = edgeCanvas.workspace_y || 0;
-                // Snapshot pre-drag state so undo restores the canvas's
-                // original workspace position. mouseUp passes
-                // skipSaveState:true to the updateCanvas commit so we
-                // don't get a duplicate post-drag snapshot.
-                if (window.app && typeof window.app.saveState === 'function') {
-                    window.app.saveState('Move Canvas');
-                }
+                // saveState moved to canvas-drag END (in updateCanvas .then())
+                // so the snapshot is the POST-drag workspace position. Pre-drag
+                // saveState was off-by-one and made undo skip past the drag.
                 // Activate the dragged canvas so the sidebar reflects it.
                 if (window.app && window.app.project
                     && window.app.project.active_canvas_id !== edgeCanvas.id
@@ -691,10 +687,12 @@ class CanvasRenderer {
                     }
                     this.isDraggingLayer = true;
                     this.dragLayerMode = (this.viewMode === 'show-look') ? 'show' : 'processor';
-                    // Save state BEFORE the drag starts so undo reverts to pre-move positions
-                    if (typeof window.app.saveState === 'function') {
-                        window.app.saveState(this.dragLayerMode === 'show' ? 'Move Layers (Show Look)' : 'Move Layers');
-                    }
+                    // saveState moved to drag-END so the snapshot captures the
+                    // POST-drag project state. Undo decrements then restores
+                    // the previous post-state, which matches the user's
+                    // expectation of "one Cmd+Z reverts one drag." Pre-drag
+                    // saveState was off-by-one and made undo skip past the
+                    // most recent action.
                     this.dragLayerStartX = worldX;
                     this.dragLayerStartY = worldY;
                     const useShow = this.dragLayerMode === 'show';
@@ -1078,10 +1076,10 @@ class CanvasRenderer {
                     c.workspace_x = wx;
                     c.workspace_y = wy;
                     if (typeof window.app.updateCanvas === 'function') {
-                        // Skip the helper's own saveState — drag-start already
-                        // captured a 'Move Canvas' snapshot, so adding another
-                        // here would create a no-op duplicate history entry.
-                        window.app.updateCanvas(id, { workspace_x: wx, workspace_y: wy }, { skipSaveState: true });
+                        // updateCanvas now snapshots POST-mutation state in
+                        // its server-response .then() so a single Cmd+Z reverts
+                        // exactly this drag. No skipSaveState needed.
+                        window.app.updateCanvas(id, { workspace_x: wx, workspace_y: wy });
                     }
                     if (typeof window.app._checkCanvasOverlapAndToast === 'function') {
                         window.app._checkCanvasOverlapAndToast(id);
@@ -1367,22 +1365,24 @@ class CanvasRenderer {
                                 }
                             });
                         }
-                        // Pass skipSaveState — the drag-start saveState
-                        // ('Move Layers' at line ~689) is the correct
-                        // pre-drag snapshot. Without skip, the helper
-                        // would push a SECOND mid-drag snapshot and undo
-                        // would restore weird intermediate coords.
+                        // Cross-canvas helpers now snapshot post-action state
+                        // themselves (in their .then() after the server
+                        // round-trip), so we don't pass skipSaveState anymore.
                         if (movedIds.length > 1 && typeof window.app.moveLayersCrossCanvas === 'function') {
-                            window.app.moveLayersCrossCanvas(movedIds, targetCanvas.id, mode, { skipSaveState: true });
+                            window.app.moveLayersCrossCanvas(movedIds, targetCanvas.id, mode);
                             crossCanvasHandled = true;
                         } else if (typeof window.app.moveLayerCrossCanvas === 'function') {
-                            window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode, { skipSaveState: true });
+                            window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode);
                             crossCanvasHandled = true;
                         }
                     }
                 }
 
                 if (!crossCanvasHandled) {
+                    // Snapshot POST-drag state so one Cmd+Z reverts this drag.
+                    if (typeof window.app.saveState === 'function') {
+                        window.app.saveState(this.dragLayerMode === 'show' ? 'Move Layers (Show Look)' : 'Move Layers');
+                    }
                     const toUpdate = window.app.getSelectedLayers ? window.app.getSelectedLayers() : [window.app.currentLayer];
                     window.app.updateLayers(toUpdate, false);
                 }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -182,11 +182,20 @@ class CanvasRenderer {
      */
     isMirroredView() {
         if (!window.app || !window.app.project) return false;
+        // v0.8 Slice 8: perspective is per-canvas. Read from the active
+        // canvas first; fall back to the project root for legacy projects
+        // that haven't been migrated (and the synthetic canvasesToRender
+        // entry built at render() for pre-Slice-1 fallbacks).
+        const proj = window.app.project;
+        const active = (typeof window.app._activeCanvas === 'function')
+            ? window.app._activeCanvas() : null;
         if (this.viewMode === 'data-flow') {
-            return window.app.project.data_flow_perspective === 'back';
+            const v = (active && active.data_flow_perspective) || proj.data_flow_perspective;
+            return v === 'back';
         }
         if (this.viewMode === 'power') {
-            return window.app.project.power_perspective === 'back';
+            const v = (active && active.power_perspective) || proj.power_perspective;
+            return v === 'back';
         }
         return false;
     }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -403,7 +403,9 @@ class CanvasRenderer {
                     }
                     if ((!window.app.currentLayer || window.app.currentLayer.id !== layer.id)
                         && typeof window.app.selectLayer === 'function') {
-                        window.app.selectLayer(layer.id);
+                        // selectLayer takes the layer OBJECT, not the id
+                        // (the !layer.id guard rejects raw integers).
+                        window.app.selectLayer(layer);
                     }
                 }
             } else {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1874,6 +1874,16 @@ class CanvasRenderer {
         }
 
         if (text) {
+            // Clip text rendering to the text-layer's own box so overlong
+            // content can't spill onto neighboring canvases or out of the
+            // layer's raster footprint. The clip is scoped to a separate
+            // save() so the background + border (already drawn above) are
+            // unaffected.
+            this.ctx.save();
+            this.ctx.beginPath();
+            this.ctx.rect(x, y, w, h);
+            this.ctx.clip();
+
             this.ctx.fillStyle = fontColor;
             // Build font string with bold/italic
             let fontStyle = '';
@@ -1891,24 +1901,26 @@ class CanvasRenderer {
 
             lines.forEach((line, i) => {
                 const ty = y + padding + i * lineHeight;
-                if (ty + lineHeight <= y + h + lineHeight) {
-                    this._fillText(line, textX, ty);
-                    // Underline
-                    if (layer.fontUnderline && line.length > 0) {
-                        const metrics = this.ctx.measureText(line);
-                        let ulX = textX;
-                        if (textAlign === 'center') ulX = textX - metrics.width / 2;
-                        else if (textAlign === 'right') ulX = textX - metrics.width;
-                        const ulY = ty + fontSize + 2;
-                        this.ctx.beginPath();
-                        this.ctx.strokeStyle = fontColor;
-                        this.ctx.lineWidth = Math.max(1, fontSize / 15);
-                        this.ctx.moveTo(ulX, ulY);
-                        this.ctx.lineTo(ulX + metrics.width, ulY);
-                        this.ctx.stroke();
-                    }
+                // Cheap vertical-overflow short-circuit so we don't measure +
+                // fillText for lines fully below the box (clip would suppress
+                // them anyway, but skipping saves work on big text dumps).
+                if (ty > y + h) return;
+                this._fillText(line, textX, ty);
+                if (layer.fontUnderline && line.length > 0) {
+                    const metrics = this.ctx.measureText(line);
+                    let ulX = textX;
+                    if (textAlign === 'center') ulX = textX - metrics.width / 2;
+                    else if (textAlign === 'right') ulX = textX - metrics.width;
+                    const ulY = ty + fontSize + 2;
+                    this.ctx.beginPath();
+                    this.ctx.strokeStyle = fontColor;
+                    this.ctx.lineWidth = Math.max(1, fontSize / 15);
+                    this.ctx.moveTo(ulX, ulY);
+                    this.ctx.lineTo(ulX + metrics.width, ulY);
+                    this.ctx.stroke();
                 }
             });
+            this.ctx.restore();
         }
 
         this.ctx.restore();

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1367,6 +1367,26 @@ class CanvasRenderer {
         }
     }
     
+    /**
+     * v0.8 multi-canvas: return the workspace translate ({wx, wy}) for the
+     * canvas a layer belongs to. Layers without a canvas_id (legacy / orphan)
+     * and projects with no canvases array fall back to (0, 0) so single-canvas
+     * behaviour is unchanged.
+     */
+    _layerCanvasOffset(layer) {
+        if (!layer || !window.app || !window.app.project) return { wx: 0, wy: 0 };
+        const arr = window.app.project.canvases;
+        if (!Array.isArray(arr) || arr.length === 0) return { wx: 0, wy: 0 };
+        const cid = layer.canvas_id;
+        if (!cid) return { wx: 0, wy: 0 };
+        for (const c of arr) {
+            if (c && c.id === cid) {
+                return { wx: c.workspace_x || 0, wy: c.workspace_y || 0 };
+            }
+        }
+        return { wx: 0, wy: 0 };
+    }
+
     getPanelAt(worldX, worldY) {
         if (!window.app || !window.app.project) return null;
         for (let i = window.app.project.layers.length - 1; i >= 0; i--) {
@@ -1375,10 +1395,13 @@ class CanvasRenderer {
             if ((layer.type || 'screen') === 'image') continue;
             // Convert world coords back into the layer's processor space so we
             // can hit-test against panel.x/y (which are stored at processor
-            // position; show-look just renders with a translate).
+            // position; show-look renders with a translate AND, for v0.8
+            // multi-canvas, the per-layer render is wrapped in the parent
+            // canvas's workspace translate). Subtract both.
             const { dx, dy } = this.getLayerRenderOffset(layer);
-            const lx = worldX - dx;
-            const ly = worldY - dy;
+            const { wx, wy } = this._layerCanvasOffset(layer);
+            const lx = worldX - dx - wx;
+            const ly = worldY - dy - wy;
             for (const panel of layer.panels) {
                 // Don't skip hidden panels - they need to be clickable to toggle back
                 if (lx >= panel.x && lx <= panel.x + panel.width &&
@@ -1397,10 +1420,17 @@ class CanvasRenderer {
             if (!layer.visible) continue;
             // Hit-test against the layer's bounds in the *active view*, since
             // worldX/worldY are in the view's coord space (Show Look / Data /
-            // Power render at the show position).
+            // Power render at the show position). v0.8: bounds returned by
+            // getLayerBoundsInActiveView are in the canvas's local coord
+            // space; shift by the canvas's workspace_x/y so the comparison
+            // against worldX/worldY (which are in workspace coords) is right
+            // for canvases beyond the first.
             const bounds = this.getLayerBoundsInActiveView(layer);
-            if (worldX >= bounds.x && worldX <= bounds.x + bounds.width &&
-                worldY >= bounds.y && worldY <= bounds.y + bounds.height) {
+            const { wx, wy } = this._layerCanvasOffset(layer);
+            const bx = bounds.x + wx;
+            const by = bounds.y + wy;
+            if (worldX >= bx && worldX <= bx + bounds.width &&
+                worldY >= by && worldY <= by + bounds.height) {
                 return layer;
             }
         }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1857,28 +1857,52 @@ class CanvasRenderer {
         if (layer.showDate) {
             dynamicLines.push(new Date().toLocaleDateString());
         }
-        // Data port stats
-        if ((layer.showPrimaryPorts || layer.showBackupPorts) && window.app) {
-            const counts = window.app.getPortCounts();
-            if (layer.showPrimaryPorts && counts.primary > 0) {
-                dynamicLines.push(`Primary Ports: ${counts.primary}`);
+        // v0.8 Slice 10: dynamic data/power stats now honor a per-layer
+        // scope: 'canvas' (text layer's parent canvas), 'project' (all
+        // canvases — original behaviour, default), or 'both' (renders one
+        // line for the canvas, then one for the project total).
+        const scope = layer.dynamicInfoScope || 'project';
+        const wantsData = layer.showPrimaryPorts || layer.showBackupPorts;
+        const wantsPower = layer.showCircuits || layer.showSinglePhase || layer.showThreePhase;
+        if ((wantsData || wantsPower) && window.app) {
+            // Resolve the canvas this text layer sits on. For "canvas" /
+            // "both" scopes we need to pass canvas_id into the aggregators.
+            const ownCanvasId = layer.canvas_id || null;
+            const ownCanvas = (ownCanvasId && window.app._activeCanvas)
+                ? (window.app.project && window.app.project.canvases || []).find(c => c && c.id === ownCanvasId)
+                : null;
+            const canvasLabel = ownCanvas ? (ownCanvas.name || 'Canvas') : 'Canvas';
+            const passes = []; // [{ key: 'canvas'|'project', label: '... (X)' or '... (Total)' }]
+            if (scope === 'canvas') passes.push({ key: 'canvas', suffix: ` (${canvasLabel})` });
+            else if (scope === 'project') passes.push({ key: 'project', suffix: '' });
+            else { // 'both'
+                passes.push({ key: 'canvas', suffix: ` (${canvasLabel})` });
+                passes.push({ key: 'project', suffix: ' (Total)' });
             }
-            if (layer.showBackupPorts && counts.backup > 0) {
-                dynamicLines.push(`Backup Ports: ${counts.backup}`);
-            }
-        }
-        // Power stats
-        if ((layer.showCircuits || layer.showSinglePhase || layer.showThreePhase) && window.app) {
-            const pwr = window.app.getPowerCounts();
-            if (layer.showCircuits && pwr.circuits > 0) {
-                dynamicLines.push(`Circuits: ${pwr.circuits} @ ${pwr.voltage}V`);
-            }
-            if (layer.showSinglePhase && pwr.circuits > 0) {
-                dynamicLines.push(`1-Phase: ${pwr.singlePhaseAmps.toFixed(2)}A`);
-            }
-            if (layer.showThreePhase && pwr.circuits >= 3) {
-                dynamicLines.push(`3-Phase: ${pwr.threePhaseAmps.toFixed(2)}A`);
-            }
+            passes.forEach(pass => {
+                const filter = pass.key === 'canvas' ? ownCanvasId : undefined;
+                if (wantsData) {
+                    const counts = window.app.getPortCounts(filter);
+                    if (layer.showPrimaryPorts && counts.primary > 0) {
+                        dynamicLines.push(`Primary Ports${pass.suffix}: ${counts.primary}`);
+                    }
+                    if (layer.showBackupPorts && counts.backup > 0) {
+                        dynamicLines.push(`Backup Ports${pass.suffix}: ${counts.backup}`);
+                    }
+                }
+                if (wantsPower) {
+                    const pwr = window.app.getPowerCounts(filter);
+                    if (layer.showCircuits && pwr.circuits > 0) {
+                        dynamicLines.push(`Circuits${pass.suffix}: ${pwr.circuits} @ ${pwr.voltage}V`);
+                    }
+                    if (layer.showSinglePhase && pwr.circuits > 0) {
+                        dynamicLines.push(`1-Phase${pass.suffix}: ${pwr.singlePhaseAmps.toFixed(2)}A`);
+                    }
+                    if (layer.showThreePhase && pwr.circuits >= 3) {
+                        dynamicLines.push(`3-Phase${pass.suffix}: ${pwr.threePhaseAmps.toFixed(2)}A`);
+                    }
+                }
+            });
         }
         if (dynamicLines.length > 0) {
             text = text ? `${text}\n${dynamicLines.join('\n')}` : dynamicLines.join('\n');

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -15,17 +15,18 @@ class CanvasRenderer {
         this.layerSelectionRect = null;
         this.magneticSnap = true; // Magnetic snapping enabled by default
         this.spacePressed = false;
-        // rasterWidth/Height are the *currently active* view's raster size.
-        // The actual storage lives in pixelRasterWidth/Height and
-        // showRasterWidth/Height; setViewMode() swaps the active fields so
-        // pixel-map/cabinet-id render against the processor raster while
-        // show-look/data-flow/power render against the show raster.
-        this.pixelRasterWidth = 1920;
-        this.pixelRasterHeight = 1080;
-        this.showRasterWidth = 1920;
-        this.showRasterHeight = 1080;
-        this.rasterWidth = 1920;
-        this.rasterHeight = 1080;
+        // Slice 6: rasterWidth/Height (and pixel/show variants) are now
+        // accessor properties that read from the *active canvas* (or, during
+        // the per-canvas render loop, from `_activeRenderCanvas` — set by
+        // render() so each canvas's panels clip against ITS own raster, not
+        // the active canvas's). Backing fields below are the legacy
+        // single-canvas fallback used only when the project has no canvases
+        // array (extremely old / pre-Slice-1 projects).
+        this._fallbackPixelRasterWidth = 1920;
+        this._fallbackPixelRasterHeight = 1080;
+        this._fallbackShowRasterWidth = 1920;
+        this._fallbackShowRasterHeight = 1080;
+        this._activeRenderCanvas = null;
         this.showGrid = true;
         this.viewMode = 'pixel-map'; // Default view mode
         this.exportMode = false; // When true, hides grid and raster boundary for clean export
@@ -45,9 +46,64 @@ class CanvasRenderer {
         this.showOffsetTR = false;
         this.showOffsetBL = false;
         this.showOffsetBR = false;
-        
+
+        // Slice 6: install raster getters/setters that route to the active
+        // canvas. Done in the constructor so every CanvasRenderer instance
+        // gets them on its own object (cannot be on the prototype because
+        // they shadow plain assignments).
+        this._installRasterAccessors();
+
         this.setupCanvas();
         this.setupEventListeners();
+    }
+
+    /**
+     * Slice 6 (multi-canvas v0.8): rasterWidth / rasterHeight and the
+     * pixel/show variants used to be plain instance fields. They are now
+     * computed from the active canvas (or the canvas currently being rendered
+     * in the per-canvas loop). Reads return the right value for the current
+     * view tab; writes route to the active canvas via the project model so
+     * the toolbar Raster: W x H field edits the active canvas's raster.
+     *
+     * Fallback behaviour (no canvases array — legacy / pre-Slice-1 project):
+     * read/write the _fallback* backing fields. Single-canvas behaviour is
+     * preserved exactly.
+     */
+    _installRasterAccessors() {
+        const self = this;
+        const active = () => {
+            const proj = (window.app && window.app.project) || null;
+            if (!proj || !Array.isArray(proj.canvases) || proj.canvases.length === 0) return null;
+            // Per-canvas render loop sets _activeRenderCanvas so each canvas's
+            // panels clip against ITS OWN raster — not the active canvas's.
+            if (self._activeRenderCanvas) return self._activeRenderCanvas;
+            return proj.canvases.find(c => c.id === proj.active_canvas_id) || proj.canvases[0];
+        };
+        const isShow = () => self.isShowLookView();
+        const def = (name, read, write) => Object.defineProperty(self, name, {
+            configurable: true,
+            enumerable: true,
+            get: read,
+            set: write,
+        });
+        def('pixelRasterWidth',
+            () => { const c = active(); return c ? (Number(c.raster_width) || 0) : self._fallbackPixelRasterWidth; },
+            (v) => { const c = active(); if (c) c.raster_width = Number(v) || 0; else self._fallbackPixelRasterWidth = Number(v) || 0; });
+        def('pixelRasterHeight',
+            () => { const c = active(); return c ? (Number(c.raster_height) || 0) : self._fallbackPixelRasterHeight; },
+            (v) => { const c = active(); if (c) c.raster_height = Number(v) || 0; else self._fallbackPixelRasterHeight = Number(v) || 0; });
+        def('showRasterWidth',
+            () => { const c = active(); return c ? (Number(c.show_raster_width) || Number(c.raster_width) || 0) : self._fallbackShowRasterWidth; },
+            (v) => { const c = active(); if (c) c.show_raster_width = Number(v) || 0; else self._fallbackShowRasterWidth = Number(v) || 0; });
+        def('showRasterHeight',
+            () => { const c = active(); return c ? (Number(c.show_raster_height) || Number(c.raster_height) || 0) : self._fallbackShowRasterHeight; },
+            (v) => { const c = active(); if (c) c.show_raster_height = Number(v) || 0; else self._fallbackShowRasterHeight = Number(v) || 0; });
+        def('rasterWidth',
+            () => isShow() ? self.showRasterWidth : self.pixelRasterWidth,
+            (v) => { if (isShow()) self.showRasterWidth = v; else self.pixelRasterWidth = v; });
+        def('rasterHeight',
+            () => isShow() ? self.showRasterHeight : self.pixelRasterHeight,
+            (v) => { if (isShow()) self.showRasterHeight = v; else self.pixelRasterHeight = v; });
     }
     
     setupCanvas() {
@@ -1923,6 +1979,11 @@ class CanvasRenderer {
                     this.ctx.save();
                     this.ctx.translate(wx, wy);
                 }
+                // Slice 6: scope rasterWidth/Height (via the getter) to THIS
+                // canvas during its render pass so per-panel clipping uses
+                // this canvas's raster, not the active canvas's. Cleared at
+                // the end of the pass.
+                this._activeRenderCanvas = canvas.id ? canvas : null;
                 // Active-canvas tint (BEFORE layers so layers paint over it
                 // but the tint shows through in empty regions).
                 if (!this.exportMode && canvas.id && canvas.id === _activeCanvasId) {
@@ -2018,6 +2079,10 @@ class CanvasRenderer {
             // translated space.
             this._renderDx = 0;
             this._renderDy = 0;
+            // Slice 6: clear the per-canvas raster scope so any post-pass
+            // (overlays, badges, hit-testing during this render) sees the
+            // active canvas's raster via the getter again.
+            this._activeRenderCanvas = null;
 
             if (!this.exportMode && this.viewMode === 'data-flow') {
                 this.renderCustomSelectionOverlay();
@@ -2355,18 +2420,11 @@ class CanvasRenderer {
     
     setViewMode(mode) {
         this.viewMode = mode;
-        // Swap the active raster to match the view. Show-look and the
-        // downstream tabs (data-flow, power) render at the show raster;
-        // pixel-map and cabinet-id render at the processor raster.
-        if (this.isShowLookView(mode)) {
-            this.rasterWidth = this.showRasterWidth;
-            this.rasterHeight = this.showRasterHeight;
-        } else {
-            this.rasterWidth = this.pixelRasterWidth;
-            this.rasterHeight = this.pixelRasterHeight;
-        }
-        // Reflect the active raster in the toolbar inputs so the user sees
-        // the right numbers when switching tabs.
+        // Slice 6: rasterWidth/Height now read view-aware from the active
+        // canvas via getters (pixel raster on pixel-map/cabinet-id, show
+        // raster on show-look/data-flow/power), so no manual swap needed.
+        // Refresh the toolbar inputs so the user sees the right numbers when
+        // switching tabs.
         const rw = document.getElementById('toolbar-raster-width');
         const rh = document.getElementById('toolbar-raster-height');
         if (rw) rw.value = this.rasterWidth;

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1442,10 +1442,10 @@ class CanvasRenderer {
         this.zoom = newZoom;
         this.panX = mouseX - worldX * this.zoom;
         this.panY = mouseY - worldY * this.zoom;
-        document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
+        document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
     }
-    
+
     handleContextMenu(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -2288,21 +2288,31 @@ class CanvasRenderer {
         this.ctx.restore();
     }
     
+    // The displayed zoom percentage is 1 raster-pixel-to-1-device-pixel based,
+    // so "100%" truly means actual size. Internally `this.zoom` still maps
+    // raster pixels to CSS pixels; on a Retina display devicePixelRatio is 2,
+    // so 100% displayed == this.zoom == 0.5 (1 raster px → 0.5 CSS px → 1
+    // device px). This keeps render math unchanged and only adjusts the I/O
+    // boundary with the zoom-level input.
+    _displayDpr() { return window.devicePixelRatio || 1; }
+    _zoomToPercent(z) { return Math.round(z * this._displayDpr() * 100); }
+    _percentToZoom(p) { return p / 100 / this._displayDpr(); }
+
     zoomIn() {
         this.zoom = Math.min(500.0, this.zoom * 1.2);  // Max 50000% for pixel-level zoom
-        document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
+        document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
     }
-    
+
     zoomOut() {
         this.zoom = Math.max(0.01, this.zoom / 1.2);
-        document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
+        document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
     }
-    
+
     setZoom(zoomLevel) {
         this.zoom = Math.max(0.01, Math.min(500.0, zoomLevel));
-        document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
+        document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
     }
     
@@ -2345,13 +2355,15 @@ class CanvasRenderer {
         this.zoom = Math.min(zoomX, zoomY);
         this.panX = (this.canvas.width - w * this.zoom) / 2 - bb.x * this.zoom;
         this.panY = (this.canvas.height - h * this.zoom) / 2 - bb.y * this.zoom;
-        document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
+        document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
     }
-    
+
     zoomActual() {
         if (!window.app || !window.app.currentLayer) {
-            this.zoom = 1.0;
+            // 1:1 sizing: 1 raster px == 1 device px (so on Retina, halve the
+            // CSS-pixel scale).
+            this.zoom = 1.0 / this._displayDpr();
             this.panX = 100;
             this.panY = 100;
         } else {
@@ -2377,10 +2389,10 @@ class CanvasRenderer {
             this.panX = this.canvas.width / 2 - layerCenterX * this.zoom;
             this.panY = this.canvas.height / 2 - layerCenterY * this.zoom;
         }
-        document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
+        document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
     }
-    
+
     calculateMagneticSnap(offsetX, offsetY, currentLayer) {
         const snapDistance = 20; // Snap within 20 pixels - feels natural
         let snappedX = offsetX;

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -888,8 +888,19 @@ class CanvasRenderer {
                 if (c) {
                     const dx = worldX - this.canvasDragStartX;
                     const dy = worldY - this.canvasDragStartY;
-                    c.workspace_x = this.canvasDragStartWX + dx;
-                    c.workspace_y = this.canvasDragStartWY + dy;
+                    let nextX = this.canvasDragStartWX + dx;
+                    let nextY = this.canvasDragStartWY + dy;
+                    // v0.8 Slice 9: snap dragged canvas edges to neighbor
+                    // canvas edges (left↔right, right↔left, top↔bottom,
+                    // bottom↔top, plus aligned-edge snap). Honors the global
+                    // magnetic-snap toggle so users can disable it.
+                    if (this.magneticSnap) {
+                        const snapped = this._snapCanvasToNeighbors(c, nextX, nextY);
+                        nextX = snapped.x;
+                        nextY = snapped.y;
+                    }
+                    c.workspace_x = nextX;
+                    c.workspace_y = nextY;
                     this.render();
                 }
             }
@@ -2423,6 +2434,64 @@ class CanvasRenderer {
         }
         document.getElementById('zoom-level').value = `${this._zoomToPercent(this.zoom)}%`;
         this.render();
+    }
+
+    /**
+     * v0.8 Slice 9: snap a dragged canvas's edges to abut (or align with)
+     * neighboring canvases. Threshold scales with current zoom so the snap
+     * "feels" the same physical distance regardless of zoom level — ~14
+     * device px on screen.
+     *
+     * Returns the (possibly snapped) {x, y} workspace position. Each axis is
+     * checked independently so you can snap one side without locking the
+     * other.
+     */
+    _snapCanvasToNeighbors(dragged, proposedX, proposedY) {
+        if (!window.app || !window.app.project || !Array.isArray(window.app.project.canvases)) {
+            return { x: proposedX, y: proposedY };
+        }
+        const useShow = this.isShowLookView();
+        const draggedW = (useShow && dragged.show_raster_width) || dragged.raster_width || 0;
+        const draggedH = (useShow && dragged.show_raster_height) || dragged.raster_height || 0;
+        if (draggedW <= 0 || draggedH <= 0) return { x: proposedX, y: proposedY };
+        // Snap threshold in workspace coords (zoom-corrected so on-screen
+        // feel is consistent at any zoom).
+        const threshold = 14 / Math.max(this.zoom, 0.0001);
+        const draggedLeft = proposedX;
+        const draggedRight = proposedX + draggedW;
+        const draggedTop = proposedY;
+        const draggedBottom = proposedY + draggedH;
+        let bestDx = null, bestDy = null;
+        const consider = (delta, current) => {
+            if (Math.abs(delta) > threshold) return current;
+            if (current === null || Math.abs(delta) < Math.abs(current)) return delta;
+            return current;
+        };
+        for (const other of window.app.project.canvases) {
+            if (!other || other.id === dragged.id || other.visible === false) continue;
+            const ox = other.workspace_x || 0;
+            const oy = other.workspace_y || 0;
+            const ow = (useShow && other.show_raster_width) || other.raster_width || 0;
+            const oh = (useShow && other.show_raster_height) || other.raster_height || 0;
+            if (ow <= 0 || oh <= 0) continue;
+            const otherLeft = ox, otherRight = ox + ow;
+            const otherTop = oy, otherBottom = oy + oh;
+            // X-axis snap candidates: abut (left-to-right, right-to-left)
+            // plus aligned edges (left↔left, right↔right, centerline).
+            bestDx = consider(otherRight - draggedLeft, bestDx);   // dragged.left snaps to other.right (abut)
+            bestDx = consider(otherLeft - draggedRight, bestDx);   // dragged.right snaps to other.left (abut)
+            bestDx = consider(otherLeft - draggedLeft, bestDx);    // align lefts
+            bestDx = consider(otherRight - draggedRight, bestDx);  // align rights
+            // Y-axis snap candidates
+            bestDy = consider(otherBottom - draggedTop, bestDy);   // dragged.top snaps to other.bottom (abut)
+            bestDy = consider(otherTop - draggedBottom, bestDy);   // dragged.bottom snaps to other.top (abut)
+            bestDy = consider(otherTop - draggedTop, bestDy);      // align tops
+            bestDy = consider(otherBottom - draggedBottom, bestDy);// align bottoms
+        }
+        return {
+            x: proposedX + (bestDx || 0),
+            y: proposedY + (bestDy || 0),
+        };
     }
 
     calculateMagneticSnap(offsetX, offsetY, currentLayer) {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -17,7 +17,7 @@ class CanvasRenderer {
         this.spacePressed = false;
         // Slice 6: rasterWidth/Height (and pixel/show variants) are now
         // accessor properties that read from the *active canvas* (or, during
-        // the per-canvas render loop, from `_activeRenderCanvas` — set by
+        // the per-canvas render loop, from `_activeRenderCanvas`, set by
         // render() so each canvas's panels clip against ITS own raster, not
         // the active canvas's). Backing fields below are the legacy
         // single-canvas fallback used only when the project has no canvases
@@ -65,7 +65,7 @@ class CanvasRenderer {
      * view tab; writes route to the active canvas via the project model so
      * the toolbar Raster: W x H field edits the active canvas's raster.
      *
-     * Fallback behaviour (no canvases array — legacy / pre-Slice-1 project):
+     * Fallback behaviour (no canvases array, legacy / pre-Slice-1 project):
      * read/write the _fallback* backing fields. Single-canvas behaviour is
      * preserved exactly.
      */
@@ -75,7 +75,7 @@ class CanvasRenderer {
             const proj = (window.app && window.app.project) || null;
             if (!proj || !Array.isArray(proj.canvases) || proj.canvases.length === 0) return null;
             // Per-canvas render loop sets _activeRenderCanvas so each canvas's
-            // panels clip against ITS OWN raster — not the active canvas's.
+            // panels clip against ITS OWN raster, not the active canvas's.
             if (self._activeRenderCanvas) return self._activeRenderCanvas;
             return proj.canvases.find(c => c.id === proj.active_canvas_id) || proj.canvases[0];
         };
@@ -203,7 +203,7 @@ class CanvasRenderer {
     /**
      * fillText that auto-un-mirrors when the canvas is in a mirrored
      * (back-view) render so label glyphs stay right-side-up. Anchor
-     * position is the same as ctx.fillText — pass the position you would
+     * position is the same as ctx.fillText, pass the position you would
      * have used in normal rendering. Text alignment ('center' is the most
      * common in this codebase) keeps its visual centering. Edge-aligned
      * text ('left'/'right') will flip its anchor side, which is the right
@@ -243,7 +243,7 @@ class CanvasRenderer {
      * in *screen* space, even when the caller is currently inside a per-layer
      * ctx.translate(dx, dy). Without this, a naive `ctx.rect(0,0,rasterWidth,
      * rasterHeight); ctx.clip()` ends up clipping in local (translated)
-     * coords — which means screen coords [dx, dx+rasterWidth] — and lops off
+     * coords, which means screen coords [dx, dx+rasterWidth], and lops off
      * any content drawn at low screen-x when the layer is shifted right (or
      * vice versa). All renderers that paint within the per-layer translate
      * (renderLayerLabels, renderDataFlowArrows, renderPowerArrows, etc.)
@@ -273,7 +273,7 @@ class CanvasRenderer {
      *
      * Uses the canvas's own raster_width/raster_height (not the renderer's
      * project-level rasterWidth) so each canvas's rect reflects its own
-     * size — even though Slice 3 keeps the source-of-truth at project root
+     * size, even though Slice 3 keeps the source-of-truth at project root
      * for the active canvas; per-canvas raster sizes are read straight from
      * the canvas object here.
      */
@@ -414,7 +414,7 @@ class CanvasRenderer {
     _unmirrorWorldX(worldX) {
         if (!this.isMirroredView()) return worldX;
         // v0.8 Slice 8 fix: mirror axis is the workspace bounds, not the
-        // active canvas's raster — otherwise multi-canvas workspaces flip
+        // active canvas's raster, otherwise multi-canvas workspaces flip
         // off-screen because workspace_x can be far past rasterWidth.
         const k = this._mirrorAxisX();
         return k - worldX;
@@ -423,7 +423,7 @@ class CanvasRenderer {
     /**
      * The Canvas2D translate-X used as the mirror axis when Back perspective
      * is active. We mirror around the workspace bounding box so points stay
-     * in the same x-range after the flip — single-canvas projects degrade to
+     * in the same x-range after the flip, single-canvas projects degrade to
      * mirroring around rasterWidth (legacy behaviour) automatically because
      * their bbox.x is 0 and bbox.w == rasterWidth.
      */
@@ -436,7 +436,7 @@ class CanvasRenderer {
 
     /**
      * Slice 4: hit-test a workspace point against the visible canvases.
-     * Returns the first canvas (in array order — earlier wins on overlap)
+     * Returns the first canvas (in array order, earlier wins on overlap)
      * whose rect contains (worldX, worldY), or null. Uses the same per-mode
      * raster fields _drawCanvasOutline does, including the workspace_x/y
      * offset so the rect is in workspace coords (matching worldX/worldY).
@@ -469,7 +469,7 @@ class CanvasRenderer {
      * "Edge" = within `tol` of any of the four edges of the canvas rect,
      * but the point must also be inside the rect-with-tolerance overall
      * (so corners count). Inside the canvas body (more than `tol` away
-     * from every edge) does NOT count — that's reserved for body-click
+     * from every edge) does NOT count, that's reserved for body-click
      * activate / panel selection.
      */
     _canvasEdgeAtPoint(worldX, worldY) {
@@ -511,7 +511,7 @@ class CanvasRenderer {
         // Slice 5: dragging a canvas's dashed outline edge repositions
         // the canvas in the workspace. Must be checked BEFORE the Slice 4
         // panel/canvas-activate block so edge-drag wins over body-click
-        // activation. Skipped for pan (space), shift, and alt — those are
+        // activation. Skipped for pan (space), shift, and alt, those are
         // existing drag/paint behaviors. Inside the canvas body still
         // falls through to Slice 4.
         if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
@@ -551,7 +551,7 @@ class CanvasRenderer {
         //       canvas;
         //   (c) hits empty area outside any canvas → no canvas change.
         // Skipped for pan (space) and shift/alt modifiers (existing drag
-        // behaviors). Additive — the rest of mouse-down still runs.
+        // behaviors). Additive, the rest of mouse-down still runs.
         if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
             const hitPanel = this.getPanelAt(worldX, worldY);
             if (hitPanel) {
@@ -655,13 +655,13 @@ class CanvasRenderer {
                 && this.viewMode === 'pixel-map'
                 && window.app && window.app.currentLayer) {
             const startPanel = this.getPanelAt(worldX, worldY);
-            // Allow drag-start on hidden ("blank") panels too — selecting them
+            // Allow drag-start on hidden ("blank") panels too, selecting them
             // is the only way to bulk-restore via the sidebar buttons.
             const onCurrentLayer = startPanel
                 && startPanel.layerId === window.app.currentLayer.id;
             // Don't capture the click for panel-select if there's a HIGHER-Z
             // layer (image / text / another screen later in project.layers)
-            // sitting on top of the current layer at this point — the user is
+            // sitting on top of the current layer at this point, the user is
             // clicking the visible top layer, not the panel buried beneath it.
             // Bug: with a text layer over a selected screen, clicks on text
             // were grabbed by the screen's panel-select instead of selecting
@@ -683,7 +683,7 @@ class CanvasRenderer {
         if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
             // Falling through to layer-select means the user clicked outside any
             // panel in pixel-map (or in another view). Drop any stale pixel-map
-            // panel selection so it doesn't sit around — fresh layer-drag should
+            // panel selection so it doesn't sit around, fresh layer-drag should
             // start without panel-state lingering.
             if (this.viewMode === 'pixel-map' && window.app && window.app.pixelMapSelection
                     && window.app.pixelMapSelection.size > 0) {
@@ -828,7 +828,7 @@ class CanvasRenderer {
         } else if (e.button === 0 && e.altKey) {
             // Alt+click/drag toggles "blank" (hidden) on the panel.
             // When a multi-selection is active, apply to the entire selection
-            // in one shot (no drag-painting in that mode — the selection is
+            // in one shot (no drag-painting in that mode, the selection is
             // already explicit).
             if (this.viewMode === 'pixel-map') {
                 const clickedPanel = this.getPanelAt(worldX, worldY);
@@ -891,7 +891,7 @@ class CanvasRenderer {
         const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
 
-        // Slice 5: live canvas-drag — update workspace_x/y on every move,
+        // Slice 5: live canvas-drag, update workspace_x/y on every move,
         // but only PUT to the server on mouseup (avoid flooding).
         if (this.isDraggingCanvas && this.draggingCanvasId) {
             if (window.app && window.app.project) {
@@ -1001,7 +1001,7 @@ class CanvasRenderer {
                     const nextX = item.startX + snapDx;
                     const nextY = item.startY + snapDy;
                     if (showMode) {
-                        // Show Look drag — only the show position changes;
+                        // Show Look drag, only the show position changes;
                         // panels stay at their processor coords.
                         layer.showOffsetX = nextX;
                         layer.showOffsetY = nextY;
@@ -1040,7 +1040,7 @@ class CanvasRenderer {
             // Screen name dragging with snap positions - tab-specific
             if (window.app && window.app.currentLayer) {
                 const layer = window.app.currentLayer;
-                // Screen-name drag — bounds in the active view for snap calc.
+                // Screen-name drag, bounds in the active view for snap calc.
                 const bounds = this.getLayerBoundsInActiveView(layer);
                 const layerWidth = bounds.width;
                 const layerHeight = bounds.height;
@@ -1247,7 +1247,7 @@ class CanvasRenderer {
                     // Click without drag.
                     //  - Plain click on a panel: replace the selection with just that panel
                     //    (resets multi-select instead of confusingly toggling one panel out).
-                    //  - Cmd/Ctrl+click: additive — toggle that panel in/out of the selection.
+                    //  - Cmd/Ctrl+click: additive, toggle that panel in/out of the selection.
                     //  - Plain click on empty space: clear the selection.
                     const clickedPanel = this.getPanelAt(this.selectionRect.x1, this.selectionRect.y1);
                     const additive = e.metaKey || e.ctrlKey;
@@ -1381,7 +1381,7 @@ class CanvasRenderer {
 
                 // Slice 7 + multi-select fix: cross-canvas drop check. The
                 // hit-test uses the **mouse cursor position** at drop time,
-                // not the layer's geometric center — for a wide layer
+                // not the layer's geometric center, for a wide layer
                 // dragged onto a smaller canvas, the cursor lands inside
                 // the target rect long before the layer's center does, and
                 // the user expects "drop where I'm pointing". (Earlier
@@ -1508,7 +1508,7 @@ class CanvasRenderer {
             const worldX = this._unmirrorWorldX(((e.clientX - rect.left) - this.panX) / this.zoom);
             const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
             const clicked = this.getPanelAt(worldX, worldY);
-            // Right-click works on hidden panels too — the menu shows
+            // Right-click works on hidden panels too, the menu shows
             // "Restore From Blank" so they can be brought back.
             if (clicked && clicked.layerId === window.app.currentLayer.id) {
                 const key = window.app.getPanelKey(clicked.panel);
@@ -1859,7 +1859,7 @@ class CanvasRenderer {
         }
         // v0.8 Slice 10: dynamic data/power stats now honor a per-layer
         // scope: 'canvas' (text layer's parent canvas), 'project' (all
-        // canvases — original behaviour, default), or 'both' (renders one
+        // canvases, original behaviour, default), or 'both' (renders one
         // line for the canvas, then one for the project total).
         const scope = layer.dynamicInfoScope || 'project';
         const wantsData = layer.showPrimaryPorts || layer.showBackupPorts;
@@ -2038,7 +2038,7 @@ class CanvasRenderer {
         };
         // Helper: returns true if this layer's canvas is hidden (canvas-level
         // eye toggle off). Used to skip every per-layer post-pass for hidden
-        // canvases — without this, hiding a canvas removed only its outline
+        // canvases, without this, hiding a canvas removed only its outline
         // while its layers continued to render at the canvas's workspace
         // offset.
         const _layerCanvasHidden = (layer) => {
@@ -2089,8 +2089,8 @@ class CanvasRenderer {
                     if (_canvasesArr.length === 0) return true; // legacy fallback
                     return l.canvas_id === canvas.id;
                 });
-                // Empty canvases (no layers) still get drawn — outline +
-                // active tint — so the user can see the canvas exists and can
+                // Empty canvases (no layers) still get drawn, outline +
+                // active tint, so the user can see the canvas exists and can
                 // drag layers into it. Slice 7 cross-canvas drag depends on
                 // this being a valid drop target. Originally Slice 3 skipped
                 // empty canvases entirely, but that hid them from the
@@ -2148,7 +2148,7 @@ class CanvasRenderer {
                     // uses raw panel.x vs rasterWidth and silently drops
                     // panels that sit beyond rasterWidth in processor coords
                     // even when the show-offset places them inside the
-                    // visible raster — caused panels to "vanish" in Show
+                    // visible raster, caused panels to "vanish" in Show
                     // Look after a temporary raster shrink.
                     this._renderDx = dx;
                     this._renderDy = dy;
@@ -2195,7 +2195,7 @@ class CanvasRenderer {
                 }
                 if (needsCanvasShift) this.ctx.restore();
             });
-            // Per-layer translates have been restored — clear the cached
+            // Per-layer translates have been restored, clear the cached
             // render offset so any later renderers (selection overlays,
             // error badges) that happen to call _clipToActiveRaster get
             // raster bounds in real screen space, not in the last layer's
@@ -2298,12 +2298,12 @@ class CanvasRenderer {
                 if (window.app && window.app.project) {
                     window.app.project.layers.forEach(layer => {
                         if (!layer.visible) return;
-                        // Active-view bounds — selection rect is in world coords
+                        // Active-view bounds, selection rect is in world coords
                         // matching the rendered (possibly show-shifted) layout.
                         // For multi-canvas, shift bounds into workspace coords
                         // so the intersection test compares apples-to-apples
                         // with the selection rect (which is in workspace coords
-                        // — captured from world-space mouse events).
+                        //, captured from world-space mouse events).
                         const { wx, wy } = _layerWs(layer);
                         const bounds = this.getLayerBoundsInActiveView(layer);
                         const layerWidth = bounds.width;
@@ -2462,7 +2462,7 @@ class CanvasRenderer {
             const bounds = this.getLayerBoundsInActiveView(layer);
             // bounds.x/y are canvas-relative (in the layer's parent canvas's
             // raster coords). Add the canvas's workspace_x/y so the pan
-            // centers on where the layer is actually drawn in the workspace —
+            // centers on where the layer is actually drawn in the workspace,
             // otherwise 1:1 zooms to the wrong canvas's slot.
             let wx = 0, wy = 0;
             if (window.app.project && window.app.project.canvases && layer.canvas_id) {
@@ -2486,7 +2486,7 @@ class CanvasRenderer {
     /**
      * v0.8 Slice 9: snap a dragged canvas's edges to abut (or align with)
      * neighboring canvases. Threshold scales with current zoom so the snap
-     * "feels" the same physical distance regardless of zoom level — ~14
+     * "feels" the same physical distance regardless of zoom level, ~14
      * device px on screen.
      *
      * Returns the (possibly snapped) {x, y} workspace position. Each axis is
@@ -2578,7 +2578,7 @@ class CanvasRenderer {
         // Snap to other layers - HARD EDGES ONLY
         // Other layers' bounds are compared against the dragged layer's
         // proposed offset (offsetX/Y), which is in the active view's
-        // coords — so use active-view bounds for the comparison.
+        // coords, so use active-view bounds for the comparison.
         if (window.app && window.app.project) {
             window.app.project.layers.forEach(layer => {
                 if (layer.id === currentLayer.id || !layer.visible) return;
@@ -2840,7 +2840,7 @@ class CanvasRenderer {
     // Render capacity error overlay ON TOP of everything (including labels)
     // This renders WITHOUT clipping so it's visible even outside raster bounds.
     // Called from the third render pass (outside the per-layer ctx.translate),
-    // so use show-translated bounds — getLayerBounds returns processor coords
+    // so use show-translated bounds, getLayerBounds returns processor coords
     // which would land the badge at the layer's pixel-map position even when
     // the layer renders at its show position in Data Flow / Power.
     renderCapacityErrorOverlay(layer) {
@@ -3324,7 +3324,7 @@ class CanvasRenderer {
         const err = layer._powerError;
         // Same as renderCapacityErrorOverlay: this is called from the third
         // render pass outside the per-layer translate, so we need the layer's
-        // active-view bounds (show offset already baked in) — using raw
+        // active-view bounds (show offset already baked in), using raw
         // processor bounds parks the badge at the wrong screen position when
         // the layer is moved in Show Look.
         const bounds = this.getLayerBoundsInActiveView(layer);
@@ -4255,7 +4255,7 @@ class CanvasRenderer {
     }
 
     /**
-     * Wiring perspective badge — "BACK VIEW" in screen-space corner when
+     * Wiring perspective badge, "BACK VIEW" in screen-space corner when
      * Data Flow / Power are rendering in back perspective. Shown in both
      * interactive view and export so the printed map is unambiguous.
      * Front view shows nothing (clutter-free default; Front is implied).
@@ -4392,7 +4392,7 @@ class CanvasRenderer {
         this.ctx.fillStyle = committed > 0 ? '#ffffff' : 'rgba(255, 255, 255, 0.7)';
         this.ctx.fillText(committedText, pillX + pillPadX, pillY + pillPadY - 2);
 
-        // Selected pill (yellow) — only when drag-select has picked panels
+        // Selected pill (yellow), only when drag-select has picked panels
         if (showSelected) {
             pillX += committedPillW + pillGap;
             this.ctx.fillStyle = 'rgba(255, 204, 0, 0.85)';

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -412,7 +412,26 @@ class CanvasRenderer {
     // un-mirrored screen space, so we have to flip them back into layer
     // coordinates before any hit-testing / drag math.
     _unmirrorWorldX(worldX) {
-        return this.isMirroredView() ? (this.rasterWidth - worldX) : worldX;
+        if (!this.isMirroredView()) return worldX;
+        // v0.8 Slice 8 fix: mirror axis is the workspace bounds, not the
+        // active canvas's raster — otherwise multi-canvas workspaces flip
+        // off-screen because workspace_x can be far past rasterWidth.
+        const k = this._mirrorAxisX();
+        return k - worldX;
+    }
+
+    /**
+     * The Canvas2D translate-X used as the mirror axis when Back perspective
+     * is active. We mirror around the workspace bounding box so points stay
+     * in the same x-range after the flip — single-canvas projects degrade to
+     * mirroring around rasterWidth (legacy behaviour) automatically because
+     * their bbox.x is 0 and bbox.w == rasterWidth.
+     */
+    _mirrorAxisX() {
+        const bb = this._workspaceBounds();
+        // K such that K - x maps left edge to right edge of bbox:
+        //   K - bbox.x = bbox.x + bbox.w  →  K = 2*bbox.x + bbox.w
+        return 2 * (bb.x || 0) + (bb.width || this.rasterWidth);
     }
 
     /**
@@ -1929,7 +1948,11 @@ class CanvasRenderer {
         // helpers below.
         this._mirror = this.isMirroredView();
         if (this._mirror) {
-            this.ctx.translate(this.rasterWidth, 0);
+            // v0.8 Slice 8: mirror axis is the workspace bounding-box right
+            // edge so multi-canvas workspaces stay on-screen when flipped.
+            // Single-canvas legacy projects naturally land at this.rasterWidth
+            // because their bbox is (0, 0, rasterWidth, rasterHeight).
+            this.ctx.translate(this._mirrorAxisX(), 0);
             this.ctx.scale(-1, 1);
         }
 

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -341,13 +341,59 @@ class CanvasRenderer {
         return this.isMirroredView() ? (this.rasterWidth - worldX) : worldX;
     }
 
+    /**
+     * Slice 4: hit-test a workspace point against the visible canvases.
+     * Returns the first canvas (in array order — earlier wins on overlap)
+     * whose rect contains (worldX, worldY), or null. Uses the same per-mode
+     * raster fields _drawCanvasOutline does, including the workspace_x/y
+     * offset so the rect is in workspace coords (matching worldX/worldY).
+     */
+    _canvasAtPoint(worldX, worldY) {
+        if (!window.app || !window.app.project) return null;
+        const arr = window.app.project.canvases;
+        if (!Array.isArray(arr) || arr.length === 0) return null;
+        const useShow = this.isShowLookView();
+        for (const c of arr) {
+            if (!c || c.visible === false) continue;
+            const w = (useShow && c.show_raster_width) || c.raster_width || 0;
+            const h = (useShow && c.show_raster_height) || c.raster_height || 0;
+            if (w <= 0 || h <= 0) continue;
+            const x = c.workspace_x || 0;
+            const y = c.workspace_y || 0;
+            if (worldX >= x && worldX <= x + w && worldY >= y && worldY <= y + h) {
+                return c;
+            }
+        }
+        return null;
+    }
+
     handleMouseDown(e) {
         const rect = this.canvas.getBoundingClientRect();
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
         const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
-        
+
+        // Slice 4: clicking empty area inside a canvas's rect activates that
+        // canvas. Skipped for: pan (space), shift/alt modifiers (existing
+        // drag behaviors), and clicks that hit a panel (panel-select takes
+        // precedence; layer-click activation is wired separately in app.js
+        // selectLayer/toggleLayerSelection paths). Additive — the rest of
+        // mouse-down still runs, so panning/drag-select/etc. are unchanged.
+        if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
+            const hitPanel = this.getPanelAt(worldX, worldY);
+            if (!hitPanel) {
+                const hitCanvas = this._canvasAtPoint(worldX, worldY);
+                if (hitCanvas && hitCanvas.id
+                    && window.app
+                    && window.app.project
+                    && hitCanvas.id !== window.app.project.active_canvas_id
+                    && typeof window.app.setActiveCanvas === 'function') {
+                    window.app.setActiveCanvas(hitCanvas.id);
+                }
+            }
+        }
+
         if (e.button === 0 && this.spacePressed) {
             this.isDragging = true;
             this.dragStartX = mouseX;

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -374,15 +374,39 @@ class CanvasRenderer {
         const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
 
-        // Slice 4: clicking empty area inside a canvas's rect activates that
-        // canvas. Skipped for: pan (space), shift/alt modifiers (existing
-        // drag behaviors), and clicks that hit a panel (panel-select takes
-        // precedence; layer-click activation is wired separately in app.js
-        // selectLayer/toggleLayerSelection paths). Additive — the rest of
-        // mouse-down still runs, so panning/drag-select/etc. are unchanged.
+        // Slice 4 (+ multi-canvas hit-test fix): every left click in the
+        // workspace either:
+        //   (a) hits a panel in some canvas's layer → activate that canvas
+        //       and make that layer the currentLayer so the existing
+        //       panel-select / layer-action paths can run against it
+        //       without the user having to click the layer in the sidebar
+        //       first;
+        //   (b) hits empty area inside a canvas's rect → activate that
+        //       canvas;
+        //   (c) hits empty area outside any canvas → no canvas change.
+        // Skipped for pan (space) and shift/alt modifiers (existing drag
+        // behaviors). Additive — the rest of mouse-down still runs.
         if (e.button === 0 && !this.spacePressed && !e.shiftKey && !e.altKey) {
             const hitPanel = this.getPanelAt(worldX, worldY);
-            if (!hitPanel) {
+            if (hitPanel) {
+                // Panel hit: switch to its layer's canvas if needed, and
+                // promote its layer to currentLayer if needed. Both gates
+                // are no-ops when already in scope, so single-canvas /
+                // current-layer flows are unchanged.
+                const layer = window.app && window.app.project
+                    && window.app.project.layers.find(l => l.id === hitPanel.layerId);
+                if (layer) {
+                    if (layer.canvas_id
+                        && window.app.project.active_canvas_id !== layer.canvas_id
+                        && typeof window.app.setActiveCanvas === 'function') {
+                        window.app.setActiveCanvas(layer.canvas_id);
+                    }
+                    if ((!window.app.currentLayer || window.app.currentLayer.id !== layer.id)
+                        && typeof window.app.selectLayer === 'function') {
+                        window.app.selectLayer(layer.id);
+                    }
+                }
+            } else {
                 const hitCanvas = this._canvasAtPoint(worldX, worldY);
                 if (hitCanvas && hitCanvas.id
                     && window.app

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1910,7 +1910,12 @@ class CanvasRenderer {
                     if (_canvasesArr.length === 0) return true; // legacy fallback
                     return l.canvas_id === canvas.id;
                 });
-                if (layersInCanvas.length === 0) return;
+                // Empty canvases (no layers) still get drawn — outline +
+                // active tint — so the user can see the canvas exists and can
+                // drag layers into it. Slice 7 cross-canvas drag depends on
+                // this being a valid drop target. Originally Slice 3 skipped
+                // empty canvases entirely, but that hid them from the
+                // workspace which broke the drop-into-empty-canvas flow.
                 const wx = canvas.workspace_x || 0;
                 const wy = canvas.workspace_y || 0;
                 const needsCanvasShift = (wx !== 0 || wy !== 0);

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1580,10 +1580,22 @@ class CanvasRenderer {
             const c = cid ? _canvasById[cid] : null;
             return { wx: (c && c.workspace_x) || 0, wy: (c && c.workspace_y) || 0 };
         };
+        // Helper: returns true if this layer's canvas is hidden (canvas-level
+        // eye toggle off). Used to skip every per-layer post-pass for hidden
+        // canvases — without this, hiding a canvas removed only its outline
+        // while its layers continued to render at the canvas's workspace
+        // offset.
+        const _layerCanvasHidden = (layer) => {
+            const cid = layer && layer.canvas_id;
+            const c = cid ? _canvasById[cid] : null;
+            return c && c.visible === false;
+        };
         // Helper: wraps a per-layer drawing callback with the layer's
-        // canvas-workspace translate. Applies only when wx/wy are non-zero
-        // so single-canvas projects emit no extra ctx ops.
+        // canvas-workspace translate. Skips entirely if the layer's canvas
+        // is hidden. Applies translate only when wx/wy are non-zero so
+        // single-canvas projects emit no extra ctx ops.
         const _withLayerWs = (layer, fn) => {
+            if (_layerCanvasHidden(layer)) return;
             const { wx, wy } = _layerWs(layer);
             if (wx || wy) {
                 this.ctx.save();
@@ -1966,13 +1978,22 @@ class CanvasRenderer {
             const layer = window.app.currentLayer;
             // Zoom-to-layer in the active view, so it matches what's rendered.
             const bounds = this.getLayerBoundsInActiveView(layer);
+            // bounds.x/y are canvas-relative (in the layer's parent canvas's
+            // raster coords). Add the canvas's workspace_x/y so the pan
+            // centers on where the layer is actually drawn in the workspace —
+            // otherwise 1:1 zooms to the wrong canvas's slot.
+            let wx = 0, wy = 0;
+            if (window.app.project && window.app.project.canvases && layer.canvas_id) {
+                const c = window.app.project.canvases.find(c => c.id === layer.canvas_id);
+                if (c) { wx = c.workspace_x || 0; wy = c.workspace_y || 0; }
+            }
             const layerWidth = bounds.width;
             const layerHeight = bounds.height;
             const zoomX = (this.canvas.width * 0.9) / layerWidth;
             const zoomY = (this.canvas.height * 0.9) / layerHeight;
             this.zoom = Math.min(zoomX, zoomY);
-            const layerCenterX = bounds.x + layerWidth / 2;
-            const layerCenterY = bounds.y + layerHeight / 2;
+            const layerCenterX = bounds.x + wx + layerWidth / 2;
+            const layerCenterY = bounds.y + wy + layerHeight / 2;
             this.panX = this.canvas.width / 2 - layerCenterX * this.zoom;
             this.panY = this.canvas.height / 2 - layerCenterY * this.zoom;
         }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -222,10 +222,19 @@ class CanvasRenderer {
         const h = (useShow && canvas.show_raster_height) || canvas.raster_height || 0;
         if (w <= 0 || h <= 0) return;
         const color = canvas.color || '#ff0000';
+        const isCrossDropTarget = !!(this._crossCanvasDropTarget
+            && this._crossCanvasDropTarget.id === canvas.id);
         this.ctx.save();
+        if (isCrossDropTarget) {
+            // Slice 7 hint: brighten outline + faint fill so the user sees
+            // where their shift+drag will land.
+            this.ctx.fillStyle = color + '22';
+            this.ctx.fillRect(0, 0, w, h);
+        }
         this.ctx.strokeStyle = color;
         const baseLW = Math.max(3, 5 / this.zoom);
-        this.ctx.lineWidth = isActive ? baseLW * 1.5 : baseLW;
+        this.ctx.lineWidth = isCrossDropTarget ? baseLW * 2.2
+            : (isActive ? baseLW * 1.5 : baseLW);
         this.ctx.setLineDash([10, 5]);
         this.ctx.strokeRect(0, 0, w, h);
         this.ctx.setLineDash([]);
@@ -903,6 +912,22 @@ class CanvasRenderer {
                     }
                 });
 
+                // Slice 7: track cross-canvas drop target for visual hint.
+                // Use the primary (current) layer's center in workspace coords.
+                const _primary = window.app.currentLayer;
+                const _primaryCanvas = window.app.project && Array.isArray(window.app.project.canvases)
+                    ? window.app.project.canvases.find(c => c && c.id === _primary.canvas_id)
+                    : null;
+                if (_primaryCanvas) {
+                    const _b = this.getLayerBoundsInActiveView(_primary);
+                    const _cx = (_primaryCanvas.workspace_x || 0) + _b.x + _b.width / 2;
+                    const _cy = (_primaryCanvas.workspace_y || 0) + _b.y + _b.height / 2;
+                    const _tgt = this._canvasAtPoint(_cx, _cy);
+                    this._crossCanvasDropTarget = (_tgt && _tgt.id !== _primary.canvas_id) ? _tgt : null;
+                } else {
+                    this._crossCanvasDropTarget = null;
+                }
+
                 this.render();
             }
         } else if (this.isDraggingScreenName) {
@@ -1189,7 +1214,8 @@ class CanvasRenderer {
             this.canvas.style.cursor = this.spacePressed ? 'grab' : 'default';
         } else if (this.isDraggingLayer) {
             this.isDraggingLayer = false;
-            
+            this._crossCanvasDropTarget = null;
+
             if (window.app && window.app.currentLayer) {
                 const dx = Math.round(this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom) - this.dragLayerStartX);
                 const dy = Math.round(((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom - this.dragLayerStartY);
@@ -1244,8 +1270,33 @@ class CanvasRenderer {
                     document.getElementById('offset-y').value = window.app.currentLayer.offset_y;
                 }
 
-                const toUpdate = window.app.getSelectedLayers ? window.app.getSelectedLayers() : [window.app.currentLayer];
-                window.app.updateLayers(toUpdate, false);
+                // Slice 7: cross-canvas drop check. If the primary layer's
+                // post-drag center lands inside a DIFFERENT canvas's rect,
+                // reassign (move) or duplicate it to that canvas instead of
+                // committing the within-canvas offset change.
+                const primary = window.app.currentLayer;
+                const primaryCanvas = window.app.project && Array.isArray(window.app.project.canvases)
+                    ? window.app.project.canvases.find(c => c && c.id === primary.canvas_id)
+                    : null;
+                let crossCanvasHandled = false;
+                if (primaryCanvas) {
+                    const bounds = this.getLayerBoundsInActiveView(primary);
+                    const cx = (primaryCanvas.workspace_x || 0) + bounds.x + bounds.width / 2;
+                    const cy = (primaryCanvas.workspace_y || 0) + bounds.y + bounds.height / 2;
+                    const targetCanvas = this._canvasAtPoint(cx, cy);
+                    if (targetCanvas && targetCanvas.id !== primary.canvas_id) {
+                        const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
+                        if (typeof window.app.moveLayerCrossCanvas === 'function') {
+                            window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode);
+                            crossCanvasHandled = true;
+                        }
+                    }
+                }
+
+                if (!crossCanvasHandled) {
+                    const toUpdate = window.app.getSelectedLayers ? window.app.getSelectedLayers() : [window.app.currentLayer];
+                    window.app.updateLayers(toUpdate, false);
+                }
                 this.dragLayerMode = null;
             }
         } else if (this.isDraggingScreenName) {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -199,6 +199,59 @@ class CanvasRenderer {
      * showOffset - offset_x/y delta so selection rects, hit-tests, and
      * magnetic snap line up with the rendered position.
      */
+    /**
+     * Multi-canvas (v0.8 Slice 3): draw a single canvas's dashed outline at
+     * the origin of the current ctx (caller is expected to have already
+     * translated to canvas.workspace_x/y). The outline color matches
+     * canvas.color; the active canvas gets a 1.5x bolder stroke. Skipped in
+     * exportMode by the caller.
+     *
+     * Uses the canvas's own raster_width/raster_height (not the renderer's
+     * project-level rasterWidth) so each canvas's rect reflects its own
+     * size — even though Slice 3 keeps the source-of-truth at project root
+     * for the active canvas; per-canvas raster sizes are read straight from
+     * the canvas object here.
+     */
+    _drawCanvasOutline(canvas, isActive) {
+        if (!canvas) return;
+        // For Slice 3, pixel-map / cabinet-id views use raster_width/height;
+        // show-look / data-flow / power use show_raster_width/height. Falls
+        // back to raster_width/height if the show-raster fields are missing.
+        const useShow = this.isShowLookView();
+        const w = (useShow && canvas.show_raster_width) || canvas.raster_width || 0;
+        const h = (useShow && canvas.show_raster_height) || canvas.raster_height || 0;
+        if (w <= 0 || h <= 0) return;
+        const color = canvas.color || '#ff0000';
+        this.ctx.save();
+        this.ctx.strokeStyle = color;
+        const baseLW = Math.max(3, 5 / this.zoom);
+        this.ctx.lineWidth = isActive ? baseLW * 1.5 : baseLW;
+        this.ctx.setLineDash([10, 5]);
+        this.ctx.strokeRect(0, 0, w, h);
+        this.ctx.setLineDash([]);
+        this.ctx.restore();
+    }
+
+    /**
+     * Faint background tint for the active canvas. Painted BEFORE layers
+     * (so layers paint over it) so the tint is visible only in empty
+     * regions of the active canvas's raster.
+     */
+    _drawActiveCanvasTint(canvas) {
+        if (!canvas) return;
+        const useShow = this.isShowLookView();
+        const w = (useShow && canvas.show_raster_width) || canvas.raster_width || 0;
+        const h = (useShow && canvas.show_raster_height) || canvas.raster_height || 0;
+        if (w <= 0 || h <= 0) return;
+        const color = canvas.color || '#ff0000';
+        // ~6% alpha (0F in 8-digit hex). Caller already translated to canvas
+        // origin, so fill at (0, 0).
+        this.ctx.save();
+        this.ctx.fillStyle = color + '0F';
+        this.ctx.fillRect(0, 0, w, h);
+        this.ctx.restore();
+    }
+
     getLayerBoundsInActiveView(layer) {
         const b = this.getLayerBounds(layer);
         const { dx, dy } = this.getLayerRenderOffset(layer);
@@ -1508,19 +1561,81 @@ class CanvasRenderer {
         // Disable image smoothing to prevent anti-aliasing artifacts (seams between panels)
         this.ctx.imageSmoothingEnabled = false;
         
-        // Raster boundary - skip in export mode
-        if (!this.exportMode) {
-            this.ctx.strokeStyle = '#ff0000';
-            // Scale inversely with zoom so it's always visible (min 3px on screen)
-            this.ctx.lineWidth = Math.max(3, 5 / this.zoom);
-            this.ctx.setLineDash([10, 5]);
-            this.ctx.strokeRect(0, 0, this.rasterWidth, this.rasterHeight);
-            this.ctx.setLineDash([]);
-        }
-        
+        // Multi-canvas (v0.8 Slice 3): build a lookup so per-layer post-passes
+        // (selection overlays, error badges, pixel grid) can translate to
+        // the layer's own canvas's workspace position. For pre-v0.8 projects
+        // that haven't been migrated yet, fall back to a synthetic canvas at
+        // (0, 0) so single-canvas behaviour is unchanged.
+        const _canvasesArr = (window.app && window.app.project && Array.isArray(window.app.project.canvases))
+            ? window.app.project.canvases
+            : [];
+        const _canvasById = {};
+        _canvasesArr.forEach(c => { if (c && c.id) _canvasById[c.id] = c; });
+        const _activeCanvasId = (window.app && window.app.project)
+            ? window.app.project.active_canvas_id : null;
+        // Helper: returns the workspace translate for a layer (or 0,0 for
+        // legacy / orphan layers). Used by the post-pass wrappers below.
+        const _layerWs = (layer) => {
+            const cid = layer && layer.canvas_id;
+            const c = cid ? _canvasById[cid] : null;
+            return { wx: (c && c.workspace_x) || 0, wy: (c && c.workspace_y) || 0 };
+        };
+        // Helper: wraps a per-layer drawing callback with the layer's
+        // canvas-workspace translate. Applies only when wx/wy are non-zero
+        // so single-canvas projects emit no extra ctx ops.
+        const _withLayerWs = (layer, fn) => {
+            const { wx, wy } = _layerWs(layer);
+            if (wx || wy) {
+                this.ctx.save();
+                this.ctx.translate(wx, wy);
+                fn();
+                this.ctx.restore();
+            } else {
+                fn();
+            }
+        };
+
         if (window.app && window.app.project && window.app.project.layers) {
-            // First pass: render all panels and mode-specific content (except labels)
-            window.app.project.layers.forEach(layer => {
+            // Per-canvas loop (Slice 3): translate to each canvas's
+            // workspace position, render that canvas's layers (existing
+            // per-layer body, unmodified), then draw the canvas's dashed
+            // outline ON TOP. Empty + hidden canvases are skipped.
+            // Pre-Slice-1 projects with no `canvases` array fall back to a
+            // synthetic single canvas using project root raster fields so
+            // legacy single-canvas behaviour is identical to v0.7.7.4.
+            const canvasesToRender = (_canvasesArr.length > 0)
+                ? _canvasesArr
+                : [{
+                    id: null,
+                    workspace_x: 0,
+                    workspace_y: 0,
+                    raster_width: this.rasterWidth,
+                    raster_height: this.rasterHeight,
+                    color: '#ff0000',
+                    visible: true,
+                }];
+            canvasesToRender.forEach(canvas => {
+                if (canvas.visible === false) return;
+                const layersInCanvas = window.app.project.layers.filter(l => {
+                    if (!l.visible) return false;
+                    if (_canvasesArr.length === 0) return true; // legacy fallback
+                    return l.canvas_id === canvas.id;
+                });
+                if (layersInCanvas.length === 0) return;
+                const wx = canvas.workspace_x || 0;
+                const wy = canvas.workspace_y || 0;
+                const needsCanvasShift = (wx !== 0 || wy !== 0);
+                if (needsCanvasShift) {
+                    this.ctx.save();
+                    this.ctx.translate(wx, wy);
+                }
+                // Active-canvas tint (BEFORE layers so layers paint over it
+                // but the tint shows through in empty regions).
+                if (!this.exportMode && canvas.id && canvas.id === _activeCanvasId) {
+                    this._drawActiveCanvasTint(canvas);
+                }
+                // First pass: render all panels and mode-specific content (except labels)
+                layersInCanvas.forEach(layer => {
                 if (layer.visible) {
                     if (this.viewMode === 'power') {
                         this.preparePowerLayerRenderData(layer);
@@ -1594,6 +1709,13 @@ class CanvasRenderer {
                     this.renderLayerLabels(layer);
                     if (needsShift) this.ctx.restore();
                 }
+                });
+                // Canvas outline drawn LAST so it sits on top of any
+                // layer content that bleeds outside the raster bounds.
+                if (!this.exportMode) {
+                    this._drawCanvasOutline(canvas, canvas.id === _activeCanvasId);
+                }
+                if (needsCanvasShift) this.ctx.restore();
             });
             // Per-layer translates have been restored — clear the cached
             // render offset so any later renderers (selection overlays,
@@ -1626,18 +1748,18 @@ class CanvasRenderer {
             if (this.viewMode === 'data-flow') {
                 window.app.project.layers.forEach(layer => {
                     if (layer.visible) {
-                        this.renderCapacityErrorOverlay(layer);
+                        _withLayerWs(layer, () => this.renderCapacityErrorOverlay(layer));
                     }
                 });
             }
             if (this.viewMode === 'power') {
                 window.app.project.layers.forEach(layer => {
                     if (layer.visible) {
-                        this.renderPowerErrorOverlay(layer);
+                        _withLayerWs(layer, () => this.renderPowerErrorOverlay(layer));
                     }
                 });
             }
-            
+
             // Draw bounding boxes around selected layers (skip during export)
             // These render OUTSIDE the per-layer ctx.translate, so use the
             // active-view bounds.
@@ -1646,14 +1768,16 @@ class CanvasRenderer {
                 window.app.project.layers.forEach(layer => {
                     if (!layer.visible) return;
                     if (!selectedIds.has(layer.id)) return;
-                    const bounds = this.getLayerBoundsInActiveView(layer);
-                    const layerWidth = bounds.width;
-                    const layerHeight = bounds.height;
-                    this.ctx.strokeStyle = (window.app.currentLayer && window.app.currentLayer.id === layer.id) ? '#00ccff' : '#4A90E2';
-                    this.ctx.lineWidth = 2 / this.zoom;
-                    this.ctx.setLineDash([8 / this.zoom, 4 / this.zoom]);
-                    this.ctx.strokeRect(bounds.x, bounds.y, layerWidth, layerHeight);
-                    this.ctx.setLineDash([]);
+                    _withLayerWs(layer, () => {
+                        const bounds = this.getLayerBoundsInActiveView(layer);
+                        const layerWidth = bounds.width;
+                        const layerHeight = bounds.height;
+                        this.ctx.strokeStyle = (window.app.currentLayer && window.app.currentLayer.id === layer.id) ? '#00ccff' : '#4A90E2';
+                        this.ctx.lineWidth = 2 / this.zoom;
+                        this.ctx.setLineDash([8 / this.zoom, 4 / this.zoom]);
+                        this.ctx.strokeRect(bounds.x, bounds.y, layerWidth, layerHeight);
+                        this.ctx.setLineDash([]);
+                    });
                 });
             }
 
@@ -1661,20 +1785,22 @@ class CanvasRenderer {
             if (!this.exportMode && this.isDraggingLayer && window.app && window.app.currentLayer) {
                 const selectedLayer = window.app.currentLayer;
                 if (selectedLayer.visible) {
-                    const bounds = this.getLayerBoundsInActiveView(selectedLayer);
-                    const layerWidth = bounds.width;
-                    const layerHeight = bounds.height;
+                    _withLayerWs(selectedLayer, () => {
+                        const bounds = this.getLayerBoundsInActiveView(selectedLayer);
+                        const layerWidth = bounds.width;
+                        const layerHeight = bounds.height;
 
-                    this.ctx.strokeStyle = '#4A90E2';  // Blue highlight color
-                    this.ctx.lineWidth = 3 / this.zoom;  // Scale with zoom
-                    this.ctx.setLineDash([10 / this.zoom, 5 / this.zoom]);
-                    this.ctx.strokeRect(
-                        bounds.x,
-                        bounds.y,
-                        layerWidth,
-                        layerHeight
-                    );
-                    this.ctx.setLineDash([]);
+                        this.ctx.strokeStyle = '#4A90E2';  // Blue highlight color
+                        this.ctx.lineWidth = 3 / this.zoom;  // Scale with zoom
+                        this.ctx.setLineDash([10 / this.zoom, 5 / this.zoom]);
+                        this.ctx.strokeRect(
+                            bounds.x,
+                            bounds.y,
+                            layerWidth,
+                            layerHeight
+                        );
+                        this.ctx.setLineDash([]);
+                    });
                 }
             }
 
@@ -1692,11 +1818,16 @@ class CanvasRenderer {
                         if (!layer.visible) return;
                         // Active-view bounds — selection rect is in world coords
                         // matching the rendered (possibly show-shifted) layout.
+                        // For multi-canvas, shift bounds into workspace coords
+                        // so the intersection test compares apples-to-apples
+                        // with the selection rect (which is in workspace coords
+                        // — captured from world-space mouse events).
+                        const { wx, wy } = _layerWs(layer);
                         const bounds = this.getLayerBoundsInActiveView(layer);
                         const layerWidth = bounds.width;
                         const layerHeight = bounds.height;
-                        const x1 = bounds.x;
-                        const y1 = bounds.y;
+                        const x1 = bounds.x + wx;
+                        const y1 = bounds.y + wy;
                         const x2 = x1 + layerWidth;
                         const y2 = y1 + layerHeight;
                         const intersects = x1 <= maxX && x2 >= minX && y1 <= maxY && y2 >= minY;
@@ -1719,7 +1850,7 @@ class CanvasRenderer {
             if (this.zoom >= 10) {
                 window.app.project.layers.forEach(layer => {
                     if (layer.visible) {
-                        this.renderPixelGrid(layer);
+                        _withLayerWs(layer, () => this.renderPixelGrid(layer));
                     }
                 });
             }
@@ -1783,12 +1914,45 @@ class CanvasRenderer {
         this.render();
     }
     
+    /**
+     * Compute the workspace bounding box of all visible canvases. Returns
+     * {x, y, width, height} of the union. Falls back to a synthetic box at
+     * (0, 0, rasterWidth, rasterHeight) for projects with no canvases array
+     * (pre-Slice-1) or when no canvases are visible.
+     */
+    _workspaceBounds() {
+        const proj = window.app && window.app.project;
+        const canvases = (proj && Array.isArray(proj.canvases)) ? proj.canvases : [];
+        const visible = canvases.filter(c => c && c.visible !== false);
+        if (visible.length === 0) {
+            return { x: 0, y: 0, width: this.rasterWidth, height: this.rasterHeight };
+        }
+        const useShow = this.isShowLookView();
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        visible.forEach(c => {
+            const wx = c.workspace_x || 0;
+            const wy = c.workspace_y || 0;
+            const w = (useShow && c.show_raster_width) || c.raster_width || 0;
+            const h = (useShow && c.show_raster_height) || c.raster_height || 0;
+            if (wx < minX) minX = wx;
+            if (wy < minY) minY = wy;
+            if (wx + w > maxX) maxX = wx + w;
+            if (wy + h > maxY) maxY = wy + h;
+        });
+        return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+    }
+
     fitToView() {
-        const zoomX = (this.canvas.width * 0.9) / this.rasterWidth;
-        const zoomY = (this.canvas.height * 0.9) / this.rasterHeight;
+        // Multi-canvas (v0.8 Slice 3): fit to the union bbox of all visible
+        // canvases instead of just the active canvas's raster.
+        const bb = this._workspaceBounds();
+        const w = bb.width || this.rasterWidth;
+        const h = bb.height || this.rasterHeight;
+        const zoomX = (this.canvas.width * 0.9) / w;
+        const zoomY = (this.canvas.height * 0.9) / h;
         this.zoom = Math.min(zoomX, zoomY);
-        this.panX = (this.canvas.width - this.rasterWidth * this.zoom) / 2;
-        this.panY = (this.canvas.height - this.rasterHeight * this.zoom) / 2;
+        this.panX = (this.canvas.width - w * this.zoom) / 2 - bb.x * this.zoom;
+        this.panY = (this.canvas.height - h * this.zoom) / 2 - bb.y * this.zoom;
         document.getElementById('zoom-level').value = `${Math.round(this.zoom * 100)}%`;
         this.render();
     }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -495,6 +495,13 @@ class CanvasRenderer {
                 this.canvasDragStartY = worldY;
                 this.canvasDragStartWX = edgeCanvas.workspace_x || 0;
                 this.canvasDragStartWY = edgeCanvas.workspace_y || 0;
+                // Snapshot pre-drag state so undo restores the canvas's
+                // original workspace position. mouseUp passes
+                // skipSaveState:true to the updateCanvas commit so we
+                // don't get a duplicate post-drag snapshot.
+                if (window.app && typeof window.app.saveState === 'function') {
+                    window.app.saveState('Move Canvas');
+                }
                 // Activate the dragged canvas so the sidebar reflects it.
                 if (window.app && window.app.project
                     && window.app.project.active_canvas_id !== edgeCanvas.id
@@ -968,17 +975,12 @@ class CanvasRenderer {
                     }
                 });
 
-                // Slice 7: track cross-canvas drop target for visual hint.
-                // Use the primary (current) layer's center in workspace coords.
+                // Track cross-canvas drop target for visual hint. Match the
+                // mouseUp drop logic: hit-test the **mouse cursor**, not the
+                // layer center (so wide layers feel responsive).
                 const _primary = window.app.currentLayer;
-                const _primaryCanvas = window.app.project && Array.isArray(window.app.project.canvases)
-                    ? window.app.project.canvases.find(c => c && c.id === _primary.canvas_id)
-                    : null;
-                if (_primaryCanvas) {
-                    const _b = this.getLayerBoundsInActiveView(_primary);
-                    const _cx = (_primaryCanvas.workspace_x || 0) + _b.x + _b.width / 2;
-                    const _cy = (_primaryCanvas.workspace_y || 0) + _b.y + _b.height / 2;
-                    const _tgt = this._canvasAtPoint(_cx, _cy);
+                if (_primary) {
+                    const _tgt = this._canvasAtPoint(worldX, worldY);
                     this._crossCanvasDropTarget = (_tgt && _tgt.id !== _primary.canvas_id) ? _tgt : null;
                 } else {
                     this._crossCanvasDropTarget = null;
@@ -1076,7 +1078,10 @@ class CanvasRenderer {
                     c.workspace_x = wx;
                     c.workspace_y = wy;
                     if (typeof window.app.updateCanvas === 'function') {
-                        window.app.updateCanvas(id, { workspace_x: wx, workspace_y: wy });
+                        // Skip the helper's own saveState — drag-start already
+                        // captured a 'Move Canvas' snapshot, so adding another
+                        // here would create a no-op duplicate history entry.
+                        window.app.updateCanvas(id, { workspace_x: wx, workspace_y: wy }, { skipSaveState: true });
                     }
                     if (typeof window.app._checkCanvasOverlapAndToast === 'function') {
                         window.app._checkCanvasOverlapAndToast(id);
@@ -1326,24 +1331,52 @@ class CanvasRenderer {
                     document.getElementById('offset-y').value = window.app.currentLayer.offset_y;
                 }
 
-                // Slice 7: cross-canvas drop check. If the primary layer's
-                // post-drag center lands inside a DIFFERENT canvas's rect,
-                // reassign (move) or duplicate it to that canvas instead of
-                // committing the within-canvas offset change.
+                // Slice 7 + multi-select fix: cross-canvas drop check. The
+                // hit-test uses the **mouse cursor position** at drop time,
+                // not the layer's geometric center — for a wide layer
+                // dragged onto a smaller canvas, the cursor lands inside
+                // the target rect long before the layer's center does, and
+                // the user expects "drop where I'm pointing". (Earlier
+                // implementation used layer center and felt unresponsive
+                // on big layers.) Layers in OTHER canvases keep their
+                // normal within-canvas offset change.
                 const primary = window.app.currentLayer;
                 const primaryCanvas = window.app.project && Array.isArray(window.app.project.canvases)
                     ? window.app.project.canvases.find(c => c && c.id === primary.canvas_id)
                     : null;
                 let crossCanvasHandled = false;
                 if (primaryCanvas) {
-                    const bounds = this.getLayerBoundsInActiveView(primary);
-                    const cx = (primaryCanvas.workspace_x || 0) + bounds.x + bounds.width / 2;
-                    const cy = (primaryCanvas.workspace_y || 0) + bounds.y + bounds.height / 2;
-                    const targetCanvas = this._canvasAtPoint(cx, cy);
+                    // Mouse cursor world coords at drop (already computed
+                    // above for the offset delta).
+                    const cursorWX = this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom);
+                    const cursorWY = ((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom;
+                    const targetCanvas = this._canvasAtPoint(cursorWX, cursorWY);
                     if (targetCanvas && targetCanvas.id !== primary.canvas_id) {
                         const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
-                        if (typeof window.app.moveLayerCrossCanvas === 'function') {
-                            window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode);
+                        // Collect all selected layer ids that share the
+                        // primary's canvas (so the whole multi-selection
+                        // travels together). Primary first so it stays the
+                        // currentLayer in the target.
+                        const movedIds = [primary.id];
+                        if (window.app.selectedLayerIds && window.app.selectedLayerIds.size > 1) {
+                            window.app.selectedLayerIds.forEach(id => {
+                                if (id === primary.id) return;
+                                const l = window.app.project.layers.find(x => x.id === id);
+                                if (l && l.canvas_id === primary.canvas_id && !l.locked) {
+                                    movedIds.push(id);
+                                }
+                            });
+                        }
+                        // Pass skipSaveState — the drag-start saveState
+                        // ('Move Layers' at line ~689) is the correct
+                        // pre-drag snapshot. Without skip, the helper
+                        // would push a SECOND mid-drag snapshot and undo
+                        // would restore weird intermediate coords.
+                        if (movedIds.length > 1 && typeof window.app.moveLayersCrossCanvas === 'function') {
+                            window.app.moveLayersCrossCanvas(movedIds, targetCanvas.id, mode, { skipSaveState: true });
+                            crossCanvasHandled = true;
+                        } else if (typeof window.app.moveLayerCrossCanvas === 'function') {
+                            window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode, { skipSaveState: true });
                             crossCanvasHandled = true;
                         }
                     }

--- a/src/static/js/updater.js
+++ b/src/static/js/updater.js
@@ -1,5 +1,5 @@
 /**
- * LED Raster Designer — Update Checker
+ * LED Raster Designer, Update Checker
  *
  * Checks /api/update/check on startup and when the user clicks
  * Help → Check for Updates. Shows a dismissable banner when a

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1647,6 +1647,10 @@
                     <tr><td style="padding: 4px 0;">Pan Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Space + Drag</td></tr>
                     <tr><td style="padding: 4px 0;">Zoom In / Out</td><td style="padding: 4px 0; text-align: right; color: #666;">Scroll Wheel</td></tr>
                     <tr><td style="padding: 4px 0;">Move Layer</td><td style="padding: 4px 0; text-align: right; color: #666;">Shift + Drag</td></tr>
+                    <tr><td style="padding: 4px 0;">Move Layer to Another Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Shift + Drag onto Canvas</td></tr>
+                    <tr><td style="padding: 4px 0;">Duplicate Layer to Another Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Cmd/Alt + Shift + Drag onto Canvas</td></tr>
+                    <tr><td style="padding: 4px 0;">Move a Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Drag the canvas's dashed outline</td></tr>
+                    <tr><td style="padding: 4px 0;">Cross-Canvas Multi-Select</td><td style="padding: 4px 0; text-align: right; color: #666;">Shift + Click layers in different canvases</td></tr>
                     <tr><td style="padding: 4px 0;">Toggle Panel</td><td style="padding: 4px 0; text-align: right; color: #666;">Option/Alt + Click</td></tr>
                     <tr><td style="padding: 4px 0;">Bulk Toggle Panels</td><td style="padding: 4px 0; text-align: right; color: #666;">Option/Alt + Click + Drag</td></tr>
                 </table>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.7.7.4</title>
+    <title>LED Raster Designer v0.8.0-dev</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.7.7.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.0-dev</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1362,7 +1362,15 @@
                 <label style="display: block; margin-bottom: 6px; color: #ccc; font-size: 13px;">Project Name:</label>
                 <input type="text" id="export-name" placeholder="Enter project name" style="width: 100%; padding: 10px; background: #1a1a1a; border: 1px solid #3a3a3a; color: #fff; border-radius: 4px; box-sizing: border-box;">
             </div>
-            
+
+            <!-- v0.8 Slice 11: Canvases to export. Filled dynamically by JS
+                 from project.canvases when the modal opens. Visible canvases
+                 default-checked; hidden default-unchecked but selectable. -->
+            <div id="export-canvases-section" style="margin-bottom: 18px;">
+                <label style="display: block; margin-bottom: 8px; color: #ccc; font-size: 13px;">Canvases to Export:</label>
+                <div id="export-canvases-list" class="export-views"></div>
+            </div>
+
             <!-- Views to Export -->
             <div id="export-views-section" style="margin-bottom: 18px;">
                 <label style="display: block; margin-bottom: 8px; color: #ccc; font-size: 13px;">Views to Export:</label>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1266,6 +1266,8 @@
                     <button id="btn-save-preset" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Save the currently selected layer's settings as a reusable preset">💾 Save as Preset</button>
                     <button id="btn-add-image" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add an image or logo layer">+ Add Image/Logo</button>
                     <button id="btn-add-text" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add a text label layer">+ Add Text Label</button>
+                    <hr style="border:none; border-top:1px solid #2c2c2c; margin:12px 0 8px;">
+                    <button id="btn-add-canvas" class="btn btn-secondary full-width" data-tooltip="Add a new canvas (a separate raster / processor) to this project">+ Add Canvas</button>
                 </div>
             </div>
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.0-dev</title>
+    <title>LED Raster Designer v0.8.0</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.0-dev</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.0</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1258,9 +1258,8 @@
                         <span style="color:#888; font-size:12px;">Lock Selected</span>
                     </div>
                     <div id="layers-list"></div>
-                    <button id="btn-save-preset" class="btn btn-secondary full-width" data-tooltip="Save the currently selected layer's settings as a reusable preset">💾 Save as Preset</button>
-                    <hr style="border:none; border-top:1px solid #2c2c2c; margin:12px 0 8px;">
-                    <button id="btn-add-canvas" class="btn btn-secondary full-width" data-tooltip="Add a new canvas (a separate raster / processor) to this project">+ Add Canvas</button>
+                    <button id="btn-add-canvas" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add a new canvas (a separate raster / processor) to this project">+ Add Canvas</button>
+                    <button id="btn-save-preset" class="btn btn-secondary full-width" style="margin-top: 6px;" data-tooltip="Save the currently selected layer's settings as a reusable preset">💾 Save as Preset</button>
                 </div>
             </div>
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1519,6 +1519,13 @@
                     </div>
                 </div>
                 <div class="prefs-group">
+                    <label>Canvas gap (px)</label>
+                    <div class="prefs-row">
+                        <input type="number" id="pref-canvas-gap" placeholder="50" min="0" step="1">
+                        <span>px between auto-placed canvases</span>
+                    </div>
+                </div>
+                <div class="prefs-group">
                     <label>Default Power (V / A / W)</label>
                     <div class="prefs-row">
                         <select id="pref-power-voltage-select">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -751,7 +751,28 @@
                         </div>
                     </div>
                 </div>
-                
+
+                <!-- v0.8 Slice 10: data totals always visible on the Data Flow
+                     tab, broken out per active canvas + project. Numbers
+                     respect canvas visibility (hidden canvases excluded). -->
+                <div class="panel tab-panel" data-tab="data-flow" style="display: none;">
+                    <div class="panel-header" data-tooltip="Aggregated data port counts. 'This Canvas' shows only the active canvas; 'All Canvases' is the project total. Hidden canvases are excluded from both.">
+                        <h2>Totals</h2>
+                    </div>
+                    <div class="panel-content">
+                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc; margin-bottom: 8px;">
+                            <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">This Canvas <span id="data-totals-canvas-name" style="color: #888; font-weight: 400;"></span></div>
+                            <div>Primary Ports: <span id="data-totals-canvas-primary">0</span></div>
+                            <div>Backup Ports: <span id="data-totals-canvas-backup">0</span></div>
+                        </div>
+                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc;">
+                            <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">All Canvases</div>
+                            <div>Primary Ports: <span id="data-totals-project-primary">0</span></div>
+                            <div>Backup Ports: <span id="data-totals-project-backup">0</span></div>
+                        </div>
+                    </div>
+                </div>
+
                 <style>
                 .flow-pattern-btn {
                     background: #1a1a1a;
@@ -1077,7 +1098,32 @@
                         </div>
                     </div>
                 </div>
-                
+
+                <!-- v0.8 Slice 10: power totals always visible on the Power
+                     tab, broken out per active canvas + project. Numbers
+                     respect canvas visibility (hidden canvases excluded). -->
+                <div class="panel tab-panel" data-tab="power" style="display: none;">
+                    <div class="panel-header" data-tooltip="Aggregated power load. 'This Canvas' shows only the active canvas; 'All Canvases' is the project total. Hidden canvases are excluded from both.">
+                        <h2>Totals</h2>
+                    </div>
+                    <div class="panel-content">
+                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc; margin-bottom: 8px;">
+                            <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">This Canvas <span id="power-totals-canvas-name" style="color: #888; font-weight: 400;"></span></div>
+                            <div>Watts: <span id="power-totals-canvas-watts">0</span></div>
+                            <div>Circuits: <span id="power-totals-canvas-circuits">0</span></div>
+                            <div>Amps (1φ): <span id="power-totals-canvas-1ph">0</span></div>
+                            <div>Amps (3φ): <span id="power-totals-canvas-3ph">0</span></div>
+                        </div>
+                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc;">
+                            <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">All Canvases</div>
+                            <div>Watts: <span id="power-totals-project-watts">0</span></div>
+                            <div>Circuits: <span id="power-totals-project-circuits">0</span></div>
+                            <div>Amps (1φ): <span id="power-totals-project-1ph">0</span></div>
+                            <div>Amps (3φ): <span id="power-totals-project-3ph">0</span></div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Colors panel - only for Pixel Map -->
                 <div class="panel tab-panel screen-only" data-tab="pixel-map">
                     <div class="panel-header" data-tooltip="Colors — Set the two alternating checkerboard colors used to distinguish cabinets in the pixel map view.">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1258,14 +1258,7 @@
                         <span style="color:#888; font-size:12px;">Lock Selected</span>
                     </div>
                     <div id="layers-list"></div>
-                    <div id="layer-order-controls" class="layer-order-controls">
-                        <button id="btn-layer-up" class="btn btn-secondary" data-tooltip="Move selected layer up in draw order">▲ Up</button>
-                        <button id="btn-layer-down" class="btn btn-secondary" data-tooltip="Move selected layer down in draw order">▼ Down</button>
-                    </div>
-                    <button id="btn-add-layer" class="btn btn-primary full-width" data-tooltip="Add a new LED screen layer — pick a saved preset or a panel from the built-in catalog (2,500+ panels)">+ Add Screen</button>
-                    <button id="btn-save-preset" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Save the currently selected layer's settings as a reusable preset">💾 Save as Preset</button>
-                    <button id="btn-add-image" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add an image or logo layer">+ Add Image/Logo</button>
-                    <button id="btn-add-text" class="btn btn-secondary full-width" style="margin-top: 8px;" data-tooltip="Add a text label layer">+ Add Text Label</button>
+                    <button id="btn-save-preset" class="btn btn-secondary full-width" data-tooltip="Save the currently selected layer's settings as a reusable preset">💾 Save as Preset</button>
                     <hr style="border:none; border-top:1px solid #2c2c2c; margin:12px 0 8px;">
                     <button id="btn-add-canvas" class="btn btn-secondary full-width" data-tooltip="Add a new canvas (a separate raster / processor) to this project">+ Add Canvas</button>
                 </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1231,6 +1231,12 @@
                             <label style="display:flex; align-items:center; gap:6px; cursor:pointer; margin-bottom:4px;">
                                 <input type="checkbox" id="text-layer-show-date"> Date
                             </label>
+                            <label style="text-transform:uppercase; font-size:10px; color:#666; margin:8px 0 4px; display:block;">Data &amp; Power Scope</label>
+                            <select id="text-layer-dynamic-info-scope" style="width:100%; padding:4px 6px; background:#1a1a1a; border:1px solid #444; color:#ddd; border-radius:3px; font-size:12px; margin-bottom:6px;" data-tooltip="Choose which totals to inject into the text layer. 'This Canvas' uses the text layer's parent canvas; 'Both' renders both lines (e.g. 'Primary Ports (SR): 4' and 'Primary Ports (Total): 12').">
+                                <option value="canvas">This Canvas Only</option>
+                                <option value="project" selected>All Canvases (Project Total)</option>
+                                <option value="both">Both — This Canvas + Project Total</option>
+                            </select>
                             <label style="text-transform:uppercase; font-size:10px; color:#666; margin:8px 0 4px; display:block;">Data</label>
                             <label style="display:flex; align-items:center; gap:6px; cursor:pointer; margin-bottom:4px;">
                                 <input type="checkbox" id="text-layer-show-primary-ports"> Primary Ports

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -100,11 +100,11 @@
         </div>
 
         <div id="view-tabs">
-            <button class="view-tab active" data-mode="pixel-map" data-tooltip="Pixel map view — layout and positioning (the layout the processor expects)">Pixel Map</button>
-            <button class="view-tab" data-mode="cabinet-id" data-tooltip="Cabinet ID view — label and identify panels (matches Pixel Map layout)">Cabinet ID</button>
-            <button class="view-tab" data-mode="show-look" data-tooltip="Show Look — rearrange screens to the real-world stage layout. Drives the layout shown in Data and Power views.">Show Look</button>
-            <button class="view-tab" data-mode="data-flow" data-tooltip="Data flow view — signal routing and ports (uses Show Look layout)">Data</button>
-            <button class="view-tab" data-mode="power" data-tooltip="Power view — electrical distribution (uses Show Look layout)">Power</button>
+            <button class="view-tab active" data-mode="pixel-map" data-tooltip="Pixel map view, layout and positioning (the layout the processor expects)">Pixel Map</button>
+            <button class="view-tab" data-mode="cabinet-id" data-tooltip="Cabinet ID view, label and identify panels (matches Pixel Map layout)">Cabinet ID</button>
+            <button class="view-tab" data-mode="show-look" data-tooltip="Show Look, rearrange screens to the real-world stage layout. Drives the layout shown in Data and Power views.">Show Look</button>
+            <button class="view-tab" data-mode="data-flow" data-tooltip="Data flow view, signal routing and ports (uses Show Look layout)">Data</button>
+            <button class="view-tab" data-mode="power" data-tooltip="Power view, electrical distribution (uses Show Look layout)">Power</button>
         </div>
 
         <div id="main-container">
@@ -112,32 +112,32 @@
             <div id="left-sidebar">
                 <!-- Pixel Map Controls -->
                 <div class="panel tab-panel" data-tab="pixel-map">
-                    <div class="panel-header" data-tooltip="Screen Info — Set the position, cabinet size, grid layout, physical dimensions, and weight of the selected LED screen layer.">
+                    <div class="panel-header" data-tooltip="Screen Info, Set the position, cabinet size, grid layout, physical dimensions, and weight of the selected LED screen layer.">
                         <h2>Screen Info</h2>
                     </div>
                     <div class="panel-content">
-                        <div class="info-row screen-only" data-tooltip="Offset X — Horizontal position of the layer on the canvas in pixels.">
+                        <div class="info-row screen-only" data-tooltip="Offset X, Horizontal position of the layer on the canvas in pixels.">
                             <label>Offset X</label>
                             <input type="text" id="offset-x" value="0">
                         </div>
-                        <div class="info-row screen-only" data-tooltip="Offset Y — Vertical position of the layer on the canvas in pixels.">
+                        <div class="info-row screen-only" data-tooltip="Offset Y, Vertical position of the layer on the canvas in pixels.">
                             <label>Offset Y</label>
                             <input type="text" id="offset-y" value="0">
                         </div>
                         <div id="screen-grid-settings" class="screen-only">
-                            <div class="info-row" data-tooltip="Cabinet Width — Width of a single LED cabinet/panel in pixels.">
+                            <div class="info-row" data-tooltip="Cabinet Width, Width of a single LED cabinet/panel in pixels.">
                                 <label>Cabinet Width (px)</label>
                                 <input type="text" id="cabinet-width" value="128">
                             </div>
-                            <div class="info-row" data-tooltip="Cabinet Height — Height of a single LED cabinet/panel in pixels.">
+                            <div class="info-row" data-tooltip="Cabinet Height, Height of a single LED cabinet/panel in pixels.">
                                 <label>Cabinet Height (px)</label>
                                 <input type="text" id="cabinet-height" value="128">
                             </div>
-                            <div class="info-row" data-tooltip="Columns — Number of cabinets across the screen horizontally.">
+                            <div class="info-row" data-tooltip="Columns, Number of cabinets across the screen horizontally.">
                                 <label>Columns</label>
                                 <input type="text" id="screen-columns" value="8">
                             </div>
-                            <div class="info-row" data-tooltip="Rows — Number of cabinets down the screen vertically.">
+                            <div class="info-row" data-tooltip="Rows, Number of cabinets down the screen vertically.">
                                 <label>Rows</label>
                                 <input type="text" id="screen-rows" value="5">
                             </div>
@@ -151,25 +151,25 @@
                                     <span style="font-size:11px; color:#fff;"><span id="pixel-map-bulk-count">0</span> <span id="pixel-map-bulk-label">panels</span></span>
                                 </div>
                                 <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px;">
-                                    <button id="bulk-set-blank" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Set Blank — Hide the selected panels (same as Alt+click).">🚫 Set Blank</button>
-                                    <button id="bulk-unset-blank" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Restore — Bring the selected panels back to visible.">↺ Restore</button>
-                                    <button id="bulk-set-half-auto" class="btn btn-secondary" style="font-size:11px; padding:6px 8px; grid-column: 1 / -1;" data-tooltip="Set Half-tile (auto) — Auto-detect width vs height per panel from its wall-edge position.">◐ Set Half-tile (auto)</button>
+                                    <button id="bulk-set-blank" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Set Blank, Hide the selected panels (same as Alt+click).">🚫 Set Blank</button>
+                                    <button id="bulk-unset-blank" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Restore, Bring the selected panels back to visible.">↺ Restore</button>
+                                    <button id="bulk-set-half-auto" class="btn btn-secondary" style="font-size:11px; padding:6px 8px; grid-column: 1 / -1;" data-tooltip="Set Half-tile (auto), Auto-detect width vs height per panel from its wall-edge position.">◐ Set Half-tile (auto)</button>
                                     <button id="bulk-set-half-width" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Force half-width on all selected panels.">◧ Half-Width</button>
                                     <button id="bulk-set-half-height" class="btn btn-secondary" style="font-size:11px; padding:6px 8px;" data-tooltip="Force half-height on all selected panels.">⬓ Half-Height</button>
-                                    <button id="bulk-clear-half" class="btn btn-secondary" style="font-size:11px; padding:6px 8px; grid-column: 1 / -1;" data-tooltip="Clear half-tile — Restore selected panels to full size.">◯ Restore Full</button>
+                                    <button id="bulk-clear-half" class="btn btn-secondary" style="font-size:11px; padding:6px 8px; grid-column: 1 / -1;" data-tooltip="Clear half-tile, Restore selected panels to full size.">◯ Restore Full</button>
                                 </div>
                                 <div style="margin-top:8px; font-size:10px; color:#888; line-height:1.4;">Esc to clear selection. Alt+Shift+click toggles half-tile on a single panel.</div>
                             </div>
 
-                            <div class="info-row" data-tooltip="Panel Width — Physical width of each cabinet in millimeters, used for real-world size labels.">
+                            <div class="info-row" data-tooltip="Panel Width, Physical width of each cabinet in millimeters, used for real-world size labels.">
                                 <label>Panel Width (mm)</label>
                                 <input type="number" id="panel-width-mm" value="500" step="0.1" autocomplete="off" style="width: 70px;">
                             </div>
-                            <div class="info-row" data-tooltip="Panel Height — Physical height of each cabinet in millimeters, used for real-world size labels.">
+                            <div class="info-row" data-tooltip="Panel Height, Physical height of each cabinet in millimeters, used for real-world size labels.">
                                 <label>Panel Height (mm)</label>
                                 <input type="number" id="panel-height-mm" value="500" step="0.1" autocomplete="off" style="width: 70px;">
                             </div>
-                            <div class="info-row" data-tooltip="Weight per Panel — Weight of a single cabinet, used for total weight calculations.">
+                            <div class="info-row" data-tooltip="Weight per Panel, Weight of a single cabinet, used for total weight calculations.">
                                 <label>Weight per Panel</label>
                                 <div style="display: flex; gap: 6px; align-items: center;">
                                     <input type="number" id="panel-weight-kg" value="20" step="0.1" autocomplete="off" style="width: 70px;">
@@ -183,11 +183,11 @@
                         <div id="image-layer-section" style="display: none;">
                             <div class="info-row" style="margin-top: 8px;">
                                 <label>Image/Logo</label>
-                                <button id="btn-replace-image" class="btn btn-secondary" style="width: 100%;" data-tooltip="Replace Image — Choose a new image file to replace the current image layer.">Replace Image</button>
+                                <button id="btn-replace-image" class="btn btn-secondary" style="width: 100%;" data-tooltip="Replace Image, Choose a new image file to replace the current image layer.">Replace Image</button>
                             </div>
                             <div class="info-row">
                                 <label>Image Size</label>
-                                <div id="image-size-display" style="color:#aaa; font-size: 12px;">—</div>
+                                <div id="image-size-display" style="color:#aaa; font-size: 12px;">-</div>
                             </div>
                             <div class="info-row">
                                 <label>Scale (%)</label>
@@ -197,11 +197,11 @@
                                 <input type="range" id="image-scale-range" min="10" max="500" value="100" step="1" style="width: 100%;">
                             </div>
                         </div>
-                        <div class="info-row checkbox-row screen-only" data-tooltip="Border — Show or hide grid lines between individual cabinets on the pixel map view.">
+                        <div class="info-row checkbox-row screen-only" data-tooltip="Border, Show or hide grid lines between individual cabinets on the pixel map view.">
                             <input type="checkbox" id="show-panel-borders">
                             <label for="show-panel-borders">Border</label>
                         </div>
-                        <div class="info-row checkbox-row screen-only" data-tooltip="Circle with X — Draw an X through each cabinet with a circle, useful for marking dead or unused panels.">
+                        <div class="info-row checkbox-row screen-only" data-tooltip="Circle with X, Draw an X through each cabinet with a circle, useful for marking dead or unused panels.">
                             <input type="checkbox" id="show-circle-with-x">
                             <label for="show-circle-with-x">Circle with X</label>
                         </div>
@@ -218,23 +218,23 @@
                 
                 <!-- Labels Section -->
                 <div class="panel tab-panel screen-only" data-tab="pixel-map">
-                    <div class="panel-header" data-tooltip="Labels — Control which information labels are displayed on each screen layer in the pixel map view.">
+                    <div class="panel-header" data-tooltip="Labels, Control which information labels are displayed on each screen layer in the pixel map view.">
                         <h2>Labels</h2>
                     </div>
                     <div class="panel-content">
-                        <div class="info-row checkbox-row" data-tooltip="Screen Name — Display the layer's name on the canvas. Each tab has its own independent toggle.">
+                        <div class="info-row checkbox-row" data-tooltip="Screen Name, Display the layer's name on the canvas. Each tab has its own independent toggle.">
                             <input type="checkbox" id="show-label-name" checked>
                             <label for="show-label-name">Screen Name</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Layer Size (px) — Show the total pixel dimensions of the screen layer.">
+                        <div class="info-row checkbox-row" data-tooltip="Layer Size (px), Show the total pixel dimensions of the screen layer.">
                             <input type="checkbox" id="show-label-size-px">
                             <label for="show-label-size-px">Layer Size (px)</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Layer Size (m) — Show the physical size of the screen in meters, based on panel dimensions.">
+                        <div class="info-row checkbox-row" data-tooltip="Layer Size (m), Show the physical size of the screen in meters, based on panel dimensions.">
                             <input type="checkbox" id="show-label-size-m">
                             <label for="show-label-size-m">Layer Size (m)</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Layer Size (ft) — Show the physical size in feet and inches. Enable Fractions to show fractional inches.">
+                        <div class="info-row checkbox-row" data-tooltip="Layer Size (ft), Show the physical size in feet and inches. Enable Fractions to show fractional inches.">
                             <input type="checkbox" id="show-label-size-ft">
                             <label for="show-label-size-ft">Layer Size (ft)</label>
                             <label style="margin-left: 10px; font-size: 11px; color: #888;">
@@ -242,33 +242,33 @@
                                 Fractions
                             </label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Panel Weight — Show the total weight of all panels in the layer.">
+                        <div class="info-row checkbox-row" data-tooltip="Panel Weight, Show the total weight of all panels in the layer.">
                             <input type="checkbox" id="show-label-weight">
                             <label for="show-label-weight">Panel Weight</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Info — Show a custom info label on each layer. Adjust the font size with the number field.">
+                        <div class="info-row checkbox-row" data-tooltip="Info, Show a custom info label on each layer. Adjust the font size with the number field.">
                             <input type="checkbox" id="show-label-info">
                             <label for="show-label-info">Info</label>
                             <input type="number" id="info-label-size" min="8" max="200" value="14" autocomplete="off" style="margin-left: auto; width: 64px;">
                         </div>
                         <div style="margin-top: 10px; margin-bottom: 6px; color: #666; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;">Offset Labels</div>
-                        <div class="info-row checkbox-row" data-tooltip="Top Left — Show the pixel offset label at the top-left corner of the layer.">
+                        <div class="info-row checkbox-row" data-tooltip="Top Left, Show the pixel offset label at the top-left corner of the layer.">
                             <input type="checkbox" id="show-offset-tl">
                             <label for="show-offset-tl">Top Left</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Top Right — Show the pixel offset label at the top-right corner of the layer.">
+                        <div class="info-row checkbox-row" data-tooltip="Top Right, Show the pixel offset label at the top-right corner of the layer.">
                             <input type="checkbox" id="show-offset-tr">
                             <label for="show-offset-tr">Top Right</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Bottom Left — Show the pixel offset label at the bottom-left corner of the layer.">
+                        <div class="info-row checkbox-row" data-tooltip="Bottom Left, Show the pixel offset label at the bottom-left corner of the layer.">
                             <input type="checkbox" id="show-offset-bl">
                             <label for="show-offset-bl">Bottom Left</label>
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Bottom Right — Show the pixel offset label at the bottom-right corner of the layer.">
+                        <div class="info-row checkbox-row" data-tooltip="Bottom Right, Show the pixel offset label at the bottom-right corner of the layer.">
                             <input type="checkbox" id="show-offset-br">
                             <label for="show-offset-br">Bottom Right</label>
                         </div>
-                        <div class="info-row" data-tooltip="Labels Color — Set the text color for all labels on this layer.">
+                        <div class="info-row" data-tooltip="Labels Color, Set the text color for all labels on this layer.">
                             <label>Labels Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="labels-color" value="#ffffff">
@@ -286,28 +286,28 @@
                 
                 <!-- Cabinet ID Controls -->
                 <div class="panel tab-panel screen-only" data-tab="cabinet-id" style="display: none;">
-                    <div class="panel-header" data-tooltip="Cabinet ID Settings — Configure cabinet identification labels, numbering style, position, and border appearance for the selected screen.">
+                    <div class="panel-header" data-tooltip="Cabinet ID Settings, Configure cabinet identification labels, numbering style, position, and border appearance for the selected screen.">
                         <h2>Cabinet ID Settings</h2>
                     </div>
                     <div class="panel-content">
-                        <div class="info-row checkbox-row" data-tooltip="Screen Name — Show or hide the screen layer name on the canvas in Cabinet ID view.">
+                        <div class="info-row checkbox-row" data-tooltip="Screen Name, Show or hide the screen layer name on the canvas in Cabinet ID view.">
                             <input type="checkbox" id="show-label-name-cabinet" checked>
                             <label for="show-label-name-cabinet">Screen Name</label>
                         </div>
 
-                        <div class="info-row" data-tooltip="Screen Name Size — Font size in pixels for the screen name label in Cabinet ID view.">
+                        <div class="info-row" data-tooltip="Screen Name Size, Font size in pixels for the screen name label in Cabinet ID view.">
                             <label>Screen Name Size</label>
                             <input type="number" id="screen-name-size-cabinet" value="30" min="8" max="200" autocomplete="off" style="width: 60px;">
                         </div>
                         
                         <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Shift+drag screen name to reposition</p>
                         
-                        <div class="info-row checkbox-row" data-tooltip="Show Cabinet ID — Display the column-row identifier label on each cabinet panel.">
+                        <div class="info-row checkbox-row" data-tooltip="Show Cabinet ID, Display the column-row identifier label on each cabinet panel.">
                             <input type="checkbox" id="show-numbers" checked>
                             <label for="show-numbers">Show Cabinet ID</label>
                         </div>
                         
-                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Numbering Style — Choose how cabinets are labeled: column-row (A1, B1), row-column (A1, A2), or numeric row,col format.">
+                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Numbering Style, Choose how cabinets are labeled: column-row (A1, B1), row-column (A1, A2), or numeric row,col format.">
                             <label style="font-weight: 600; margin-bottom: 8px; display: block;">Numbering Style</label>
                             <div style="display: flex; flex-direction: column; gap: 8px;">
                                 <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
@@ -325,7 +325,7 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Label Position — Place the cabinet ID label at the top-left corner or centered within each panel.">
+                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Label Position, Place the cabinet ID label at the top-left corner or centered within each panel.">
                             <label style="font-weight: 600; margin-bottom: 8px; display: block;">Label Position</label>
                             <div style="display: flex; flex-direction: column; gap: 8px;">
                                 <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
@@ -339,12 +339,12 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" data-tooltip="Font Size — Size in pixels for the cabinet ID label text.">
+                        <div class="info-row" data-tooltip="Font Size, Size in pixels for the cabinet ID label text.">
                             <label>Font Size (px)</label>
                             <input type="number" id="number-size" value="30" min="8" max="200" autocomplete="off" style="width: 60px;">
                         </div>
 
-                        <div class="info-row" data-tooltip="Label Color — Color of the cabinet ID text drawn on each panel.">
+                        <div class="info-row" data-tooltip="Label Color, Color of the cabinet ID text drawn on each panel.">
                             <label>Label Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="cabinet-id-color" value="#ffffff">
@@ -355,11 +355,11 @@
                         
                         <hr style="border: none; border-top: 1px solid #3a3a3a; margin: 12px 0;">
                         
-                        <div class="info-row checkbox-row" data-tooltip="Border — Show or hide grid lines between cabinets in Cabinet ID view.">
+                        <div class="info-row checkbox-row" data-tooltip="Border, Show or hide grid lines between cabinets in Cabinet ID view.">
                             <input type="checkbox" id="show-panel-borders-cabinet" checked>
                             <label for="show-panel-borders-cabinet">Border</label>
                         </div>
-                        <div class="info-row" data-tooltip="Border Color — Color of the grid lines drawn between cabinets in Cabinet ID view.">
+                        <div class="info-row" data-tooltip="Border Color, Color of the grid lines drawn between cabinets in Cabinet ID view.">
                             <label>Border Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="border-color-cabinet" value="#ffffff">
@@ -383,18 +383,18 @@
 
                 <!-- Show Look Controls -->
                 <div class="panel tab-panel screen-only" data-tab="show-look" style="display: none;">
-                    <div class="panel-header" data-tooltip="Show Look — Rearrange screens to match the real-world stage layout. Pixel Map and Cabinet ID stay tied to the processor's expected layout; Show Look drives Data and Power.">
+                    <div class="panel-header" data-tooltip="Show Look, Rearrange screens to match the real-world stage layout. Pixel Map and Cabinet ID stay tied to the processor's expected layout; Show Look drives Data and Power.">
                         <h2>Show Look</h2>
                     </div>
                     <div class="panel-content">
                         <div style="color:#aaa; font-size: 11px; margin-bottom: 10px; line-height: 1.4;">
                             Shift-drag a screen on the canvas to position it for the real-world stage layout, or set the offsets here. Data and Power views render at this layout.
                         </div>
-                        <div class="info-row" data-tooltip="Show Offset X — Horizontal position of this screen in the Show Look layout.">
+                        <div class="info-row" data-tooltip="Show Offset X, Horizontal position of this screen in the Show Look layout.">
                             <label>Show Offset X</label>
                             <input type="text" id="show-offset-x" value="0">
                         </div>
-                        <div class="info-row" data-tooltip="Show Offset Y — Vertical position of this screen in the Show Look layout.">
+                        <div class="info-row" data-tooltip="Show Offset Y, Vertical position of this screen in the Show Look layout.">
                             <label>Show Offset Y</label>
                             <input type="text" id="show-offset-y" value="0">
                         </div>
@@ -406,7 +406,7 @@
 
                 <!-- Data Controls -->
                 <div class="panel tab-panel screen-only" data-tab="data-flow" style="display: none;">
-                    <div class="panel-header" data-tooltip="Data Settings — Configure data port mapping, flow patterns, port labels, and visual styling for the data flow overlay.">
+                    <div class="panel-header" data-tooltip="Data Settings, Configure data port mapping, flow patterns, port labels, and visual styling for the data flow overlay.">
                         <h2>Data Settings</h2>
                     </div>
                     <div class="panel-content">
@@ -419,16 +419,16 @@
                             </div>
                         </div>
 
-                        <div class="info-row checkbox-row" data-tooltip="Screen Name — Show or hide the screen layer name on the canvas in Data Flow view.">
+                        <div class="info-row checkbox-row" data-tooltip="Screen Name, Show or hide the screen layer name on the canvas in Data Flow view.">
                             <input type="checkbox" id="show-label-name-data" checked>
                             <label for="show-label-name-data">Screen Name</label>
                         </div>
 
-                        <div class="info-row" data-tooltip="Screen Name Size — Font size in pixels for the screen name label in Data Flow view.">
+                        <div class="info-row" data-tooltip="Screen Name Size, Font size in pixels for the screen name label in Data Flow view.">
                             <label>Screen Name Size</label>
                             <input type="number" id="screen-name-size" value="30" min="8" max="200" autocomplete="off" style="width: 60px;">
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Show Port Info — Display pixel count and port capacity details on each data port region.">
+                        <div class="info-row checkbox-row" data-tooltip="Show Port Info, Display pixel count and port capacity details on each data port region.">
                             <input type="checkbox" id="show-data-flow-port-info">
                             <label for="show-data-flow-port-info">Show Port Info</label>
                         </div>
@@ -439,7 +439,7 @@
                         <div style="margin-top: 15px; padding: 12px; background: #1a1a1a; border-radius: 6px; border: 1px solid #333;">
                             <label style="font-weight: 600; margin-bottom: 10px; display: block; color: #4A90E2;">Port Capacity</label>
                             
-                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Processing — Select the video processor model to calculate port pixel capacity.">
+                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Processing, Select the video processor model to calculate port pixel capacity.">
                                 <label>Processing</label>
                                 <select id="processor-type" class="info-select" style="width: 100%;">
                                     <option value="novastar-armor">NovaStar (Legacy)</option>
@@ -452,7 +452,7 @@
                                 </select>
                             </div>
                             
-                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Bit Depth — Color depth used by the processor; higher values reduce pixels per port.">
+                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Bit Depth, Color depth used by the processor; higher values reduce pixels per port.">
                                 <label>Bit Depth</label>
                                 <select id="bit-depth" class="info-select" style="width: 100%;">
                                     <option value="8">8-bit</option>
@@ -461,7 +461,7 @@
                                 </select>
                             </div>
                             
-                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Frame Rate — Output refresh rate in Hz; higher rates reduce pixels per port.">
+                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Frame Rate, Output refresh rate in Hz; higher rates reduce pixels per port.">
                                 <label>Frame Rate</label>
                                 <select id="frame-rate" class="info-select" style="width: 100%;">
                                     <option value="23.976">23.976 Hz</option>
@@ -486,7 +486,7 @@
                                 </select>
                             </div>
                             
-                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Port Mapping — Organized fills clean rows/columns per port; Max Capacity fills to the pixel limit.">
+                            <div class="info-row" style="margin-bottom: 8px;" data-tooltip="Port Mapping, Organized fills clean rows/columns per port; Max Capacity fills to the pixel limit.">
                                 <label>Port Mapping</label>
                                 <div style="display: flex; gap: 4px; width: 100%;">
                                     <button type="button" id="mapping-organized" class="mapping-mode-btn active" 
@@ -518,7 +518,7 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Flow Pattern — Choose the serpentine direction data cables follow through the cabinets.">
+                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Flow Pattern, Choose the serpentine direction data cables follow through the cabinets.">
                             <label style="font-weight: 600; margin-bottom: 12px; display: block;">Flow Pattern</label>
                             <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px;">
                                 <!-- Row 1: Top start patterns -->
@@ -602,7 +602,7 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Custom Path Mode — Manually assign cabinets to specific data ports by clicking panels on the canvas.">
+                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Custom Path Mode, Manually assign cabinets to specific data ports by clicking panels on the canvas.">
                             <label style="font-weight: 600; margin-bottom: 8px; display: block;">Custom Path Mode</label>
                             <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
                                 <input type="checkbox" id="custom-flow-toggle" style="margin: 0;">
@@ -628,7 +628,7 @@
                             </div>
                         </div>
 
-                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Port Labels — Customize the text labels shown on primary and return data ports using templates with # as the port number.">
+                        <div class="info-row" style="margin-top: 15px;" data-tooltip="Port Labels, Customize the text labels shown on primary and return data ports using templates with # as the port number.">
                             <label style="font-weight: 600; margin-bottom: 8px; display: block;">Port Labels</label>
                             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 8px;">
                                 <div>
@@ -662,7 +662,7 @@
                             <p style="font-size: 11px; color: #888; margin: 6px 0 0;">Use # for port number. Overrides apply per port.</p>
                         </div>
                         
-                        <div class="info-row" data-tooltip="Line Color — Color of the data flow connection lines drawn between cabinets.">
+                        <div class="info-row" data-tooltip="Line Color, Color of the data flow connection lines drawn between cabinets.">
                             <label>Line Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="data-flow-color" value="#FFFFFF">
@@ -671,7 +671,7 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" data-tooltip="Arrow Color — Color of the directional arrows on the data flow lines.">
+                        <div class="info-row" data-tooltip="Arrow Color, Color of the directional arrows on the data flow lines.">
                             <label>Arrow Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="arrow-color" value="#0042AA">
@@ -680,17 +680,17 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" data-tooltip="Line Width — Thickness in pixels of the data flow connection lines.">
+                        <div class="info-row" data-tooltip="Line Width, Thickness in pixels of the data flow connection lines.">
                             <label>Line Width</label>
                             <input type="number" id="arrow-line-width" value="6" min="1" max="10" autocomplete="off" style="width: 60px;">
                         </div>
 
-                        <div class="info-row" data-tooltip="Label Size — Font size in pixels for the data port number labels.">
+                        <div class="info-row" data-tooltip="Label Size, Font size in pixels for the data port number labels.">
                             <label>Label Size</label>
                             <input type="number" id="label-size" value="30" min="6" max="200" autocomplete="off" style="width: 60px;">
                         </div>
                         
-                        <div class="info-row" data-tooltip="Primary — Background color for primary data port regions on the canvas.">
+                        <div class="info-row" data-tooltip="Primary, Background color for primary data port regions on the canvas.">
                             <label>Primary</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="primary-color" value="#00FF00">
@@ -698,7 +698,7 @@
                                 <input type="text" id="primary-color-hex" value="#00FF00" maxlength="7" style="width: 70px; font-family: monospace;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Primary Text — Text color for labels inside primary data port regions.">
+                        <div class="info-row" data-tooltip="Primary Text, Text color for labels inside primary data port regions.">
                             <label>Primary Text</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="primary-text-color" value="#000000">
@@ -707,7 +707,7 @@
                             </div>
                         </div>
                         
-                        <div class="info-row" data-tooltip="Redundancy — Background color for redundancy/return data port regions on the canvas.">
+                        <div class="info-row" data-tooltip="Redundancy, Background color for redundancy/return data port regions on the canvas.">
                             <label>Redundancy</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="backup-color" value="#FF0000">
@@ -715,7 +715,7 @@
                                 <input type="text" id="backup-color-hex" value="#FF0000" maxlength="7" style="width: 70px; font-family: monospace;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Redundancy Text — Text color for labels inside redundancy/return data port regions.">
+                        <div class="info-row" data-tooltip="Redundancy Text, Text color for labels inside redundancy/return data port regions.">
                             <label>Redundancy Text</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="backup-text-color" value="#FFFFFF">
@@ -726,11 +726,11 @@
                         
                         <hr style="border: none; border-top: 1px solid #3a3a3a; margin: 12px 0;">
                         
-                        <div class="info-row checkbox-row" data-tooltip="Border — Show or hide grid lines between cabinets in Data Flow view.">
+                        <div class="info-row checkbox-row" data-tooltip="Border, Show or hide grid lines between cabinets in Data Flow view.">
                             <input type="checkbox" id="show-panel-borders-data" checked>
                             <label for="show-panel-borders-data">Border</label>
                         </div>
-                        <div class="info-row" data-tooltip="Border Color — Color of the grid lines drawn between cabinets in Data Flow view.">
+                        <div class="info-row" data-tooltip="Border Color, Color of the grid lines drawn between cabinets in Data Flow view.">
                             <label>Border Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="border-color-data" value="#ffffff">
@@ -806,7 +806,7 @@
                 
                 <!-- Power Controls -->
                 <div class="panel tab-panel screen-only" data-tab="power" style="display: none;">
-                    <div class="panel-header" data-tooltip="Power Settings — Configure power circuit mapping, voltage, amperage, flow patterns, and visual styling for the power overlay.">
+                    <div class="panel-header" data-tooltip="Power Settings, Configure power circuit mapping, voltage, amperage, flow patterns, and visual styling for the power overlay.">
                         <h2>Power Settings</h2>
                     </div>
                     <div class="panel-content">
@@ -818,23 +818,23 @@
                             </div>
                         </div>
 
-                        <div class="info-row checkbox-row" data-tooltip="Screen Name — Show or hide the screen layer name on the canvas in Power view.">
+                        <div class="info-row checkbox-row" data-tooltip="Screen Name, Show or hide the screen layer name on the canvas in Power view.">
                             <input type="checkbox" id="show-label-name-power" checked>
                             <label for="show-label-name-power">Screen Name</label>
                         </div>
 
-                        <div class="info-row" data-tooltip="Screen Name Size — Font size in pixels for the screen name label in Power view.">
+                        <div class="info-row" data-tooltip="Screen Name Size, Font size in pixels for the screen name label in Power view.">
                             <label>Screen Name Size</label>
                             <input type="number" id="screen-name-size-power" value="30" min="8" max="200" autocomplete="off" style="width: 60px;">
                         </div>
-                        <div class="info-row checkbox-row" data-tooltip="Show Circuit Info — Display wattage and panel count details on each power circuit region.">
+                        <div class="info-row checkbox-row" data-tooltip="Show Circuit Info, Display wattage and panel count details on each power circuit region.">
                             <input type="checkbox" id="show-power-circuit-info">
                             <label for="show-power-circuit-info">Show Circuit Info</label>
                         </div>
                         
                         <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Shift+drag screen name to reposition</p>
 
-                        <div class="info-row" data-tooltip="Voltage — Supply voltage for circuit capacity calculations.">
+                        <div class="info-row" data-tooltip="Voltage, Supply voltage for circuit capacity calculations.">
                             <label>Voltage (V)</label>
                             <div style="display: flex; gap: 6px; align-items: center;">
                                 <select id="power-voltage-select" class="info-select" style="width: auto;">
@@ -848,7 +848,7 @@
                                 <input type="number" id="power-voltage-custom" value="110" min="0" autocomplete="off" style="width: 70px; display: none;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Amperage — Circuit breaker rating used to calculate how many panels fit per circuit.">
+                        <div class="info-row" data-tooltip="Amperage, Circuit breaker rating used to calculate how many panels fit per circuit.">
                             <label>Amperage (A)</label>
                             <div style="display: flex; gap: 6px; align-items: center;">
                                 <select id="power-amperage-select" class="info-select" style="width: auto;">
@@ -859,7 +859,7 @@
                                 <input type="number" id="power-amperage-custom" value="15" min="0" step="0.1" autocomplete="off" style="width: 70px; display: none;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Watts per Panel — Power draw of a single LED cabinet at full white, used to calculate circuits required. Math OK (e.g., 200+50, 500*2, 1000/3).">
+                        <div class="info-row" data-tooltip="Watts per Panel, Power draw of a single LED cabinet at full white, used to calculate circuits required. Math OK (e.g., 200+50, 500*2, 1000/3).">
                             <label>Watts per Panel</label>
                             <input type="text" inputmode="decimal" id="power-panel-watts" value="200" autocomplete="off" style="width: 100px;" placeholder="e.g., 200 or 200+50">
                         </div>
@@ -936,7 +936,7 @@
                                 <input type="checkbox" id="power-random-colors" style="margin: 0;">
                                 <label for="power-random-colors" style="margin: 0; font-size: 12px;">Random Colors</label>
                             </div>
-                            <div class="info-row checkbox-row" style="margin-top: 8px;" data-tooltip="Circuit Color View — Color-code each power circuit with a unique color on the canvas.">
+                            <div class="info-row checkbox-row" style="margin-top: 8px;" data-tooltip="Circuit Color View, Color-code each power circuit with a unique color on the canvas.">
                                 <input type="checkbox" id="power-color-coded-view">
                                 <label for="power-color-coded-view">Circuit Color View</label>
                             </div>
@@ -969,11 +969,11 @@
                                     <input type="text" id="power-circuit-color-custom-hex" value="#BC382F" maxlength="7" style="width: 80px; font-family: monospace;">
                                 </div>
                             </div>
-                            <div class="info-row checkbox-row" style="margin-top: 8px;" data-tooltip="Maximize Power Use — Fill each circuit to its maximum wattage capacity before starting a new circuit.">
+                            <div class="info-row checkbox-row" style="margin-top: 8px;" data-tooltip="Maximize Power Use, Fill each circuit to its maximum wattage capacity before starting a new circuit.">
                                 <input type="checkbox" id="power-maximize">
                                 <label for="power-maximize">Maximize Power Use</label>
                             </div>
-                            <div class="info-row checkbox-row" data-tooltip="Organized — Assign circuits in clean rows or columns instead of splitting mid-row.">
+                            <div class="info-row checkbox-row" data-tooltip="Organized, Assign circuits in clean rows or columns instead of splitting mid-row.">
                                 <input type="checkbox" id="power-organized" checked>
                                 <label for="power-organized">Organized</label>
                             </div>
@@ -1032,11 +1032,11 @@
 
                         <hr style="border: none; border-top: 1px solid #3a3a3a; margin: 12px 0;">
 
-                        <div class="info-row" data-tooltip="Line Width — Thickness in pixels of the power circuit connection lines.">
+                        <div class="info-row" data-tooltip="Line Width, Thickness in pixels of the power circuit connection lines.">
                             <label>Line Width</label>
                             <input type="number" id="power-line-width" value="8" min="1" max="16" autocomplete="off" style="width: 60px;">
                         </div>
-                        <div class="info-row" data-tooltip="Line Color — Color of the power circuit connection lines drawn between cabinets.">
+                        <div class="info-row" data-tooltip="Line Color, Color of the power circuit connection lines drawn between cabinets.">
                             <label>Line Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="power-line-color" value="#FF0000">
@@ -1044,7 +1044,7 @@
                                 <input type="text" id="power-line-color-hex" value="#FF0000" maxlength="7" style="width: 70px; font-family: monospace;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Arrow Color — Color of the directional arrows on the power circuit lines.">
+                        <div class="info-row" data-tooltip="Arrow Color, Color of the directional arrows on the power circuit lines.">
                             <label>Arrow Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="power-arrow-color" value="#0042AA">
@@ -1052,11 +1052,11 @@
                                 <input type="text" id="power-arrow-color-hex" value="#0042AA" maxlength="7" style="width: 70px; font-family: monospace;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Label Size — Font size in pixels for the power circuit number labels.">
+                        <div class="info-row" data-tooltip="Label Size, Font size in pixels for the power circuit number labels.">
                             <label>Label Size</label>
                             <input type="number" id="power-label-size" value="14" min="8" max="200" autocomplete="off" style="width: 60px;">
                         </div>
-                        <div class="info-row" data-tooltip="Label Background — Background color of the power circuit label badges.">
+                        <div class="info-row" data-tooltip="Label Background, Background color of the power circuit label badges.">
                             <label>Label Background</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="power-label-bg-color" value="#D95000">
@@ -1064,7 +1064,7 @@
                                 <input type="text" id="power-label-bg-color-hex" value="#D95000" maxlength="7" style="width: 70px; font-family: monospace;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Label Text — Text color of the power circuit label badges.">
+                        <div class="info-row" data-tooltip="Label Text, Text color of the power circuit label badges.">
                             <label>Label Text</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="power-label-text-color" value="#000000">
@@ -1073,11 +1073,11 @@
                             </div>
                         </div>
                         
-                        <div class="info-row checkbox-row" data-tooltip="Border — Show or hide grid lines between cabinets in Power view.">
+                        <div class="info-row checkbox-row" data-tooltip="Border, Show or hide grid lines between cabinets in Power view.">
                             <input type="checkbox" id="show-panel-borders-power" checked>
                             <label for="show-panel-borders-power">Border</label>
                         </div>
-                        <div class="info-row" data-tooltip="Border Color — Color of the grid lines drawn between cabinets in Power view.">
+                        <div class="info-row" data-tooltip="Border Color, Color of the grid lines drawn between cabinets in Power view.">
                             <label>Border Color</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="border-color-power" value="#ffffff">
@@ -1126,11 +1126,11 @@
 
                 <!-- Colors panel - only for Pixel Map -->
                 <div class="panel tab-panel screen-only" data-tab="pixel-map">
-                    <div class="panel-header" data-tooltip="Colors — Set the two alternating checkerboard colors used to distinguish cabinets in the pixel map view.">
+                    <div class="panel-header" data-tooltip="Colors, Set the two alternating checkerboard colors used to distinguish cabinets in the pixel map view.">
                         <h2>Colors</h2>
                     </div>
                     <div class="panel-content">
-                        <div class="info-row" data-tooltip="Color 1 — First checkerboard color used for alternating cabinet tiles in pixel map view.">
+                        <div class="info-row" data-tooltip="Color 1, First checkerboard color used for alternating cabinet tiles in pixel map view.">
                             <label>Color 1</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="color1-picker" value="#404680">
@@ -1138,7 +1138,7 @@
                                 <input type="text" id="color1-hex" value="#404680" maxlength="7" style="width: 70px; font-family: monospace;">
                             </div>
                         </div>
-                        <div class="info-row" data-tooltip="Color 2 — Second checkerboard color used for alternating cabinet tiles in pixel map view.">
+                        <div class="info-row" data-tooltip="Color 2, Second checkerboard color used for alternating cabinet tiles in pixel map view.">
                             <label>Color 2</label>
                             <div style="display: flex; gap: 5px; align-items: center;">
                                 <input type="color" id="color2-picker" value="#959CB8">
@@ -1151,7 +1151,7 @@
 
                 <!-- Text Layer Settings (shared across all tabs) -->
                 <div id="text-layer-panel" class="panel text-only" style="display: none;">
-                    <div class="panel-header" data-tooltip="Text Label — Configure text content, font, colors, and per-tab visibility for this text label.">
+                    <div class="panel-header" data-tooltip="Text Label, Configure text content, font, colors, and per-tab visibility for this text label.">
                         <h2>Text Label</h2>
                     </div>
                     <div class="panel-content">
@@ -1235,7 +1235,7 @@
                             <select id="text-layer-dynamic-info-scope" style="width:100%; padding:4px 6px; background:#1a1a1a; border:1px solid #444; color:#ddd; border-radius:3px; font-size:12px; margin-bottom:6px;" data-tooltip="Choose which totals to inject into the text layer. 'This Canvas' uses the text layer's parent canvas; 'Both' renders both lines (e.g. 'Primary Ports (SR): 4' and 'Primary Ports (Total): 12').">
                                 <option value="canvas">This Canvas Only</option>
                                 <option value="project" selected>All Canvases (Project Total)</option>
-                                <option value="both">Both — This Canvas + Project Total</option>
+                                <option value="both">Both, This Canvas + Project Total</option>
                             </select>
                             <label style="text-transform:uppercase; font-size:10px; color:#666; margin:8px 0 4px; display:block;">Data</label>
                             <label style="display:flex; align-items:center; gap:6px; cursor:pointer; margin-bottom:4px;">
@@ -1279,14 +1279,14 @@
             <div id="canvas-container">
                 <div id="canvas-controls">
                     <span class="toolbar-label">Raster:</span>
-                    <input type="text" id="toolbar-raster-width" value="1920" class="canvas-raster-input" data-tooltip="Raster Width — Total canvas width in pixels. This is the output resolution width.">
+                    <input type="text" id="toolbar-raster-width" value="1920" class="canvas-raster-input" data-tooltip="Raster Width, Total canvas width in pixels. This is the output resolution width.">
                     <span class="toolbar-label">×</span>
-                    <input type="text" id="toolbar-raster-height" value="1080" class="canvas-raster-input" data-tooltip="Raster Height — Total canvas height in pixels. This is the output resolution height.">
+                    <input type="text" id="toolbar-raster-height" value="1080" class="canvas-raster-input" data-tooltip="Raster Height, Total canvas height in pixels. This is the output resolution height.">
                     <button id="btn-zoom-out" data-tooltip="Zoom out">-</button>
-                    <input type="text" id="zoom-level" value="100%" style="width: 60px; text-align: center; background: #1a1a1a; border: 1px solid #3a3a3a; color: #fff; border-radius: 3px; padding: 2px 4px;" data-tooltip="Zoom Level — Current zoom percentage. Type a value or use +/- buttons. Scroll wheel to zoom on canvas.">
+                    <input type="text" id="zoom-level" value="100%" style="width: 60px; text-align: center; background: #1a1a1a; border: 1px solid #3a3a3a; color: #fff; border-radius: 3px; padding: 2px 4px;" data-tooltip="Zoom Level, Current zoom percentage. Type a value or use +/- buttons. Scroll wheel to zoom on canvas.">
                     <button id="btn-zoom-in" data-tooltip="Zoom in">+</button>
                     <button id="btn-fit" data-tooltip="Fit raster to view (Ctrl/Cmd+Shift+1)">Fit</button>
-                    <button id="btn-zoom-actual" data-tooltip="Zoom to Selection — Zoom to fit the selected screen layer at actual size (Ctrl/Cmd+Shift+2)">1:1</button>
+                    <button id="btn-zoom-actual" data-tooltip="Zoom to Selection, Zoom to fit the selected screen layer at actual size (Ctrl/Cmd+Shift+2)">1:1</button>
                     <label class="magnet-toggle" style="margin-left: 15px;" data-tooltip="Snap layers to grid when dragging (Ctrl/Cmd+Shift+')">
                         <input type="checkbox" id="magnetic-snap" checked>
                         <span>🧲 Snap</span>
@@ -1301,7 +1301,7 @@
         <button id="right-sidebar-toggle" class="sidebar-toggle" data-side="right" title="Collapse right panel" aria-label="Toggle right panel">›</button>
         <div id="right-sidebar">
             <div class="panel">
-                <div class="panel-header" data-tooltip="Screens — Manage screen and image layers: reorder, lock, add, or remove layers in the design.">
+                <div class="panel-header" data-tooltip="Screens, Manage screen and image layers: reorder, lock, add, or remove layers in the design.">
                     <h2>Screens</h2>
                 </div>
                 <div class="panel-content">
@@ -1676,7 +1676,7 @@
                         <span style="display:flex; align-items:center; gap:8px; font-weight:normal; text-transform:none; letter-spacing:0;">
                             <span id="panel-catalog-source-tag" style="color:#777; font-size:10px;" title="Source of the panel catalog currently loaded">Bundled</span>
                             <button type="button" id="panel-catalog-refresh-btn" class="btn" style="background:#2a2a2a; border:1px solid #3a3a3a; color:#ccc; font-size:11px; padding:3px 8px;" title="Pull the latest panel catalog from GitHub">↻ Refresh</button>
-                            <span style="color:#777; font-size:11px;" title="Most panels come from FidoLED's database — accurate but sometimes slightly older than current manufacturer specs. ⭐ marks panels we've cross-checked against the manufacturer's own spec sheet.">⭐ = verified</span>
+                            <span style="color:#777; font-size:11px;" title="Most panels come from FidoLED's database, accurate but sometimes slightly older than current manufacturer specs. ⭐ marks panels we've cross-checked against the manufacturer's own spec sheet.">⭐ = verified</span>
                         </span>
                     </div>
                     <div style="display: flex; gap: 6px; margin-bottom: 6px;">
@@ -1690,12 +1690,12 @@
                     <div style="font-size: 11px; color: #777; margin-top: 6px; text-align: right;">
                         Bad specs or missing panel?
                         <a href="#" id="panel-submit-correction" style="color: #8ab4f8; text-decoration: none;">Submit a correction or add a panel →</a>
-                        <div style="color: #888; font-size: 10px; margin-top: 2px;">Opens GitHub in a new tab — you must be signed in and click <b>“Submit new issue”</b> for it to reach us.</div>
+                        <div style="color: #888; font-size: 10px; margin-top: 2px;">Opens GitHub in a new tab, you must be signed in and click <b>“Submit new issue”</b> for it to reach us.</div>
                     </div>
                 </div>
             </div>
             <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 14px; gap: 12px;">
-                <div id="preset-picker-summary" style="color: #888; font-size: 12px; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Nothing selected — will use Default.</div>
+                <div id="preset-picker-summary" style="color: #888; font-size: 12px; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Nothing selected, will use Default.</div>
                 <div style="display: flex; gap: 8px;">
                     <button id="preset-picker-cancel" class="btn" style="background: #3a3a3a; padding: 8px 16px;">Cancel</button>
                     <button id="preset-picker-add" class="btn btn-primary" style="padding: 8px 16px;">Add Screen</button>
@@ -1757,7 +1757,7 @@
                 </label>
                 <label style="color: #ccc; font-size: 12px;">Until:
                     <input id="logs-until" type="text" placeholder="e.g. 5 min ago (blank = now)"
-                           title="Relative or absolute. Blank means now — all entries after Since are shown."
+                           title="Relative or absolute. Blank means now, all entries after Since are shown."
                            style="background: #1a1a1a; border: 1px solid #333; color: #fff; padding: 4px 6px; border-radius: 4px; margin-left: 4px; width: 200px; font-family: inherit; font-size: 12px;">
                 </label>
                 <button id="logs-filter-clear" class="btn" style="background: #3a3a3a; padding: 4px 10px; font-size: 12px;">Clear filter</button>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1276,9 +1276,10 @@
             </div>
 
             <!-- Help Tooltip Panel (Resolume-style) -->
-            <div id="help-tooltip-panel">
+            <div id="help-tooltip-panel" class="collapsed">
                 <div id="help-tooltip-header">
                     <span>Help</span>
+                    <button id="help-tooltip-toggle" title="Toggle Help" style="background:none; border:none; color:#888; cursor:pointer; font-size:14px; padding:0 4px;">▶</button>
                 </div>
                 <div id="help-tooltip-body">
                     Move your mouse over the interface element that you would like more info about.

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1396,12 +1396,13 @@
             <h2 style="margin-top: 0; color: #fff; margin-bottom: 20px;">Preferences</h2>
             <div class="prefs-grid">
                 <div class="prefs-group">
-                    <label>Default Raster Size</label>
+                    <label>Default Canvas Size</label>
                     <div class="prefs-row">
                         <input type="text" id="pref-raster-width" placeholder="1920">
                         <span>×</span>
                         <input type="text" id="pref-raster-height" placeholder="1080">
                     </div>
+                    <div style="font-size: 11px; color: #888; margin-top: 4px;">Used for new projects and each new canvas added via + Add Canvas.</div>
                 </div>
                 <div class="prefs-group">
                     <label>Default Grid</label>

--- a/src/updater.py
+++ b/src/updater.py
@@ -146,10 +146,10 @@ def check_for_update(force=False):
 
     except HTTPError as e:
         if e.code == 404:
-            # No published releases yet — not an error, just nothing to update to
+            # No published releases yet, not an error, just nothing to update to
             logger.debug("No published releases found (404)")
         elif e.code == 403:
-            result["error"] = "Rate limited — try again later"
+            result["error"] = "Rate limited, try again later"
             logger.warning("Update check HTTP error: %s", e)
         else:
             result["error"] = f"GitHub API error: {e.code}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def pytest_addoption(parser):
     )
 
 import app as app_module
-from app import app, socketio, initialize_default_layer
+from app import app, socketio, initialize_default_layer, _build_initial_project
 
 
 @pytest.fixture()
@@ -27,13 +27,9 @@ def client():
     # Reset project state before each test.
     # Must set on the module directly because some endpoints reassign
     # the global (e.g. new_project, restore_project).
-    app_module.current_project = {
-        'name': 'Untitled Project',
-        'raster_width': 1920,
-        'raster_height': 1080,
-        'layers': [],
-        'is_pristine': True
-    }
+    # _build_initial_project() returns a v0.8-shaped dict (canvases +
+    # format_version) so tests reflect real app state.
+    app_module.current_project = _build_initial_project()
     app_module.next_layer_id = 1
 
     with app.test_client() as client:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -22,7 +22,7 @@ import pytest
 # Add src/ to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-# Try importing playwright — skip all tests if not installed
+# Try importing playwright, skip all tests if not installed
 pw = pytest.importorskip("playwright.sync_api", reason="playwright not installed")
 
 
@@ -186,7 +186,7 @@ def test_arrow_color_hex_input(page):
 
 
 def test_canvas_has_content(page):
-    """Canvas is not blank — at least some pixels are non-white."""
+    """Canvas is not blank, at least some pixels are non-white."""
     canvas = page.locator('canvas#main-canvas')
     if canvas.count() == 0:
         pytest.skip("No canvas found")
@@ -208,7 +208,7 @@ def test_canvas_has_content(page):
     }''')
     assert result is not None, "Could not read canvas pixel"
     # Canvas should have some content (alpha > 0 somewhere)
-    # We just verify we can read pixels — the rendering itself is visual
+    # We just verify we can read pixels, the rendering itself is visual
 
 
 # ── View tab tests ───────────────────────────────────────────────────────

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,7 +1,7 @@
 """Tests for color property persistence across all layer operations.
 
 Verifies that every color property set on a layer is stored and returned
-with the exact value provided — no silent defaults, no color mangling.
+with the exact value provided, no silent defaults, no color mangling.
 """
 
 import json

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -139,7 +139,15 @@ def test_export_resolume_xml(client_with_layer):
 
 
 def test_export_resolume_xml_has_slice(client_with_layer):
-    """Resolume XML contains a Slice for the screen layer."""
+    """Resolume XML contains a Slice for the screen layer.
+
+    v0.8 Slice 11: the wrapping <Screen> element is named after the canvas
+    (default 'Canvas 1' for a fresh project, not the old hard-coded
+    'Screen 1'); the layer's own name lives on the inner Polygon/Slice
+    Common Params block. Verify both: the per-canvas Screen wrapper exists,
+    and the Slice carries the layer's name from the conftest fixture
+    ('TestScreen').
+    """
     resp = client_with_layer.post('/api/export/resolume', json={
         'project_name': 'Test',
         'raster_width': 1920,
@@ -147,7 +155,8 @@ def test_export_resolume_xml_has_slice(client_with_layer):
     })
     xml = resp.data.decode('utf-8')
     assert '<Slice' in xml
-    assert 'value="Screen1"' in xml or 'value="Screen 1"' in xml
+    assert '<Screen name="Canvas 1"' in xml
+    assert 'value="TestScreen"' in xml
 
 
 def test_export_resolume_xml_correct_rect(client_with_layer):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,7 +17,7 @@ def _make_layer(**overrides):
         'cabinet_height': 80,
         'offset_x': 0,
         'offset_y': 0,
-        # Legacy half flags — _build_panels migrates these to per-panel
+        # Legacy half flags, _build_panels migrates these to per-panel
         # halfTile values on first call and clears them. New code should
         # set halfTile per-panel via panel_states.
         'halfFirstColumn': False,
@@ -138,7 +138,7 @@ def test_build_panels_preserves_state():
 def test_build_panels_state_keyed_by_position():
     # Resizing columns shouldn't shuffle hidden/blank/halfTile state.
     # Build a 4-col layer with a hidden panel at (0, 2), then "resize" to
-    # 6 cols by passing the same states dict — the hidden panel should
+    # 6 cols by passing the same states dict, the hidden panel should
     # still be at (0, 2).
     layer = _make_layer(columns=4, rows=2)
     states = {(0, 2): {'hidden': True, 'blank': False, 'halfTile': 'none'}}

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -534,3 +534,129 @@ def test_duplicate_canvas_name_appends_1_when_no_suffix(client_with_layer):
     p = r.get_json()
     names = [c['name'] for c in p['canvases']]
     assert names == ['EDC', 'EDC 1', 'EDC 2']
+
+
+# -----------------------------------------------------------------------------
+# Slice 6 — per-canvas raster (toolbar source-of-truth on active canvas).
+# -----------------------------------------------------------------------------
+
+
+def test_toolbar_raster_change_only_touches_active_canvas(client):
+    """PUT /api/canvas/<id> with raster_* changes ONLY that canvas; siblings
+    keep their own raster sizes (per-canvas raster is now real)."""
+    # Two canvases, each with its own initial raster.
+    client.put('/api/canvas/c1', json={'raster_width': 1920, 'raster_height': 1080})
+    client.post('/api/canvas', json={})  # c2 (auto-cloned from active = c1)
+    client.put('/api/canvas/c2', json={'raster_width': 800, 'raster_height': 600})
+
+    # Activate c1 and "edit the toolbar" via the canvas update endpoint —
+    # mimics the Slice 6 client which routes the toolbar change to the
+    # active canvas, not to project root.
+    client.put('/api/canvas/c1/active')
+    resp = client.put('/api/canvas/c1', json={
+        'raster_width': 11520, 'raster_height': 2272,
+        'show_raster_width': 11520, 'show_raster_height': 2272,
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    by_id = {c['id']: c for c in proj['canvases']}
+
+    # c1 picked up the change.
+    assert by_id['c1']['raster_width'] == 11520
+    assert by_id['c1']['raster_height'] == 2272
+    # c2 is untouched.
+    assert by_id['c2']['raster_width'] == 800
+    assert by_id['c2']['raster_height'] == 600
+
+
+def test_root_raster_mirrors_active_canvas(client):
+    """Backwards-compat shim: project root raster_* mirrors the active
+    canvas's raster on every save/update response."""
+    client.post('/api/canvas', json={})  # c2 (active)
+    client.put('/api/canvas/c2', json={'raster_width': 4096, 'raster_height': 2160})
+
+    proj = client.get('/api/project').get_json()
+    # Active is c2 → root mirrors c2's raster.
+    assert proj['active_canvas_id'] == 'c2'
+    assert proj['raster_width'] == 4096
+    assert proj['raster_height'] == 2160
+
+    # Switch active to c1 → root remirrors to c1's raster.
+    client.put('/api/canvas/c1/active')
+    # Trigger a refresh by hitting the project endpoint.
+    proj = client.get('/api/project').get_json()
+    # GET /api/project does not re-mirror (it just returns current_project),
+    # but set_active_canvas uses socketio_emit; either way we want any state-
+    # changing call to leave root in sync. Prove this by issuing a no-op
+    # canvas update on c1 and inspecting the response.
+    resp = client.put('/api/canvas/c1', json={})
+    proj = resp.get_json()
+    by_id = {c['id']: c for c in proj['canvases']}
+    assert proj['raster_width'] == by_id['c1']['raster_width']
+    assert proj['raster_height'] == by_id['c1']['raster_height']
+
+
+def test_save_project_with_root_raster_propagates_to_active_canvas(client):
+    """Backwards-compat: a POST /api/project that sends only root-level
+    raster_* (no canvases payload) flows through to the active canvas so
+    older clients/tests still drive raster size from the toolbar."""
+    proj_before = client.get('/api/project').get_json()
+    active_id = proj_before['active_canvas_id']
+
+    client.post('/api/project', json={
+        'raster_width': 7680,
+        'raster_height': 4320,
+    })
+
+    proj = client.get('/api/project').get_json()
+    by_id = {c['id']: c for c in proj['canvases']}
+    assert by_id[active_id]['raster_width'] == 7680
+    assert by_id[active_id]['raster_height'] == 4320
+    # Root is mirrored.
+    assert proj['raster_width'] == 7680
+    assert proj['raster_height'] == 4320
+
+
+def test_set_active_canvas_changes_what_toolbar_reads(client):
+    """Switching active canvas updates the project-root raster mirror so the
+    toolbar (which reflects whichever canvas is active) shows the new
+    values. Mirrors a typical setActiveCanvas → syncRasterFromProject flow."""
+    # c1 has 1920x1080 by default. Add c2 with a different raster.
+    client.post('/api/canvas', json={})  # c2 active
+    client.put('/api/canvas/c2', json={'raster_width': 3840, 'raster_height': 2160})
+    proj = client.get('/api/project').get_json()
+    assert proj['active_canvas_id'] == 'c2'
+    assert proj['raster_width'] == 3840
+
+    # Switch active to c1.
+    client.put('/api/canvas/c1/active')
+    # A subsequent canvas update (or any state-changing call) re-mirrors:
+    proj = client.put('/api/canvas/c1', json={}).get_json()
+    by_id = {c['id']: c for c in proj['canvases']}
+    assert proj['raster_width'] == by_id['c1']['raster_width']
+    # And the original c2 raster is untouched.
+    assert by_id['c2']['raster_width'] == 3840
+
+
+def test_per_canvas_raster_round_trips(client):
+    """Save / restore a multi-canvas project; each canvas's per-view raster
+    sizes survive intact (Slice 6 prerequisite for per-view per-canvas)."""
+    proj = client.get('/api/project').get_json()
+    proj['canvases'].append({
+        'id': 'c2', 'name': 'C2', 'color': '#F5A623',
+        'workspace_x': 5000, 'workspace_y': 0,
+        'raster_width': 1280, 'raster_height': 720,
+        'show_raster_width': 2560, 'show_raster_height': 1440,
+        'data_flow_perspective': 'front',
+        'power_perspective': 'front',
+        'visible': True,
+    })
+    proj['active_canvas_id'] = 'c2'
+    restored = client.put('/api/project', json=proj).get_json()
+    by_id = {c['id']: c for c in restored['canvases']}
+    assert by_id['c2']['raster_width'] == 1280
+    assert by_id['c2']['raster_height'] == 720
+    assert by_id['c2']['show_raster_width'] == 2560
+    assert by_id['c2']['show_raster_height'] == 1440
+    # And the c1 default raster is preserved (independent of c2's).
+    assert by_id['c1']['raster_width'] != by_id['c2']['raster_width']

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -65,7 +65,7 @@ def test_migrate_v07_project_creates_default_canvas(client):
 
 
 def test_migrate_preserves_root_fields(client):
-    """Slice 1 is additive — root raster/perspective fields must remain."""
+    """Slice 1 is additive, root raster/perspective fields must remain."""
     project = _v07_project()
     resp = client.put('/api/project', json=project)
     assert resp.status_code == 200
@@ -179,7 +179,7 @@ def test_refuse_newer_format_version(client):
 
 
 # -----------------------------------------------------------------------------
-# Slice 2 — canvas CRUD endpoints.
+# Slice 2, canvas CRUD endpoints.
 # -----------------------------------------------------------------------------
 
 
@@ -226,7 +226,7 @@ def test_delete_canvas_removes_layers(client_with_layer):
     assert proj['layers'][0]['canvas_id'] == 'c1'
     assert proj['active_canvas_id'] == 'c2'  # newly added is active
 
-    # Delete c1 — should remove its layer and reassign active to c2.
+    # Delete c1, should remove its layer and reassign active to c2.
     resp = client_with_layer.delete('/api/canvas/c1')
     assert resp.status_code == 200
     proj = resp.get_json()
@@ -252,7 +252,7 @@ def test_duplicate_canvas_clones_layers(client_with_layer):
     # v0.8: smart name iteration. "Canvas 1" + dup → "Canvas 2".
     assert new_canvas['name'] == 'Canvas 2'
     assert proj['active_canvas_id'] == 'c2'
-    # Should now have two layers — original on c1, clone on c2 with new id.
+    # Should now have two layers, original on c1, clone on c2 with new id.
     assert len(proj['layers']) == 2
     cloned = [l for l in proj['layers'] if l['canvas_id'] == 'c2']
     assert len(cloned) == 1
@@ -390,7 +390,7 @@ def test_update_canvas_persists_workspace_position(client):
 
 
 # -----------------------------------------------------------------------------
-# Slice 3 — auto-place new canvases horizontally with a configurable gap.
+# Slice 3, auto-place new canvases horizontally with a configurable gap.
 # -----------------------------------------------------------------------------
 
 DEFAULT_CANVAS_GAP = 50
@@ -500,7 +500,7 @@ def test_active_canvas_selection_scoping_rule_documented():
         currentLayer.canvas_id === project.active_canvas_id
 
     after every layer selection or canvas activation. This test is a
-    documentation anchor — if you remove the scoping logic, please update
+    documentation anchor, if you remove the scoping logic, please update
     docs/multi-canvas-design.md and delete this assertion deliberately.
     """
     # Marker assertion; the real verification is the manual UX checklist
@@ -537,7 +537,7 @@ def test_duplicate_canvas_name_appends_1_when_no_suffix(client_with_layer):
 
 
 # -----------------------------------------------------------------------------
-# Slice 6 — per-canvas raster (toolbar source-of-truth on active canvas).
+# Slice 6, per-canvas raster (toolbar source-of-truth on active canvas).
 # -----------------------------------------------------------------------------
 
 
@@ -549,7 +549,7 @@ def test_toolbar_raster_change_only_touches_active_canvas(client):
     client.post('/api/canvas', json={})  # c2 (auto-cloned from active = c1)
     client.put('/api/canvas/c2', json={'raster_width': 800, 'raster_height': 600})
 
-    # Activate c1 and "edit the toolbar" via the canvas update endpoint —
+    # Activate c1 and "edit the toolbar" via the canvas update endpoint,
     # mimics the Slice 6 client which routes the toolbar change to the
     # active canvas, not to project root.
     client.put('/api/canvas/c1/active')

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -400,3 +400,25 @@ def test_duplicated_canvas_auto_placed(client_with_layer):
     dup = proj['canvases'][1]
     assert dup['workspace_x'] == expected_x
     assert dup['workspace_y'] == 0
+
+
+def test_active_canvas_id_round_trips_on_save_load(client):
+    """Slice 4: active_canvas_id survives a save/load round-trip so when
+    the user reopens a project the canvas they had selected is still
+    active (toolbar raster + sidebar highlight + workspace tint all
+    follow it). Frontend selection paths set active_canvas_id; this
+    verifies the persistence half of that contract."""
+    # Add a second canvas and make it active.
+    client.post('/api/canvas', json={})  # creates c2, sets it active
+    resp = client.put('/api/canvas/c2/active')
+    assert resp.status_code == 200
+    proj_before = resp.get_json()
+    assert proj_before['active_canvas_id'] == 'c2'
+
+    # Save, then reload.
+    save = client.post('/api/project', json=proj_before)
+    assert save.status_code == 200
+    restored = client.put('/api/project', json=proj_before).get_json()
+
+    assert restored['active_canvas_id'] == 'c2'
+    assert [c['id'] for c in restored['canvases']] == ['c1', 'c2']

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -422,3 +422,47 @@ def test_active_canvas_id_round_trips_on_save_load(client):
 
     assert restored['active_canvas_id'] == 'c2'
     assert [c['id'] for c in restored['canvases']] == ['c1', 'c2']
+
+
+def test_set_active_does_not_drop_layers(client_with_layer):
+    """Slice 5: switching the active canvas must not delete or reassign
+    any layers. The selection-strip behaviour (clearing cross-canvas
+    selected layer ids) lives on the client; the server's job is purely
+    to record the new active_canvas_id and return the project unchanged.
+    Guards against future refactors that might over-eagerly prune layers."""
+    proj = client_with_layer.get('/api/project').get_json()
+    layer_ids_before = sorted(l['id'] for l in proj['layers'])
+    layer_canvases_before = {l['id']: l['canvas_id'] for l in proj['layers']}
+
+    # Add a second canvas (auto-activates) then switch back to c1.
+    client_with_layer.post('/api/canvas', json={})  # c2, now active
+    resp = client_with_layer.put('/api/canvas/c1/active')
+    assert resp.status_code == 200
+    after = resp.get_json()
+
+    assert after['active_canvas_id'] == 'c1'
+    layer_ids_after = sorted(l['id'] for l in after['layers'])
+    layer_canvases_after = {l['id']: l['canvas_id'] for l in after['layers']}
+    assert layer_ids_before == layer_ids_after
+    assert layer_canvases_before == layer_canvases_after
+
+
+def test_active_canvas_selection_scoping_rule_documented():
+    """Slice 5 design rule (frontend-only, documented here for future devs):
+
+    When the active canvas changes, the client clears any selected layer
+    ids that don't belong to the new active canvas, and demotes
+    currentLayer if it's no longer in-scope. This is implemented in
+    ``setActiveCanvas`` in src/static/js/app.js. Together with Slice 4's
+    ``_activateCanvasForLayer`` (called from selectLayer /
+    toggleLayerSelection / selectLayerRange), the invariant is:
+
+        currentLayer.canvas_id === project.active_canvas_id
+
+    after every layer selection or canvas activation. This test is a
+    documentation anchor — if you remove the scoping logic, please update
+    docs/multi-canvas-design.md and delete this assertion deliberately.
+    """
+    # Marker assertion; the real verification is the manual UX checklist
+    # in the slice 5 PR description (no headless browser in CI).
+    assert True

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -350,6 +350,17 @@ def test_update_canvas_partial(client):
     assert proj['canvases'][0]['visible'] is False
 
 
+def test_update_canvas_persists_workspace_position(client):
+    """Slice 5: workspace_x / workspace_y written by canvas-drag drop persist."""
+    resp = client.put('/api/canvas/c1', json={
+        'workspace_x': 1234, 'workspace_y': -56,
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert proj['canvases'][0]['workspace_x'] == 1234
+    assert proj['canvases'][0]['workspace_y'] == -56
+
+
 # -----------------------------------------------------------------------------
 # Slice 3 — auto-place new canvases horizontally with a configurable gap.
 # -----------------------------------------------------------------------------

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -176,3 +176,174 @@ def test_refuse_newer_format_version(client):
     body = resp.get_json()
     assert 'newer' in body['error'].lower()
     assert '0.9' in body['error']
+
+
+# -----------------------------------------------------------------------------
+# Slice 2 — canvas CRUD endpoints.
+# -----------------------------------------------------------------------------
+
+
+def test_create_canvas_appends_and_activates(client):
+    """POST /api/canvas appends a new canvas and makes it active."""
+    resp = client.post('/api/canvas', json={})
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert len(proj['canvases']) == 2
+    new_canvas = proj['canvases'][1]
+    assert new_canvas['id'] == 'c2'
+    assert new_canvas['name'] == 'Canvas 2'
+    assert new_canvas['visible'] is True
+    assert proj['active_canvas_id'] == 'c2'
+    # Color should be different from canvas 1 (auto-cycled).
+    assert new_canvas['color'] != proj['canvases'][0]['color']
+
+
+def test_create_canvas_skips_used_colors(client):
+    """Auto-cycled color skips colors already in use."""
+    # First canvas uses palette[0]. Force it to palette[1] manually so the
+    # next auto-pick should land on palette[0] (the first unused one).
+    from app import DEFAULT_CANVAS_PALETTE
+    client.put('/api/canvas/c1', json={'color': DEFAULT_CANVAS_PALETTE[1]})
+    resp = client.post('/api/canvas', json={})
+    proj = resp.get_json()
+    assert proj['canvases'][1]['color'] == DEFAULT_CANVAS_PALETTE[0]
+
+
+def test_delete_canvas_refuses_last(client):
+    """Cannot delete the final remaining canvas."""
+    resp = client.delete('/api/canvas/c1')
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert 'last' in body['error'].lower()
+
+
+def test_delete_canvas_removes_layers(client_with_layer):
+    """Deleting a canvas removes all of that canvas's layers and reassigns active."""
+    # Add a second canvas, then move/add layers there.
+    client_with_layer.post('/api/canvas', json={})  # c2
+    # The default layer is on c1; verify it.
+    proj = client_with_layer.get('/api/project').get_json()
+    assert proj['layers'][0]['canvas_id'] == 'c1'
+    assert proj['active_canvas_id'] == 'c2'  # newly added is active
+
+    # Delete c1 — should remove its layer and reassign active to c2.
+    resp = client_with_layer.delete('/api/canvas/c1')
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert len(proj['canvases']) == 1
+    assert proj['canvases'][0]['id'] == 'c2'
+    assert proj['active_canvas_id'] == 'c2'
+    assert all(l['canvas_id'] == 'c2' for l in proj['layers'])
+    # The c1 layer is gone.
+    assert len(proj['layers']) == 0
+
+
+def test_duplicate_canvas_clones_layers(client_with_layer):
+    """Duplicating a canvas clones its layers with fresh layer ids."""
+    proj = client_with_layer.get('/api/project').get_json()
+    src_layer_id = proj['layers'][0]['id']
+
+    resp = client_with_layer.post('/api/canvas/c1/duplicate')
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert len(proj['canvases']) == 2
+    new_canvas = proj['canvases'][1]
+    assert new_canvas['id'] == 'c2'
+    assert new_canvas['name'].endswith('Copy')
+    assert proj['active_canvas_id'] == 'c2'
+    # Should now have two layers — original on c1, clone on c2 with new id.
+    assert len(proj['layers']) == 2
+    cloned = [l for l in proj['layers'] if l['canvas_id'] == 'c2']
+    assert len(cloned) == 1
+    assert cloned[0]['id'] != src_layer_id
+
+
+def test_reorder_canvases(client):
+    """POST /api/canvas/reorder reorders the canvases array."""
+    client.post('/api/canvas', json={})  # c2
+    client.post('/api/canvas', json={})  # c3
+    resp = client.post('/api/canvas/reorder', json={
+        'canvas_ids': ['c3', 'c1', 'c2']
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert [c['id'] for c in proj['canvases']] == ['c3', 'c1', 'c2']
+
+
+def test_reorder_rejects_mismatched_ids(client):
+    """Reorder with an unknown id returns 400."""
+    resp = client.post('/api/canvas/reorder', json={'canvas_ids': ['c1', 'cX']})
+    assert resp.status_code == 400
+
+
+def test_set_active_canvas(client):
+    """PUT /api/canvas/<id>/active updates active_canvas_id."""
+    client.post('/api/canvas', json={})  # c2 (now active)
+    resp = client.put('/api/canvas/c1/active')
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert proj['active_canvas_id'] == 'c1'
+
+
+def test_move_layer_to_canvas_resets_offsets(client_with_layer):
+    """Moving a layer to another canvas resets its offsets to 0,0."""
+    proj = client_with_layer.get('/api/project').get_json()
+    layer_id = proj['layers'][0]['id']
+    # Set a non-zero offset so we can verify the reset.
+    client_with_layer.put(f'/api/layer/{layer_id}', json={
+        'offset_x': 500, 'offset_y': 300,
+        'showOffsetX': 500, 'showOffsetY': 300,
+    })
+    client_with_layer.post('/api/canvas', json={})  # c2
+
+    resp = client_with_layer.put(f'/api/layer/{layer_id}/canvas', json={
+        'canvas_id': 'c2', 'mode': 'move',
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    moved = next(l for l in proj['layers'] if l['id'] == layer_id)
+    assert moved['canvas_id'] == 'c2'
+    assert moved['offset_x'] == 0 and moved['offset_y'] == 0
+    assert moved['showOffsetX'] == 0 and moved['showOffsetY'] == 0
+
+
+def test_duplicate_layer_to_canvas(client_with_layer):
+    """Duplicate mode creates a copy with a new id at 0,0 in the target canvas."""
+    proj = client_with_layer.get('/api/project').get_json()
+    src_layer_id = proj['layers'][0]['id']
+    src_name = proj['layers'][0]['name']
+    client_with_layer.post('/api/canvas', json={})  # c2
+
+    resp = client_with_layer.put(f'/api/layer/{src_layer_id}/canvas', json={
+        'canvas_id': 'c2', 'mode': 'duplicate',
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert len(proj['layers']) == 2
+    src_still_there = next(l for l in proj['layers'] if l['id'] == src_layer_id)
+    assert src_still_there['canvas_id'] == 'c1'
+    clone = next(l for l in proj['layers'] if l['id'] != src_layer_id)
+    assert clone['canvas_id'] == 'c2'
+    assert clone['name'] == src_name
+    assert clone['offset_x'] == 0 and clone['offset_y'] == 0
+
+
+def test_move_layer_to_unknown_canvas_404(client_with_layer):
+    """Moving to a non-existent canvas returns 404."""
+    proj = client_with_layer.get('/api/project').get_json()
+    layer_id = proj['layers'][0]['id']
+    resp = client_with_layer.put(f'/api/layer/{layer_id}/canvas', json={
+        'canvas_id': 'cX', 'mode': 'move',
+    })
+    assert resp.status_code == 404
+
+
+def test_update_canvas_partial(client):
+    """PUT /api/canvas/<id> applies a partial update."""
+    resp = client.put('/api/canvas/c1', json={
+        'name': 'Main Stage', 'visible': False,
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    assert proj['canvases'][0]['name'] == 'Main Stage'
+    assert proj['canvases'][0]['visible'] is False

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -1,0 +1,178 @@
+"""Tests for v0.8 multi-canvas data model + migrator (Slice 1).
+
+Slice 1 is *additive backend only*: the project file format gains a
+``canvases`` array, ``format_version``, ``active_canvas_id``; layers gain
+``canvas_id``; v0.7 projects auto-migrate on load. The client is unchanged
+in this slice, so root-level raster fields must still be preserved.
+"""
+
+
+def _v07_project():
+    """Build a representative v0.7-format project (no canvases / format_version)."""
+    return {
+        'name': 'Legacy Show',
+        'raster_width': 11520,
+        'raster_height': 2272,
+        'show_raster_width': 11520,
+        'show_raster_height': 2272,
+        'data_flow_perspective': 'front',
+        'power_perspective': 'back',
+        'layers': [
+            {
+                'id': 1, 'type': 'screen', 'name': 'SR',
+                'offset_x': 0, 'offset_y': 0,
+                'showOffsetX': 0, 'showOffsetY': 0,
+                'columns': 4, 'rows': 3,
+                'cabinet_width': 128, 'cabinet_height': 128,
+                'panels': [],
+            },
+            {
+                'id': 2, 'type': 'screen', 'name': 'SL',
+                'offset_x': 1024, 'offset_y': 0,
+                'showOffsetX': 1024, 'showOffsetY': 0,
+                'columns': 4, 'rows': 3,
+                'cabinet_width': 128, 'cabinet_height': 128,
+                'panels': [],
+            },
+        ],
+    }
+
+
+def test_migrate_v07_project_creates_default_canvas(client):
+    """A v0.7 project loaded via PUT gains canvases + canvas_id on every layer."""
+    project = _v07_project()
+    resp = client.put('/api/project', json=project)
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data['format_version'] == '0.8'
+    assert isinstance(data['canvases'], list) and len(data['canvases']) == 1
+    canvas = data['canvases'][0]
+    assert canvas['id'] == 'c1'
+    assert canvas['name'] == 'Canvas 1'
+    assert canvas['raster_width'] == 11520
+    assert canvas['raster_height'] == 2272
+    assert canvas['show_raster_width'] == 11520
+    assert canvas['show_raster_height'] == 2272
+    assert canvas['data_flow_perspective'] == 'front'
+    assert canvas['power_perspective'] == 'back'
+    assert canvas['workspace_x'] == 0 and canvas['workspace_y'] == 0
+    assert canvas['visible'] is True
+    assert canvas['color']  # palette colour present
+
+    assert data['active_canvas_id'] == 'c1'
+    assert all(layer['canvas_id'] == 'c1' for layer in data['layers'])
+
+
+def test_migrate_preserves_root_fields(client):
+    """Slice 1 is additive — root raster/perspective fields must remain."""
+    project = _v07_project()
+    resp = client.put('/api/project', json=project)
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    # Root-level fields the existing single-canvas client still reads.
+    assert data['raster_width'] == 11520
+    assert data['raster_height'] == 2272
+    assert data['show_raster_width'] == 11520
+    assert data['show_raster_height'] == 2272
+    assert data['data_flow_perspective'] == 'front'
+    assert data['power_perspective'] == 'back'
+
+
+def test_migrate_idempotent(client):
+    """Loading an already-v0.8 project must not duplicate canvases."""
+    project = _v07_project()
+    # First load: migrates.
+    first = client.put('/api/project', json=project).get_json()
+    assert first['format_version'] == '0.8'
+    assert len(first['canvases']) == 1
+    canvases_after_first = first['canvases']
+
+    # Second load of the (now-v0.8) project: no-op.
+    second = client.put('/api/project', json=first).get_json()
+    assert second['format_version'] == '0.8'
+    assert len(second['canvases']) == 1
+    assert second['canvases'] == canvases_after_first
+    assert second['active_canvas_id'] == 'c1'
+
+
+def test_new_project_has_one_canvas(client_with_layer):
+    """POST /api/project/new returns a v0.8 project with one canvas + default layer."""
+    resp = client_with_layer.post('/api/project/new')
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data['format_version'] == '0.8'
+    assert len(data['canvases']) == 1
+    canvas = data['canvases'][0]
+    assert canvas['id'] == 'c1'
+    assert data['active_canvas_id'] == 'c1'
+
+    # Default layer assigned to the canvas.
+    assert len(data['layers']) == 1
+    assert data['layers'][0]['canvas_id'] == 'c1'
+
+
+def test_add_layer_assigns_canvas_id(client):
+    """POST /api/layer/add stamps the new layer with the active canvas id."""
+    project_resp = client.get('/api/project').get_json()
+    expected_canvas_id = project_resp['active_canvas_id']
+    assert expected_canvas_id  # sanity
+
+    resp = client.post('/api/layer/add', json={
+        'name': 'NewScreen',
+        'columns': 2, 'rows': 2,
+        'cabinet_width': 128, 'cabinet_height': 128,
+    })
+    assert resp.status_code == 200
+    layer = resp.get_json()
+    assert layer['canvas_id'] == expected_canvas_id
+
+
+def test_round_trip_preserves_canvases(client):
+    """Save then restore a multi-canvas project; canvases array survives intact."""
+    project = _v07_project()
+    # Migrate first.
+    migrated = client.put('/api/project', json=project).get_json()
+
+    # Hand-craft a second canvas to verify multi-canvas round-trips work.
+    migrated['canvases'].append({
+        'id': 'c2',
+        'name': 'Canvas 2',
+        'color': '#F5A623',
+        'workspace_x': 5000,
+        'workspace_y': 0,
+        'raster_width': 1920,
+        'raster_height': 1080,
+        'show_raster_width': 1920,
+        'show_raster_height': 1080,
+        'data_flow_perspective': 'front',
+        'power_perspective': 'front',
+        'visible': True,
+    })
+    migrated['active_canvas_id'] = 'c2'
+
+    # Round-trip via save then restore.
+    save_resp = client.post('/api/project', json=migrated)
+    assert save_resp.status_code == 200
+    restored = client.put('/api/project', json=migrated).get_json()
+
+    assert len(restored['canvases']) == 2
+    assert restored['canvases'][1]['id'] == 'c2'
+    assert restored['canvases'][1]['workspace_x'] == 5000
+    assert restored['active_canvas_id'] == 'c2'
+    assert restored['format_version'] == '0.8'
+    # Layers unchanged.
+    assert all(l['canvas_id'] == 'c1' for l in restored['layers'])
+
+
+def test_refuse_newer_format_version(client):
+    """Loading a project authored by a newer app version returns 400."""
+    project = _v07_project()
+    project['format_version'] = '0.9'
+    resp = client.put('/api/project', json=project)
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert 'newer' in body['error'].lower()
+    assert '0.9' in body['error']

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -329,6 +329,34 @@ def test_duplicate_layer_to_canvas(client_with_layer):
     assert clone['offset_x'] == 0 and clone['offset_y'] == 0
 
 
+def test_duplicate_layer_to_canvas_resets_clone_offsets(client_with_layer):
+    """Slice 7: duplicate-to-canvas drops the clone at 0,0 even when the
+    source has non-zero offsets. The cross-canvas drag relies on this
+    server-side guarantee so the clone always lands at the new canvas's
+    top-left, regardless of where the user dropped it.
+    """
+    proj = client_with_layer.get('/api/project').get_json()
+    src_id = proj['layers'][0]['id']
+    client_with_layer.put(f'/api/layer/{src_id}', json={
+        'offset_x': 777, 'offset_y': 555,
+        'showOffsetX': 999, 'showOffsetY': 111,
+    })
+    client_with_layer.post('/api/canvas', json={})  # c2
+
+    resp = client_with_layer.put(f'/api/layer/{src_id}/canvas', json={
+        'canvas_id': 'c2', 'mode': 'duplicate',
+    })
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    clone = next(l for l in proj['layers'] if l['id'] != src_id)
+    assert clone['canvas_id'] == 'c2'
+    assert clone['offset_x'] == 0 and clone['offset_y'] == 0
+    assert clone['showOffsetX'] == 0 and clone['showOffsetY'] == 0
+    # Source untouched
+    src = next(l for l in proj['layers'] if l['id'] == src_id)
+    assert src['offset_x'] == 777 and src['offset_y'] == 555
+
+
 def test_move_layer_to_unknown_canvas_404(client_with_layer):
     """Moving to a non-existent canvas returns 404."""
     proj = client_with_layer.get('/api/project').get_json()

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -249,7 +249,8 @@ def test_duplicate_canvas_clones_layers(client_with_layer):
     assert len(proj['canvases']) == 2
     new_canvas = proj['canvases'][1]
     assert new_canvas['id'] == 'c2'
-    assert new_canvas['name'].endswith('Copy')
+    # v0.8: smart name iteration. "Canvas 1" + dup → "Canvas 2".
+    assert new_canvas['name'] == 'Canvas 2'
     assert proj['active_canvas_id'] == 'c2'
     # Should now have two layers — original on c1, clone on c2 with new id.
     assert len(proj['layers']) == 2
@@ -466,3 +467,31 @@ def test_active_canvas_selection_scoping_rule_documented():
     # Marker assertion; the real verification is the manual UX checklist
     # in the slice 5 PR description (no headless browser in CI).
     assert True
+
+
+def test_duplicate_canvas_name_iterates_trailing_number(client_with_layer):
+    """Duplicating "Canvas 1" yields "Canvas 2" (next free trailing number)."""
+    r = client_with_layer.post('/api/canvas/c1/duplicate')
+    assert r.status_code == 200
+    p = r.get_json()
+    names = [c['name'] for c in p['canvases']]
+    assert names == ['Canvas 1', 'Canvas 2']
+    # Duplicating again → "Canvas 3"
+    r = client_with_layer.post('/api/canvas/c2/duplicate')
+    p = r.get_json()
+    names = [c['name'] for c in p['canvases']]
+    assert names == ['Canvas 1', 'Canvas 2', 'Canvas 3']
+
+
+def test_duplicate_canvas_name_appends_1_when_no_suffix(client_with_layer):
+    """Duplicating a custom-named canvas like "EDC" yields "EDC 1"."""
+    client_with_layer.put('/api/canvas/c1', json={'name': 'EDC'})
+    r = client_with_layer.post('/api/canvas/c1/duplicate')
+    p = r.get_json()
+    names = [c['name'] for c in p['canvases']]
+    assert names == ['EDC', 'EDC 1']
+    # And again → "EDC 2"
+    r = client_with_layer.post('/api/canvas/c2/duplicate')
+    p = r.get_json()
+    names = [c['name'] for c in p['canvases']]
+    assert names == ['EDC', 'EDC 1', 'EDC 2']

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -347,3 +347,56 @@ def test_update_canvas_partial(client):
     proj = resp.get_json()
     assert proj['canvases'][0]['name'] == 'Main Stage'
     assert proj['canvases'][0]['visible'] is False
+
+
+# -----------------------------------------------------------------------------
+# Slice 3 — auto-place new canvases horizontally with a configurable gap.
+# -----------------------------------------------------------------------------
+
+DEFAULT_CANVAS_GAP = 50
+
+
+def test_new_canvas_auto_placed_to_right(client):
+    """A second canvas is placed at workspace_x = first_canvas.raster_width + gap."""
+    import app as app_module
+    app_module.server_preferences = {}
+    proj = client.get('/api/project').get_json()
+    first = proj['canvases'][0]
+    expected_x = (first['workspace_x'] or 0) + first['raster_width'] + DEFAULT_CANVAS_GAP
+
+    resp = client.post('/api/canvas', json={})
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    new_canvas = proj['canvases'][1]
+    assert new_canvas['workspace_x'] == expected_x
+    assert new_canvas['workspace_y'] == 0
+
+
+def test_canvas_gap_preference(client):
+    """Setting canvasGap via /api/preferences changes the auto-placement gap."""
+    import app as app_module
+    app_module.server_preferences = {}
+    client.put('/api/preferences', json={'canvasGap': 200})
+    proj = client.get('/api/project').get_json()
+    first = proj['canvases'][0]
+    expected_x = (first['workspace_x'] or 0) + first['raster_width'] + 200
+
+    resp = client.post('/api/canvas', json={})
+    proj = resp.get_json()
+    assert proj['canvases'][1]['workspace_x'] == expected_x
+
+
+def test_duplicated_canvas_auto_placed(client_with_layer):
+    """Duplicating a canvas places the duplicate to the right with the gap."""
+    import app as app_module
+    app_module.server_preferences = {}
+    proj = client_with_layer.get('/api/project').get_json()
+    first = proj['canvases'][0]
+    expected_x = (first['workspace_x'] or 0) + first['raster_width'] + DEFAULT_CANVAS_GAP
+
+    resp = client_with_layer.post('/api/canvas/c1/duplicate')
+    assert resp.status_code == 200
+    proj = resp.get_json()
+    dup = proj['canvases'][1]
+    assert dup['workspace_x'] == expected_x
+    assert dup['workspace_y'] == 0

--- a/tests/test_multi_canvas.py
+++ b/tests/test_multi_canvas.py
@@ -393,7 +393,10 @@ def test_update_canvas_persists_workspace_position(client):
 # Slice 3, auto-place new canvases horizontally with a configurable gap.
 # -----------------------------------------------------------------------------
 
-DEFAULT_CANVAS_GAP = 50
+# v0.8 Slice 9: default canvas gap dropped 50 -> 0. Most LED installs are
+# abutting walls, not floating screens. The canvasGap preference still
+# overrides this when set (test_canvas_gap_preference covers that path).
+DEFAULT_CANVAS_GAP = 0
 
 
 def test_new_canvas_auto_placed_to_right(client):

--- a/tests/test_pristine_flag.py
+++ b/tests/test_pristine_flag.py
@@ -214,7 +214,7 @@ def test_socket_reconnect_after_file_load_not_pristine():
                         'offset_x': 0, 'offset_y': 0, 'panels': []}]
         })
 
-    # Simulate reconnect — new socket connection
+    # Simulate reconnect, new socket connection
     ws = socketio.test_client(app)
     received = ws.get_received()
     project_events = [r for r in received if r['name'] == 'project_data']

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,4 +1,4 @@
-"""Tests for WebSocket events — connect, disconnect, and broadcasts."""
+"""Tests for WebSocket events, connect, disconnect, and broadcasts."""
 
 import sys
 import os

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,4 +1,4 @@
-"""Tests for complete user workflows — multi-step sequences that simulate
+"""Tests for complete user workflows, multi-step sequences that simulate
 real usage patterns like creating a project, configuring layers, and exporting."""
 
 import io
@@ -88,7 +88,7 @@ def test_full_project_lifecycle(client):
     assert project['name'] == 'Concert Stage'
     assert len(project['layers']) == 3
 
-    # 9. Start a new project — everything resets
+    # 9. Start a new project, everything resets
     resp = client.post('/api/project/new')
     project = resp.get_json()
     assert project['name'] == 'Untitled Project'
@@ -543,7 +543,7 @@ def test_hidden_layer_excluded_from_export(client):
     # Hide the second layer
     client.put(f'/api/layer/{hidden_id}', json={'visible': False})
 
-    # Export ZIP — manifest should only include visible layer
+    # Export ZIP, manifest should only include visible layer
     resp = client.post('/api/export/zip', json={'include_borders': False})
     assert resp.status_code == 200
     zf = zipfile.ZipFile(io.BytesIO(resp.data))

--- a/tools/panel_extractor/README.md
+++ b/tools/panel_extractor/README.md
@@ -9,7 +9,7 @@ weight, max power) from FidoLED and merge it into
 FidoLED exposes a "Copy to Clipboard" button on its Calculate results window
 that outputs clean plain text. We drive the app via AppleScript: select a
 (manufacturer, panel) pair, click Calculate, click Copy to Clipboard, read
-`pbpaste`, parse, merge. Works against the stock `/Applications/FidoLED.app` —
+`pbpaste`, parse, merge. Works against the stock `/Applications/FidoLED.app`,
 no re-signing needed.
 
 An earlier memory-dump approach (lldb `process save-core` + SQLite page
@@ -38,19 +38,19 @@ a JSON batch, and merges into the main catalog.
 
 ## Files
 
-- `clipboard_extract.sh` — drives FidoLED for one batch, parses clipboard
+- `clipboard_extract.sh`, drives FidoLED for one batch, parses clipboard
   output, emits JSON.
-- `clipboard_loop.sh` — runs `clipboard_extract.sh` in a loop until no
+- `clipboard_loop.sh`, runs `clipboard_extract.sh` in a loop until no
   panels remain.
-- `next_batch.py` — picks the next N missing (manufacturer, panel) pairs
+- `next_batch.py`, picks the next N missing (manufacturer, panel) pairs
   into `/tmp/panel_batch.txt`, excluding anything in `skip_list.txt`.
-- `merge_web.py` — merges an extraction batch (or manually curated JSON)
+- `merge_web.py`, merges an extraction batch (or manually curated JSON)
   into the catalog, grouped by manufacturer.
-- `skip_list.txt` — panels known to fail extraction; excluded from batches.
+- `skip_list.txt`, panels known to fail extraction; excluded from batches.
 
 ## Catalog file
 
-`src/static/data/panel_catalog.json` — grouped by manufacturer:
+`src/static/data/panel_catalog.json`, grouped by manufacturer:
 
 ```json
 {
@@ -71,6 +71,6 @@ a JSON batch, and merges into the main catalog.
 }
 ```
 
-`src/static/data/panel_catalog_full_list.txt` — tab-separated
+`src/static/data/panel_catalog_full_list.txt`, tab-separated
 (manufacturer, panel_name) for every panel in FidoLED's dropdown. Used as
 the source-of-truth of what's missing.


### PR DESCRIPTION
## ⚠️ MAJOR RELEASE — Multi-Canvas

This is the largest change since the app shipped. Projects now contain **multiple independent canvases**, each with its own raster, perspective, position, and layers. The save format is bumped to `format_version: "0.8"`.

**Backwards compatibility:**
- v0.7 projects auto-migrate on load (one canvas containing all original layers). A one-time toast prompts the user to save in the new format.
- v0.7 builds opening a v0.8 file get a clean "format newer than supported" error and refuse to load. **Tell users to upgrade before opening v0.8 projects.**

## Summary

Multi-canvas project model. Each canvas is independently sized, positioned, exported, and bulk-edited. Targets multi-processor / multi-stage / touring workflows where one project file needs to describe multiple physical wall systems.

- Canvas list in the right sidebar with per-canvas + Add, color swatch, rename, delete, duplicate, drag-reorder, visibility toggle
- Per-canvas raster (Pixel Map + Show Look), per-canvas perspective (Front/Back), per-canvas presets
- Drag layers between canvases (Shift+Drag, Cmd/Alt+Shift+Drag to duplicate)
- Drag canvases by their dashed outline, magnetic snap to neighbor edges
- Cross-canvas multi-select for bulk edits (Shift+click layers across canvases)
- Hidden canvases excluded from totals + exports
- Per-canvas + project Totals panels in Data/Power tabs
- Text-layer dynamic info gains a Scope dropdown (This Canvas / All / Both)
- Multi-canvas export: per-canvas PNG, per-canvas PSD, multi-page PDF, multi-Screen Resolume XML
- Migration toast on first v0.7 → v0.8 load

## Bug fixes uncovered along the way

- Undo now reverts exactly one action (Slice 5/7 had off-by-one saveState)
- 0-byte JSON saves on cloud-synced folders fixed (skip Chrome's picker on localhost)
- 100% zoom now means 1 raster pixel = 1 device pixel (Retina was 2x)
- Settings sidebar refreshes after cross-canvas snap (no more deselect/reselect needed)
- Custom port / circuit assignment rejects already-mapped panels with a toast
- Text layer text now clips to its own box
- Click-on-overlay (text/image floating on screen) selects the overlay, not the screen beneath
- Em dash characters removed everywhere (UI text, comments, docs)