### PR TITLE
v0.8.5: Show Look drag stops re-parenting layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
     branches: [main]
 
+# Dedupe runs. When a push to dev/draft triggers CI and that same commit
+# is also the head of an open PR, GitHub fires both events and every job
+# runs twice. The concurrency group is keyed on the workflow + ref so a
+# second event for the same commit cancels the first run instead of
+# stacking up. Pushes to main (where the SHA is the merge commit) get
+# their own group, so release-tag CI is unaffected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.4
+# LED Raster Designer v0.8.5
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,16 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.5 - May 4, 2026
+----------------------------
+- FIX: Show Look drags were silently re-parenting screen layers to whichever
+  canvas they visually overlapped. Pixel Map and Show Look layouts are
+  meant to be independent (Pixel Map = processor layout, Show Look = stage
+  layout), but the cross-canvas drop logic fired regardless of drag mode,
+  so dragging a screen in Show Look could change its canvas_id and shift
+  its position in Pixel Map too. Cross-canvas reassignment is now gated to
+  Pixel Map drags only; Show Look drags only mutate showOffsetX/Y.
+
 v0.8.4 - May 4, 2026
 ----------------------------
 - FIX: Drag-selecting layers with a marquee on Data / Power / Cabinet ID

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.4',
-            'CFBundleVersion': '0.8.4',
+            'CFBundleShortVersionString': '0.8.5',
+            'CFBundleVersion': '0.8.5',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1410,7 +1410,15 @@ class CanvasRenderer {
                     ? window.app.project.canvases.find(c => c && c.id === primary.canvas_id)
                     : null;
                 let crossCanvasHandled = false;
-                if (primaryCanvas) {
+                // v0.8.5: Pixel Map and Show Look layouts are independent.
+                // Cross-canvas reassignment is only meaningful for Pixel Map
+                // drags (which move the layer's processor position and so its
+                // canvas membership). Show Look drags only mutate showOffsetX/Y
+                // and must leave canvas_id alone, otherwise dropping a screen
+                // visually overlapping another canvas in Show Look silently
+                // re-parents it and shifts it on Pixel Map too.
+                const allowCanvasReassign = (this.dragLayerMode !== 'show');
+                if (primaryCanvas && allowCanvasReassign) {
                     // Mouse cursor world coords at drop (already computed
                     // above for the offset delta).
                     const cursorWX = this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.4</title>
+    <title>LED Raster Designer v0.8.5</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary

- Show Look / Data / Power drags only mutate `showOffsetX/Y` — they no longer change the layer's `canvas_id` or shift its Pixel Map / Cabinet ID position.
- Pixel Map drags still re-parent `canvas_id` between canvases (unchanged — that's the only intended way to change processor membership).
- Existing **Reset to Pixel Map Position** button in the Show Look sidebar still snaps the active layer's show position back.