### PR TITLE
v0.8.1 hotfix: duplicate layer preserves half-tile state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.0
+# LED Raster Designer v0.8.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,15 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.1 - May 4, 2026
+----------------------------
+- FIX: Duplicating a screen layer that contained half-tile panels
+  stripped the half-tile state from the new layer, the duplicate came
+  back with all panels at full size. Client now sends a full per-panel
+  state list (halfTile + hidden + blank) and the server rebuilds the
+  duplicate's panel geometry from those states so column widths and
+  row heights match the source.
+
 v0.8.0 - May 4, 2026
 ----------------------------
 MULTI-CANVAS RELEASE. Projects can now contain multiple independent

--- a/src/app.py
+++ b/src/app.py
@@ -1300,7 +1300,32 @@ def add_layer():
         for panel in layer['panels']:
             if (panel['row'], panel['col']) in hidden_positions:
                 panel['hidden'] = True
-    
+
+    # Apply per-panel state (halfTile + hidden + blank) for duplicate. This
+    # is the path that preserves half-tile geometry: half-tile width/height
+    # change column/row sizing inside _build_panels, so we rebuild the
+    # geometry from these states rather than just stamping flags onto
+    # already-built panels.
+    if 'panelStates' in data and data['panelStates']:
+        ps_dict = {}
+        for ps in data['panelStates']:
+            r = ps.get('row')
+            c = ps.get('col')
+            if r is None or c is None:
+                continue
+            entry = {}
+            ht = ps.get('halfTile')
+            if ht in ('width', 'height'):
+                entry['halfTile'] = ht
+            if ps.get('hidden'):
+                entry['hidden'] = True
+            if ps.get('blank'):
+                entry['blank'] = True
+            if entry:
+                ps_dict[(r, c)] = entry
+        if ps_dict:
+            layer['panels'] = _build_panels(layer, ps_dict)
+
     current_project['layers'].append(layer)
     current_project['is_pristine'] = False
     socketio.emit('layer_added', layer)

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.0',
-            'CFBundleVersion': '0.8.0',
+            'CFBundleShortVersionString': '0.8.1',
+            'CFBundleVersion': '0.8.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -12103,10 +12103,23 @@ class LEDRasterApp {
             return;
         }
 
-        // Collect hidden panel positions (row, col) to apply to new layer
+        // Collect hidden panel positions (row, col) to apply to new layer.
+        // Backwards-compat: older server builds only knew about hiddenPanels.
         const hiddenPanels = layer.panels
             .filter(p => p.hidden)
             .map(p => ({ row: p.row, col: p.col }));
+        // v0.8.0 fix: half-tile state was being lost on duplicate. Build a
+        // full per-panel state list (halfTile + hidden + blank) so the
+        // server can rebuild the duplicate's geometry to match the source.
+        const panelStates = layer.panels
+            .filter(p => p.hidden || p.blank || (p.halfTile && p.halfTile !== 'none'))
+            .map(p => ({
+                row: p.row,
+                col: p.col,
+                halfTile: p.halfTile || 'none',
+                hidden: !!p.hidden,
+                blank: !!p.blank,
+            }));
         
         const duplicateData = {
             name: getNextName(layer.name),
@@ -12174,7 +12187,8 @@ class LEDRasterApp {
             powerLabelOverrides: JSON.parse(JSON.stringify(layer.powerLabelOverrides || {})),
             powerCustomPaths: JSON.parse(JSON.stringify(layer.powerCustomPaths || {})),
             powerCustomIndex: layer.powerCustomIndex,
-            hiddenPanels: hiddenPanels  // Pass hidden panel info
+            hiddenPanels: hiddenPanels,  // Pass hidden panel info (legacy)
+            panelStates: panelStates,    // Half-tile + hidden + blank (v0.8.0)
         };
         
         // Store client-side properties to copy after layer is created

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.0</title>
+    <title>LED Raster Designer v0.8.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.0</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary

One-fix hotfix for v0.8.0.

**Bug:** Duplicating a screen layer that contained half-tile panels stripped the half-tile metadata from the new layer. Source's half-tile cabinets came back as full-size in the duplicate.

**Cause:** Client only forwarded \`hiddenPanels=[{row,col}]\` on duplicate. Server stamped \`panel.hidden=True\` after \`_build_panels\` had already laid out the geometry. Half-tile state never made the round-trip.

**Fix:** Client now also collects a \`panelStates\` list (halfTile + hidden + blank for every non-default panel) and the server rebuilds the duplicate's geometry via \`_build_panels(layer, panel_states)\` so column widths and row heights match the source. \`hiddenPanels\` is left in for backwards-compat with older client builds.

## Files
- \`src/static/js/app.js\` - duplicateLayer collects + sends panelStates
- \`src/app.py\` - POST /api/layer/add accepts panelStates and rebuilds panel geometry
- README.md, src/VERSION.txt, src/templates/index.html, src/led_raster_designer.spec - bump 0.8.0 → 0.8.1