### PR TITLE
v0.8.5: Show Look independent canvas membership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
     branches: [main]
 
+# Dedupe runs. When a push to dev/draft triggers CI and that same commit
+# is also the head of an open PR, GitHub fires both events and every job
+# runs twice. The concurrency group is keyed on the workflow + ref so a
+# second event for the same commit cancels the first run instead of
+# stacking up. Pushes to main (where the SHA is the merge commit) get
+# their own group, so release-tag CI is unaffected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.4
+# LED Raster Designer v0.8.5
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -3,13 +3,26 @@ LED RASTER DESIGNER - VERSION HISTORY
 
 v0.8.5 - May 4, 2026
 ----------------------------
-- FIX: Show Look drags were silently re-parenting screen layers to whichever
-  canvas they visually overlapped. Pixel Map and Show Look layouts are
-  meant to be independent (Pixel Map = processor layout, Show Look = stage
-  layout), but the cross-canvas drop logic fired regardless of drag mode,
-  so dragging a screen in Show Look could change its canvas_id and shift
-  its position in Pixel Map too. Cross-canvas reassignment is now gated to
-  Pixel Map drags only; Show Look drags only mutate showOffsetX/Y.
+- FEATURE: Show Look (and Data + Power, which render at the show layout)
+  now has its own independent canvas membership per layer, separate from
+  Pixel Map / Cabinet ID. New `show_canvas_id` field per layer, defaults
+  to null (= mirror canvas_id). Cross-canvas drag in Show Look sets it
+  WITHOUT touching canvas_id, offset_x/y, or panel geometry — so a screen
+  you drag from canvas 2 into canvas 1 in Show Look is in canvas 1 for
+  Show Look / Data / Power but stays in canvas 2 for Pixel Map / Cabinet
+  ID. Cross-canvas drag in Pixel Map keeps the existing behavior of
+  fully reparenting (resets show_canvas_id too).
+- IMPROVE: "Reset to Pixel Map Position" button in the Show Look sidebar
+  now also clears show_canvas_id, so one click fully snaps the layer back
+  to mirror its Pixel Map canvas + position.
+- New endpoint: PUT /api/layer/<id>/show_canvas accepts {show_canvas_id:
+  "..." | null}. Sends a single layer_move_to_show_canvas log event.
+- Renderer: per-canvas layer grouping, layer-canvas workspace offset,
+  hidden-canvas filter, zoom-to-layer, and cross-canvas drop hint all
+  resolve via the new helper `_effectiveLayerCanvasId(layer)` which
+  returns show_canvas_id || canvas_id when in a show-look-like view.
+- PSD export per-canvas filter respects show_canvas_id when exporting
+  Show Look / Data / Power views.
 
 v0.8.4 - May 4, 2026
 ----------------------------

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,16 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.5 - May 4, 2026
+----------------------------
+- FIX: Show Look drags were silently re-parenting screen layers to whichever
+  canvas they visually overlapped. Pixel Map and Show Look layouts are
+  meant to be independent (Pixel Map = processor layout, Show Look = stage
+  layout), but the cross-canvas drop logic fired regardless of drag mode,
+  so dragging a screen in Show Look could change its canvas_id and shift
+  its position in Pixel Map too. Cross-canvas reassignment is now gated to
+  Pixel Map drags only; Show Look drags only mutate showOffsetX/Y.
+
 v0.8.4 - May 4, 2026
 ----------------------------
 - FIX: Drag-selecting layers with a marquee on Data / Power / Cabinet ID

--- a/src/app.py
+++ b/src/app.py
@@ -1284,8 +1284,12 @@ def add_layer():
         'customPortPaths', 'customPortIndex',
         'randomDataColors',
         'showOffsetX', 'showOffsetY',
+        # v0.8.5: per-layer override for which canvas the layer belongs to
+        # in Show Look (and Data + Power, which render at the show layout).
+        # null/missing = mirror canvas_id.
+        'show_canvas_id',
     ]
-    
+
     half_fields = {'halfFirstColumn', 'halfLastColumn', 'halfFirstRow', 'halfLastRow'}
     needs_rebuild = False
     for field in optional_fields:
@@ -1847,6 +1851,33 @@ def move_layer_to_canvas(layer_id):
         log_event('layer_move_to_canvas', {
             'layer_id': layer_id, 'target_canvas_id': target_id,
         })
