### PR TITLE
v0.8.5.1: compensate showOffset on cross-canvas Show Look reassign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.5
+# LED Raster Designer v0.8.5.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.5.1 - May 4, 2026
+----------------------------
+- FIX: Cross-canvas Show Look drag correctly compensates the layer's
+  showOffsetX/Y for the canvas swap. showOffsets are stored relative to
+  the layer's canvas's workspace position; without compensation a layer
+  dropped from canvas 2 into canvas 1 in Show Look kept its c2-relative
+  offset, but rendered at (c1.workspace + that_offset), so it visually
+  jumped (often off-screen, with extreme negative offsets like -1220).
+  Now offsets are adjusted by (oldCanvas.workspace - newCanvas.workspace)
+  so the layer stays exactly where the user dropped it.
+
 v0.8.5 - May 4, 2026
 ----------------------------
 - FEATURE: Show Look (and Data + Power, which render at the show layout)

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.5',
-            'CFBundleVersion': '0.8.5',
+            'CFBundleShortVersionString': '0.8.5.1',
+            'CFBundleVersion': '0.8.5.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1457,6 +1457,26 @@ class CanvasRenderer {
                             // Duplicate is not supported here (mode is
                             // forced to 'move') since show-canvas reassign
                             // isn't a clone op.
+                            //
+                            // v0.8.5 fix: showOffsetX/Y are stored CANVAS-
+                            // RELATIVE (renderer adds canvas.workspace_x/y to
+                            // them). When we swap the layer's effective show
+                            // canvas, we MUST compensate the offsets by
+                            // (oldCanvas.workspace - newCanvas.workspace) or
+                            // the layer visually JUMPS to a wrong spot
+                            // because (newCanvas.workspace + sameOffset) !=
+                            // (oldCanvas.workspace + sameOffset). Without
+                            // this, dragging a c2 screen into c1's area
+                            // looked like the layer was still in c2's space
+                            // (or even way off-screen).
+                            const dxComp = (primaryCanvas.workspace_x || 0) - (targetCanvas.workspace_x || 0);
+                            const dyComp = (primaryCanvas.workspace_y || 0) - (targetCanvas.workspace_y || 0);
+                            movedIds.forEach(id => {
+                                const l = window.app.project.layers.find(x => x.id === id);
+                                if (!l) return;
+                                l.showOffsetX = (Number(l.showOffsetX) || 0) + dxComp;
+                                l.showOffsetY = (Number(l.showOffsetY) || 0) + dyComp;
+                            });
                             const toUpdate = window.app.getSelectedLayers
                                 ? window.app.getSelectedLayers()
                                 : [window.app.currentLayer];

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.5</title>
+    <title>LED Raster Designer v0.8.5.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary

- Cross-canvas Show Look drag now compensates `showOffsetX/Y` for the canvas swap, so the layer visually lands exactly where dropped (was jumping to a wrong position because show offsets are stored canvas-relative).