### PR TITLE
v0.8.4: cross-canvas marquee drag-select holds first try

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.3
+# LED Raster Designer v0.8.4
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.4 - May 4, 2026
+----------------------------
+- FIX: Drag-selecting layers with a marquee on Data / Power / Cabinet ID
+  / Show Look would silently drop any layers belonging to the non-active
+  canvas on the first try (the second attempt would catch them). Cause:
+  selectLayersInRect auto-activated the new primary layer's canvas
+  WITHOUT preserveSelection, so the cross-canvas selection it had just
+  built was wiped by the canvas switch. Now passes preserveSelection so
+  the multi-layer marquee works first try across canvas boundaries on
+  every tab.
+
 v0.8.3 - May 4, 2026
 ----------------------------
 - IMPROVE: Text label "Show On Tabs" group now includes Show Look. The

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.3',
-            'CFBundleVersion': '0.8.3',
+            'CFBundleShortVersionString': '0.8.4',
+            'CFBundleVersion': '0.8.4',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5909,8 +5909,13 @@ class LEDRasterApp {
         if (!this.selectionAnchorLayerId && this.currentLayer) {
             this.selectionAnchorLayerId = this.currentLayer.id;
         }
-        // Slice 4: auto-activate the canvas of the new primary layer.
-        this._activateCanvasForLayer(this.currentLayer);
+        // Slice 4 + v0.8.3: auto-activate the canvas of the new primary
+        // layer, but pass preserveSelection so a marquee that crosses
+        // canvas boundaries doesn't clobber the multi-layer selection
+        // we just built. Without this, the first drag-select on Data /
+        // Power / Cabinet ID would silently drop everything from the
+        // non-active canvas.
+        this._activateCanvasForLayer(this.currentLayer, { preserveSelection: true });
         this.renderLayers();
         this.loadLayerToInputs();
         this.loadTextLayerToInputs();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.3</title>
+    <title>LED Raster Designer v0.8.4</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.4</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary

- Marquee drag-select on Data / Power / Cabinet ID / Show Look now keeps cross-canvas layers on the first try (`selectLayersInRect` was missing the `preserveSelection` flag on its auto canvas switch).