+    current_project['is_pristine'] = False
+    socketio.emit('project_updated', current_project)
+    return jsonify(current_project)
+
+
+@app.route('/api/layer/<int:layer_id>/show_canvas', methods=['PUT'])
+def move_layer_to_show_canvas(layer_id):
+    """v0.8.5: Reassign a layer's *Show Look* canvas without touching its
+    Pixel Map / Cabinet ID canvas membership or its panel geometry.
+
+    Body: ``{show_canvas_id: "..." | null}``. ``null`` clears the override
+    so Show Look falls back to mirroring ``canvas_id``. Does NOT mutate
+    ``canvas_id``, ``offset_x/y``, ``panels``, or ``showOffsetX/Y`` (the
+    drag has already updated showOffsetX/Y in-place via the regular PUT
+    path; this endpoint only stamps the new show-canvas membership).
+    """
+    data = request.json or {}
+    target_id = data.get('show_canvas_id')  # may be None
+    if target_id is not None and not _find_canvas(target_id):
+        return jsonify({'error': 'Target canvas not found'}), 404
+    layer = next((l for l in current_project['layers'] if l.get('id') == layer_id), None)
+    if not layer:
+        return jsonify({'error': 'Layer not found'}), 404
+    layer['show_canvas_id'] = target_id
+    log_event('layer_move_to_show_canvas', {
+        'layer_id': layer_id, 'target_show_canvas_id': target_id,
+    })
     current_project['is_pristine'] = False
     socketio.emit('project_updated', current_project)
     return jsonify(current_project)

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.4',
-            'CFBundleVersion': '0.8.4',
+            'CFBundleShortVersionString': '0.8.5',
+            'CFBundleVersion': '0.8.5',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2369,6 +2369,10 @@ class LEDRasterApp {
                 layers.forEach(l => {
                     l.showOffsetX = l.offset_x;
                     l.showOffsetY = l.offset_y;
+                    // v0.8.5: also clear the Show Look canvas override so
+                    // the layer falls back to mirroring its Pixel Map
+                    // canvas membership (canvas_id).
+                    l.show_canvas_id = null;
                 });
                 this.updateLayers(layers, false);
                 this.loadLayerToInputs();
@@ -8230,7 +8234,14 @@ class LEDRasterApp {
             // Legacy / single-canvas: include every layer (canvasId is null).
             const psdLayers = this.project.layers.filter(l => {
                 if (!view.canvasId) return true;
-                return l.canvas_id === view.canvasId;
+                // v0.8.5: Show Look / Data / Power exports use the layer's
+                // effective show canvas (show_canvas_id || canvas_id) so a
+                // layer reassigned in Show Look exports under its show
+                // canvas's PSD instead of its Pixel Map canvas's.
+                const isShowView = view.viewMode === 'show-look'
+                    || view.viewMode === 'data-flow' || view.viewMode === 'power';
+                const cid = (isShowView && l.show_canvas_id) ? l.show_canvas_id : l.canvas_id;
+                return cid === view.canvasId;
             }).map(l => {
                 const b = this.getLayerBounds(l);
                 return {
@@ -11080,6 +11091,59 @@ class LEDRasterApp {
      * - "duplicate": new layer id appended in target canvas; original
      *   stays put and remains selected.
      */
+    /**
+     * v0.8.5: Reassign a layer's Show Look canvas membership. Used by
+     * cross-canvas drops on the Show Look / Data / Power tabs. Does not
+     * touch canvas_id, offset_x/y, or panel geometry, so the layer's
+     * Pixel Map / Cabinet ID position and processor membership stay
+     * exactly where they were. Pass null to clear the override and let
+     * Show Look fall back to mirroring canvas_id.
+     */
+    moveLayerShowCanvas(layerId, targetCanvasId) {
+        return fetch(`/api/layer/${layerId}/show_canvas`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ show_canvas_id: targetCanvasId })
+        }).then(r => r.json()).then(data => {
+            this._applyProjectUpdate(data);
+            if (typeof this.renderLayers === 'function') this.renderLayers();
+            if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
+                window.canvasRenderer.render();
+            }
+            if (typeof this.saveState === 'function') {
+                this.saveState('Move Layer (Show Look) to Canvas');
+            }
+            return data;
+        });
+    }
+
+    /**
+     * v0.8.5: Multi-layer Show Look canvas reassign (mirrors moveLayersCrossCanvas).
+     */
+    async moveLayersShowCanvas(layerIds, targetCanvasId) {
+        if (!Array.isArray(layerIds) || layerIds.length === 0) return;
+        let lastData = null;
+        for (const id of layerIds) {
+            const r = await fetch(`/api/layer/${id}/show_canvas`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ show_canvas_id: targetCanvasId })
+            });
+            lastData = await r.json();
+        }
+        if (lastData) {
+            this._applyProjectUpdate(lastData);
+            if (typeof this.renderLayers === 'function') this.renderLayers();
+            if (window.canvasRenderer && typeof window.canvasRenderer.render === 'function') {
+                window.canvasRenderer.render();
+            }
+            if (typeof this.saveState === 'function') {
+                this.saveState(`Move ${layerIds.length} Layers (Show Look) to Canvas`);
+            }
+        }
+        return lastData;
+    }
+
     moveLayerCrossCanvas(layerId, targetCanvasId, mode) {
         const wantMove = (mode !== 'duplicate');
         return fetch(`/api/layer/${layerId}/canvas`, {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1410,7 +1410,15 @@ class CanvasRenderer {
                     ? window.app.project.canvases.find(c => c && c.id === primary.canvas_id)
                     : null;
                 let crossCanvasHandled = false;
-                if (primaryCanvas) {
+                // v0.8.5: Pixel Map and Show Look layouts are independent.
+                // Cross-canvas reassignment is only meaningful for Pixel Map
+                // drags (which move the layer's processor position and so its
+                // canvas membership). Show Look drags only mutate showOffsetX/Y
+                // and must leave canvas_id alone, otherwise dropping a screen
+                // visually overlapping another canvas in Show Look silently
+                // re-parents it and shifts it on Pixel Map too.
+                const allowCanvasReassign = (this.dragLayerMode !== 'show');
+                if (primaryCanvas && allowCanvasReassign) {
                     // Mouse cursor world coords at drop (already computed
                     // above for the offset delta).
                     const cursorWX = this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom);

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1046,7 +1046,11 @@ class CanvasRenderer {
                 const _primary = window.app.currentLayer;
                 if (_primary) {
                     const _tgt = this._canvasAtPoint(worldX, worldY);
-                    this._crossCanvasDropTarget = (_tgt && _tgt.id !== _primary.canvas_id) ? _tgt : null;
+                    // v0.8.5: in Show Look / Data / Power the cross-canvas
+                    // hint compares against the layer's effective show
+                    // canvas, matching where it renders.
+                    const _primaryCid = this._effectiveLayerCanvasId(_primary);
+                    this._crossCanvasDropTarget = (_tgt && _tgt.id !== _primaryCid) ? _tgt : null;
                 } else {
                     this._crossCanvasDropTarget = null;
                 }
@@ -1406,49 +1410,74 @@ class CanvasRenderer {
                 // on big layers.) Layers in OTHER canvases keep their
                 // normal within-canvas offset change.
                 const primary = window.app.currentLayer;
+                // v0.8.5: Pixel Map and Show Look maintain INDEPENDENT canvas
+                // membership. The Show Look canvas (used for show-look /
+                // data / power rendering) is the layer's `show_canvas_id`,
+                // falling back to `canvas_id` when null (the default).
+                // Pixel Map / Cabinet ID always use `canvas_id`.
+                const isShowMode = (this.dragLayerMode === 'show');
+                const primaryCanvasId = isShowMode
+                    ? (primary.show_canvas_id || primary.canvas_id)
+                    : primary.canvas_id;
                 const primaryCanvas = window.app.project && Array.isArray(window.app.project.canvases)
-                    ? window.app.project.canvases.find(c => c && c.id === primary.canvas_id)
+                    ? window.app.project.canvases.find(c => c && c.id === primaryCanvasId)
                     : null;
                 let crossCanvasHandled = false;
-                // v0.8.5: Pixel Map and Show Look layouts are independent.
-                // Cross-canvas reassignment is only meaningful for Pixel Map
-                // drags (which move the layer's processor position and so its
-                // canvas membership). Show Look drags only mutate showOffsetX/Y
-                // and must leave canvas_id alone, otherwise dropping a screen
-                // visually overlapping another canvas in Show Look silently
-                // re-parents it and shifts it on Pixel Map too.
-                const allowCanvasReassign = (this.dragLayerMode !== 'show');
-                if (primaryCanvas && allowCanvasReassign) {
+                if (primaryCanvas) {
                     // Mouse cursor world coords at drop (already computed
                     // above for the offset delta).
                     const cursorWX = this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom);
                     const cursorWY = ((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom;
                     const targetCanvas = this._canvasAtPoint(cursorWX, cursorWY);
-                    if (targetCanvas && targetCanvas.id !== primary.canvas_id) {
+                    if (targetCanvas && targetCanvas.id !== primaryCanvasId) {
                         const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
                         // Collect all selected layer ids that share the
                         // primary's canvas (so the whole multi-selection
                         // travels together). Primary first so it stays the
                         // currentLayer in the target.
+                        const peerCanvasId = (l) => isShowMode
+                            ? (l.show_canvas_id || l.canvas_id)
+                            : l.canvas_id;
                         const movedIds = [primary.id];
                         if (window.app.selectedLayerIds && window.app.selectedLayerIds.size > 1) {
                             window.app.selectedLayerIds.forEach(id => {
                                 if (id === primary.id) return;
                                 const l = window.app.project.layers.find(x => x.id === id);
-                                if (l && l.canvas_id === primary.canvas_id && !l.locked) {
+                                if (l && peerCanvasId(l) === primaryCanvasId && !l.locked) {
                                     movedIds.push(id);
                                 }
                             });
                         }
-                        // Cross-canvas helpers now snapshot post-action state
-                        // themselves (in their .then() after the server
-                        // round-trip), so we don't pass skipSaveState anymore.
-                        if (movedIds.length > 1 && typeof window.app.moveLayersCrossCanvas === 'function') {
-                            window.app.moveLayersCrossCanvas(movedIds, targetCanvas.id, mode);
+                        if (isShowMode) {
+                            // Show Look drag: persist the freshly-dragged
+                            // showOffsetX/Y first (no saveState on this PUT
+                            // — the moveLayerShowCanvas .then() will snapshot
+                            // post-everything state), then PUT show_canvas_id
+                            // so canvas_id, offset_x/y, panels stay put.
+                            // Duplicate is not supported here (mode is
+                            // forced to 'move') since show-canvas reassign
+                            // isn't a clone op.
+                            const toUpdate = window.app.getSelectedLayers
+                                ? window.app.getSelectedLayers()
+                                : [window.app.currentLayer];
+                            window.app.updateLayers(toUpdate, false);
+                            if (movedIds.length > 1 && typeof window.app.moveLayersShowCanvas === 'function') {
+                                window.app.moveLayersShowCanvas(movedIds, targetCanvas.id);
+                            } else if (typeof window.app.moveLayerShowCanvas === 'function') {
+                                window.app.moveLayerShowCanvas(primary.id, targetCanvas.id);
+                            }
                             crossCanvasHandled = true;
-                        } else if (typeof window.app.moveLayerCrossCanvas === 'function') {
-                            window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode);
-                            crossCanvasHandled = true;
+                        } else {
+                            // Pixel Map drag: full processor reparent
+                            // (resets offset_x/y, rebuilds panel geometry
+                            // at the new canvas's origin).
+                            if (movedIds.length > 1 && typeof window.app.moveLayersCrossCanvas === 'function') {
+                                window.app.moveLayersCrossCanvas(movedIds, targetCanvas.id, mode);
+                                crossCanvasHandled = true;
+                            } else if (typeof window.app.moveLayerCrossCanvas === 'function') {
+                                window.app.moveLayerCrossCanvas(primary.id, targetCanvas.id, mode);
+                                crossCanvasHandled = true;
+                            }
                         }
                     }
                 }
@@ -1738,11 +1767,26 @@ class CanvasRenderer {
      * and projects with no canvases array fall back to (0, 0) so single-canvas
      * behaviour is unchanged.
      */
+    /**
+     * v0.8.5: which canvas does this layer "live in" for the active view?
+     * Pixel Map / Cabinet ID always use the processor canvas (canvas_id).
+     * Show Look / Data / Power use the layer's `show_canvas_id` override
+     * (set by Show Look cross-canvas drops); when null/missing, falls back
+     * to canvas_id so the layer mirrors its Pixel Map canvas.
+     */
+    _effectiveLayerCanvasId(layer) {
+        if (!layer) return null;
+        if (this.isShowLookView() && layer.show_canvas_id) {
+            return layer.show_canvas_id;
+        }
+        return layer.canvas_id || null;
+    }
+
     _layerCanvasOffset(layer) {
         if (!layer || !window.app || !window.app.project) return { wx: 0, wy: 0 };
         const arr = window.app.project.canvases;
         if (!Array.isArray(arr) || arr.length === 0) return { wx: 0, wy: 0 };
-        const cid = layer.canvas_id;
+        const cid = this._effectiveLayerCanvasId(layer);
         if (!cid) return { wx: 0, wy: 0 };
         for (const c of arr) {
             if (c && c.id === cid) {
@@ -2093,7 +2137,7 @@ class CanvasRenderer {
         // Helper: returns the workspace translate for a layer (or 0,0 for
         // legacy / orphan layers). Used by the post-pass wrappers below.
         const _layerWs = (layer) => {
-            const cid = layer && layer.canvas_id;
+            const cid = this._effectiveLayerCanvasId(layer);
             const c = cid ? _canvasById[cid] : null;
             return { wx: (c && c.workspace_x) || 0, wy: (c && c.workspace_y) || 0 };
         };
@@ -2103,7 +2147,7 @@ class CanvasRenderer {
         // while its layers continued to render at the canvas's workspace
         // offset.
         const _layerCanvasHidden = (layer) => {
-            const cid = layer && layer.canvas_id;
+            const cid = this._effectiveLayerCanvasId(layer);
             const c = cid ? _canvasById[cid] : null;
             return c && c.visible === false;
         };
@@ -2148,7 +2192,11 @@ class CanvasRenderer {
                 const layersInCanvas = window.app.project.layers.filter(l => {
                     if (!l.visible) return false;
                     if (_canvasesArr.length === 0) return true; // legacy fallback
-                    return l.canvas_id === canvas.id;
+                    // v0.8.5: in Show Look / Data / Power, group by the
+                    // layer's effective show canvas (show_canvas_id ||
+                    // canvas_id). Pixel Map / Cabinet ID still group by
+                    // canvas_id — the helper handles the view-mode pick.
+                    return this._effectiveLayerCanvasId(l) === canvas.id;
                 });
                 // Empty canvases (no layers) still get drawn, outline +
                 // active tint, so the user can see the canvas exists and can
@@ -2526,8 +2574,12 @@ class CanvasRenderer {
             // centers on where the layer is actually drawn in the workspace,
             // otherwise 1:1 zooms to the wrong canvas's slot.
             let wx = 0, wy = 0;
-            if (window.app.project && window.app.project.canvases && layer.canvas_id) {
-                const c = window.app.project.canvases.find(c => c.id === layer.canvas_id);
+            // v0.8.5: zoom-to-layer in Show Look / Data / Power must use
+            // the layer's effective show canvas (show_canvas_id), since the
+            // layer renders at THAT canvas's workspace position there.
+            const zoomCanvasId = this._effectiveLayerCanvasId(layer);
+            if (window.app.project && window.app.project.canvases && zoomCanvasId) {
+                const c = window.app.project.canvases.find(c => c.id === zoomCanvasId);
                 if (c) { wx = c.workspace_x || 0; wy = c.workspace_y || 0; }
             }
             const layerWidth = bounds.width;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.4</title>
+    <title>LED Raster Designer v0.8.5</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary

- New per-layer `show_canvas_id` so Show Look (and Data + Power, which render at the show layout) has independent canvas membership from Pixel Map / Cabinet ID.
- Cross-canvas drag in Show Look sets `show_canvas_id` only — `canvas_id`, `offset_x/y`, and panel geometry stay put. Drag a screen from canvas 2 into canvas 1 in Show Look and it's in canvas 1 for Show Look / Data / Power but stays in canvas 2 for Pixel Map / Cabinet ID.
- **Reset to Pixel Map Position** button now also clears `show_canvas_id`, fully snapping the layer back.