### PR TITLE
v0.8.2 hotfix: Custom Flow/Power state desync + toggle double-fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.1
+# LED Raster Designer v0.8.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,23 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.2 - May 4, 2026
+----------------------------
+- FIX: Custom Data Flow + Custom Power buttons (Next/Prev circuit, Clear
+  Circuit, Clear All, jump-to-circuit, panel click, Pattern Apply,
+  keyboard shortcut step) only mutated client-side state and never PUT
+  to the server. The next time something else triggered a real PUT (Mode
+  Toggle, layer reselect, etc.), the server's stale view would either
+  overwrite the client or the client would push a collapsed snapshot of
+  the current circuit/port back, wiping all the other circuits/ports
+  the user had just configured. Every Custom mutation now PUTs after
+  the local change so the server stays authoritative.
+- FIX: Custom mode toggle (Data Flow + Power) was firing twice per
+  click on some platforms (observed: macOS WKWebView, two change events
+  ~370ms apart). Single click ended up flipping state back to where it
+  started. Added a 600ms re-entrancy guard on each toggle so the second
+  spurious change event is dropped.
+
 v0.8.1 - May 4, 2026
 ----------------------------
 - FIX: Duplicating a screen layer that contained half-tile panels

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.1',
-            'CFBundleVersion': '0.8.1',
+            'CFBundleShortVersionString': '0.8.2',
+            'CFBundleVersion': '0.8.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2911,7 +2911,19 @@ class LEDRasterApp {
         if (customModeToggle) {
             customModeToggle.addEventListener('change', () => {
                 if (!this.currentLayer) return;
-                this.toggleCustomFlowMode(customModeToggle.checked);
+                // v0.8.2 Re-entrancy guard: when the change event re-fires
+                // mid-flight (browser quirk on some platforms — observed on
+                // mac WKWebView clicking the toggle once produced two change
+                // events 367ms apart), the second invocation immediately
+                // flips the state back so the user's single click ended up
+                // disabling Custom mode. Drop the second event entirely.
+                if (this._customFlowToggleInFlight) return;
+                this._customFlowToggleInFlight = true;
+                try {
+                    this.toggleCustomFlowMode(customModeToggle.checked);
+                } finally {
+                    setTimeout(() => { this._customFlowToggleInFlight = false; }, 600);
+                }
             });
         }
         if (customPrevPortBtn) {
@@ -2921,6 +2933,12 @@ class LEDRasterApp {
                 this.currentLayer.customPortIndex = Math.max(1, (this.currentLayer.customPortIndex || 1) - 1);
                 this.saveState('Custom Port Change');
                 this.saveClientSideProperties();
+                // v0.8.2: PUT to the server. Without this, all the local
+                // mutations (Next/Prev/Clear/Apply) accumulate only on the
+                // client; the next time something else triggers a real PUT
+                // (Mode Toggle, tab switch with stale state, etc.) the
+                // client's view collapses or contradicts the server's.
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomFlowUI();
                 this.updatePortLabelEditor();
                 window.canvasRenderer.render();
@@ -2933,6 +2951,7 @@ class LEDRasterApp {
                 this.currentLayer.customPortIndex = (this.currentLayer.customPortIndex || 1) + 1;
                 this.saveState('Custom Port Change');
                 this.saveClientSideProperties();
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomFlowUI();
                 this.updatePortLabelEditor();
                 window.canvasRenderer.render();
@@ -2946,6 +2965,7 @@ class LEDRasterApp {
                 this.currentLayer.customPortPaths[portNum] = [];
                 this.saveState('Custom Clear Port');
                 this.saveClientSideProperties();
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomFlowUI();
                 this.updatePortLabelEditor();
                 window.canvasRenderer.render();
@@ -2960,6 +2980,7 @@ class LEDRasterApp {
                 this.customSelection.clear();
                 this.saveState('Custom Clear All');
                 this.saveClientSideProperties();
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomFlowUI();
                 this.updatePortLabelEditor();
                 window.canvasRenderer.render();
@@ -2981,6 +3002,7 @@ class LEDRasterApp {
                     this.currentLayer.customPortIndex = nextVal;
                     this.saveState('Custom Port Change');
                     this.saveClientSideProperties();
+                    this.updateLayers(this.getSelectedLayers());
                     this.updateCustomFlowUI();
                     this.updatePortLabelEditor();
                     window.canvasRenderer.render();
@@ -3420,7 +3442,17 @@ class LEDRasterApp {
         if (powerCustomToggle) {
             powerCustomToggle.addEventListener('change', () => {
                 if (!this.currentLayer) return;
-                this.toggleCustomPowerMode(powerCustomToggle.checked);
+                // v0.8.2: re-entrancy guard — single click was producing two
+                // change events 367ms apart, with the second flipping the
+                // state back to the opposite of what the user wanted. See
+                // matching guard in customModeToggle handler above.
+                if (this._customPowerToggleInFlight) return;
+                this._customPowerToggleInFlight = true;
+                try {
+                    this.toggleCustomPowerMode(powerCustomToggle.checked);
+                } finally {
+                    setTimeout(() => { this._customPowerToggleInFlight = false; }, 600);
+                }
             });
         }
         if (powerCustomPrev) {
@@ -3430,6 +3462,12 @@ class LEDRasterApp {
                 this.currentLayer.powerCustomIndex = Math.max(1, (this.currentLayer.powerCustomIndex || 1) - 1);
                 this.saveState('Power Custom Circuit Change');
                 this.saveClientSideProperties();
+                // v0.8.2: PUT to the server. See matching comment on the data-
+                // flow Custom handlers above. Without this, every Next/Prev/
+                // Clear Circuit/Clear All/Pattern Apply mutated only the
+                // client; the next Mode Toggle would then PUT a single-circuit
+                // collapsed view of layer.powerCustomPaths.
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomPowerUI();
                 window.canvasRenderer.render();
             });
@@ -3441,6 +3479,7 @@ class LEDRasterApp {
                 this.currentLayer.powerCustomIndex = (this.currentLayer.powerCustomIndex || 1) + 1;
                 this.saveState('Power Custom Circuit Change');
                 this.saveClientSideProperties();
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomPowerUI();
                 window.canvasRenderer.render();
             });
@@ -3453,6 +3492,7 @@ class LEDRasterApp {
                 this.currentLayer.powerCustomPaths[circuitNum] = [];
                 this.saveState('Power Custom Clear Circuit');
                 this.saveClientSideProperties();
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomPowerUI();
                 window.canvasRenderer.render();
             });
@@ -3466,6 +3506,7 @@ class LEDRasterApp {
                 this.powerCustomSelection.clear();
                 this.saveState('Power Custom Clear All');
                 this.saveClientSideProperties();
+                this.updateLayers(this.getSelectedLayers());
                 this.updateCustomPowerUI();
                 window.canvasRenderer.render();
             });
@@ -3486,6 +3527,7 @@ class LEDRasterApp {
                     this.currentLayer.powerCustomIndex = nextVal;
                     this.saveState('Power Custom Circuit Change');
                     this.saveClientSideProperties();
+                    this.updateLayers(this.getSelectedLayers());
                     this.updateCustomPowerUI();
                     window.canvasRenderer.render();
                 }
@@ -9162,6 +9204,9 @@ class LEDRasterApp {
             this.currentLayer.customPortIndex = Math.max(1, (this.currentLayer.customPortIndex || 1) + delta);
             this.saveState('Custom Port Change');
             this.saveClientSideProperties();
+            // v0.8.2: PUT to server (keyboard shortcut path needs the same
+            // server sync as the on-screen Next/Prev buttons).
+            this.updateLayers(this.getSelectedLayers());
             this.updateCustomFlowUI();
             this.updatePortLabelEditor();
             window.canvasRenderer.render();
@@ -9170,6 +9215,7 @@ class LEDRasterApp {
             this.currentLayer.powerCustomIndex = Math.max(1, (this.currentLayer.powerCustomIndex || 1) + delta);
             this.saveState('Power Custom Circuit Change');
             this.saveClientSideProperties();
+            this.updateLayers(this.getSelectedLayers());
             this.updateCustomPowerUI();
             window.canvasRenderer.render();
         }
@@ -10153,6 +10199,8 @@ class LEDRasterApp {
         this.currentLayer.customPortPaths[portNum].push({ row: panel.row, col: panel.col });
         this.saveState('Custom Path Edit');
         this.saveClientSideProperties();
+        // v0.8.2: PUT to server so per-panel port assignments persist.
+        this.updateLayers(this.getSelectedLayers());
         if (this.customDebug) {
             console.log('[CustomFlow] Add panel', { portNum, row: panel.row, col: panel.col });
         }
@@ -10180,6 +10228,8 @@ class LEDRasterApp {
         this.currentLayer.powerCustomPaths[circuitNum].push({ row: panel.row, col: panel.col });
         this.saveState('Power Custom Path Edit');
         this.saveClientSideProperties();
+        // v0.8.2: PUT to server so per-panel circuit assignments persist.
+        this.updateLayers(this.getSelectedLayers());
         if (this.powerCustomDebug) {
             console.log('[CustomPower] Add panel', { circuitNum, row: panel.row, col: panel.col });
         }
@@ -10272,6 +10322,8 @@ class LEDRasterApp {
         this.currentLayer.customPortPaths[portNum] = ordered.map(p => ({ row: p.row, col: p.col }));
         this.saveState('Custom Pattern Apply');
         this.saveClientSideProperties();
+        // v0.8.2: PUT to server so the bulk pattern assignment persists.
+        this.updateLayers(this.getSelectedLayers());
         if (this.customDebug) {
             const first = ordered[0];
             const last = ordered[ordered.length - 1];
@@ -10334,6 +10386,8 @@ class LEDRasterApp {
         this.currentLayer.powerCustomPaths[circuitNum] = ordered.map(p => ({ row: p.row, col: p.col }));
         this.saveState('Power Custom Pattern Apply');
         this.saveClientSideProperties();
+        // v0.8.2: PUT to server so the bulk pattern assignment persists.
+        this.updateLayers(this.getSelectedLayers());
         if (this.powerCustomDebug) {
             const first = ordered[0];
             const last = ordered[ordered.length - 1];

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1836,13 +1836,28 @@ class CanvasRenderer {
             this.ctx.strokeRect(x, y, w, h);
         }
 
-        // Per-tab text content
-        let text = '';
-        if (viewMode === 'pixel-map') text = layer.textContentPixelMap || layer.textContent || '';
-        else if (viewMode === 'cabinet-id') text = layer.textContentCabinetId || layer.textContent || '';
-        else if (viewMode === 'data-flow') text = layer.textContentDataFlow || layer.textContent || '';
-        else if (viewMode === 'power') text = layer.textContentPower || layer.textContent || '';
-        else text = layer.textContent || '';
+        // Per-tab text content. Fallback chain:
+        //   1. This tab's own textContent<Tab> (explicit per-tab override)
+        //   2. The global textContent (legacy default)
+        //   3. ANY other per-tab field that's non-empty (so typing into one
+        //      tab carries over to the others until the user explicitly
+        //      sets a different value per tab). Without this third step,
+        //      typing only in Pixel Map left Cabinet ID / Data Flow / Power
+        //      / Show Look rendering blank.
+        const tabKey = (viewMode === 'pixel-map')  ? 'textContentPixelMap'
+                     : (viewMode === 'cabinet-id') ? 'textContentCabinetId'
+                     : (viewMode === 'data-flow')  ? 'textContentDataFlow'
+                     : (viewMode === 'power')      ? 'textContentPower'
+                     : null;
+        let text = (tabKey ? layer[tabKey] : '') || layer.textContent || '';
+        if (!text) {
+            const fallbackKeys = ['textContentPixelMap', 'textContentCabinetId',
+                                  'textContentDataFlow', 'textContentPower'];
+            for (const k of fallbackKeys) {
+                if (k === tabKey) continue;
+                if (layer[k]) { text = layer[k]; break; }
+            }
+        }
 
         // Append dynamic info lines
         const dynamicLines = [];

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.1</title>
+    <title>LED Raster Designer v0.8.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary

Two related bugs in the Custom Data Flow and Custom Power circuit editors:

**1. State desync**: every Custom mutation button (Next/Prev circuit, Clear Circuit, Clear All, jump-to-circuit, panel click, Pattern Apply, keyboard arrow step) only mutated client-side state and saved to localStorage. **None** of them PUT to the server. The next real PUT (Mode Toggle, layer reselect) would either overwrite the user's work with the server's stale view, or push a snapshot containing only the currently-active port/circuit, collapsing all 20 wired ports back to a single one.

**2. Toggle double-fire**: the Custom Mode toggle was firing two change events per single click on macOS WKWebView (observed in user's log: 367ms apart). Single click flipped state back to the opposite of what the user wanted.

## Files

- `src/static/js/app.js` - 15 handlers updated:
  - data-flow: `customPrevPortBtn`, `customNextPortBtn`, `customClearPortBtn`, `customClearAllBtn`, `customActivePortInput`, `addPanelToCustomPath`, `applyPatternToSelection`, `customModeToggle` (re-entrancy guard)
  - power: `powerCustomPrev`, `powerCustomNext`, `powerCustomClearCircuit`, `powerCustomClearAll`, `powerCustomActive`, `addPanelToCustomPowerPath`, `applyPowerPatternToSelection`, `powerCustomToggle` (re-entrancy guard)
  - shared: `stepCustomPort` (keyboard shortcut step)
- README.md, src/VERSION.txt, src/templates/index.html, src/led_raster_designer.spec - bump 0.8.1 → 0.8.2