### PR TITLE
v0.8.5.3: full Show Look canvas/raster/layer independence + Reset Entire Show Look

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.5.1
+# LED Raster Designer v0.8.5.3
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,51 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.5.3 - May 4, 2026
+----------------------------
+- FIX: Dragging a canvas in Show Look also moved it on Pixel Map.
+  Canvases had a single workspace_x/y field shared across both views.
+  Now canvases have a per-view workspace position: workspace_x/y for
+  Pixel Map / Cabinet ID, and an optional show_workspace_x/y for
+  Show Look / Data / Power (falls back to workspace_x/y when null).
+  Show Look canvas drags only write the show_workspace fields. Pixel
+  Map drags only write workspace.
+- FIX: PUT /api/layer/<id> writable list was missing show_canvas_id,
+  so the per-layer Reset button was setting it to null on the client
+  but the server silently ignored the null and the show-canvas
+  override stayed in place. Reset now actually clears it.
+- IMPROVE: Both Reset buttons (per-layer and project-wide) also clear
+  the new show_workspace_x/y override so canvas positions in Show Look
+  re-pin to their Pixel Map positions.
+- Renderer helpers: new _canvasWorkspace(canvas) returns the right
+  workspace position for the active view; used by canvas hit-tests,
+  edge-drag start, layer workspace offset, layer-canvas zoom, workspace
+  bounding box, and the canvas render loop.
+- FIX: Canvas overlap toast and snap-to-neighbor on Show Look were
+  reading workspace_x/y instead of show_workspace_x/y, which gave false
+  "Canvases overlapping" warnings (especially when snapping) because
+  the bounds reflected the stale pixel-map positions instead of the
+  actual show-look positions.
+
+v0.8.5.2 - May 4, 2026
+----------------------------
+- FIX: Pixel Map and Show Look rasters are now fully independent. The
+  toolbar raster edit had an "auto-link" path: when the two raster sizes
+  matched before the edit, changing the Pixel Map raster also wrote the
+  Show Look raster on the same axis. This contradicted the v0.8.5
+  independence design (Pixel Map = processor layout, Show Look = stage
+  layout). Each toolbar edit now writes ONLY the raster for the view
+  the user is on.
+- IMPROVE: "Reset to Pixel Map Position" button now ALSO re-links the
+  Show Look raster of every canvas touched by the selected layer(s)
+  back to its Pixel Map raster. One click fully restores Show Look to
+  mirror Pixel Map (position + canvas membership + raster size).
+- FEATURE: New "Reset Entire Show Look" button in the Show Look sidebar
+  (under the per-layer Reset). One click resets EVERY screen layer's
+  show position to its Pixel Map position, clears every show_canvas_id
+  override, and re-links every canvas's show raster to its Pixel Map
+  raster across the whole project. Undoable in one Cmd+Z step.
+
 v0.8.5.1 - May 4, 2026
 ----------------------------
 - FIX: Cross-canvas Show Look drag correctly compensates the layer's

--- a/src/app.py
+++ b/src/app.py
@@ -1446,6 +1446,8 @@ def update_layer(layer_id):
                 'screenNameSize',
                 # Show Look position (separate from offset_x/y).
                 'showOffsetX', 'showOffsetY',
+                # v0.8.5: per-layer Show Look canvas override. null clears.
+                'show_canvas_id',
                 'showDataFlowPortInfo', 'showPowerCircuitInfo']:
         if key in data:
             layer[key] = data[key]
@@ -1683,6 +1685,9 @@ def update_canvas(canvas_id):
     allowed = {
         'name', 'color', 'visible',
         'workspace_x', 'workspace_y',
+        # v0.8.5.3: per-canvas Show Look workspace position (independent
+        # from Pixel Map's workspace_x/y). null clears.
+        'show_workspace_x', 'show_workspace_y',
         'raster_width', 'raster_height',
         'show_raster_width', 'show_raster_height',
         'data_flow_perspective', 'power_perspective',

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.5.1',
-            'CFBundleVersion': '0.8.5.1',
+            'CFBundleShortVersionString': '0.8.5.3',
+            'CFBundleVersion': '0.8.5.3',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2375,6 +2375,90 @@ class LEDRasterApp {
                     l.show_canvas_id = null;
                 });
                 this.updateLayers(layers, false);
+                // v0.8.5.2: also re-link the Show Look raster of every
+                // canvas touched by these layers back to its Pixel Map
+                // raster, so a single Reset click fully restores Show Look
+                // to mirror Pixel Map (position + canvas membership +
+                // raster size). Pushed via the canvas PUT endpoint.
+                if (this.project && Array.isArray(this.project.canvases)
+                        && typeof this.updateCanvas === 'function') {
+                    const canvasIds = new Set();
+                    layers.forEach(l => { if (l && l.canvas_id) canvasIds.add(l.canvas_id); });
+                    canvasIds.forEach(cid => {
+                        const c = this.project.canvases.find(x => x && x.id === cid);
+                        if (!c) return;
+                        const rw = Number(c.raster_width) || 0;
+                        const rh = Number(c.raster_height) || 0;
+                        const sw = Number(c.show_raster_width) || 0;
+                        const sh = Number(c.show_raster_height) || 0;
+                        const patch = {};
+                        if (rw && rw !== sw) patch.show_raster_width = rw;
+                        if (rh && rh !== sh) patch.show_raster_height = rh;
+                        // v0.8.5.3: also re-link show workspace position to
+                        // the Pixel Map workspace position (clear override).
+                        if (c.show_workspace_x != null) {
+                            c.show_workspace_x = null;
+                            patch.show_workspace_x = null;
+                        }
+                        if (c.show_workspace_y != null) {
+                            c.show_workspace_y = null;
+                            patch.show_workspace_y = null;
+                        }
+                        if (Object.keys(patch).length === 0) return;
+                        Object.assign(c, patch);
+                        this.updateCanvas(cid, patch);
+                    });
+                }
+                this.loadLayerToInputs();
+                if (window.canvasRenderer) window.canvasRenderer.render();
+            });
+        }
+        // v0.8.5.2: project-wide Show Look reset. Resets EVERY layer's
+        // showOffset to its offset_x/y, clears every show_canvas_id, and
+        // re-links every canvas's show_raster_* to its raster_* — one
+        // click puts the entire Show Look (and Data + Power, which render
+        // at the show layout) back to mirroring Pixel Map.
+        const showResetAllBtn = document.getElementById('show-look-reset-all');
+        if (showResetAllBtn) {
+            showResetAllBtn.addEventListener('click', () => {
+                if (!this.project) return;
+                this.saveState('Reset Entire Show Look');
+                const allLayers = (this.project.layers || []).filter(
+                    l => (l.type || 'screen') === 'screen'
+                );
+                allLayers.forEach(l => {
+                    l.showOffsetX = l.offset_x;
+                    l.showOffsetY = l.offset_y;
+                    l.show_canvas_id = null;
+                });
+                if (allLayers.length > 0) this.updateLayers(allLayers, false);
+                if (Array.isArray(this.project.canvases)
+                        && typeof this.updateCanvas === 'function') {
+                    this.project.canvases.forEach(c => {
+                        if (!c) return;
+                        const rw = Number(c.raster_width) || 0;
+                        const rh = Number(c.raster_height) || 0;
+                        const sw = Number(c.show_raster_width) || 0;
+                        const sh = Number(c.show_raster_height) || 0;
+                        const patch = {};
+                        if (rw && rw !== sw) patch.show_raster_width = rw;
+                        if (rh && rh !== sh) patch.show_raster_height = rh;
+                        // v0.8.5.3: clear the Show Look workspace override
+                        // so canvases visually re-pin to their Pixel Map
+                        // positions in Show Look / Data / Power.
+                        if (c.show_workspace_x != null) {
+                            c.show_workspace_x = null;
+                            patch.show_workspace_x = null;
+                        }
+                        if (c.show_workspace_y != null) {
+                            c.show_workspace_y = null;
+                            patch.show_workspace_y = null;
+                        }
+                        if (Object.keys(patch).length === 0) return;
+                        Object.assign(c, patch);
+                        this.updateCanvas(c.id, patch);
+                    });
+                }
                 this.loadLayerToInputs();
                 if (window.canvasRenderer) window.canvasRenderer.render();
             });
@@ -11233,8 +11317,18 @@ class LEDRasterApp {
         const bounds = (c) => {
             const w = (useShow && c.show_raster_width) || c.raster_width || 0;
             const h = (useShow && c.show_raster_height) || c.raster_height || 0;
-            const x = c.workspace_x || 0;
-            const y = c.workspace_y || 0;
+            // v0.8.5.3: in Show Look use the canvas's show workspace
+            // position (falls back to workspace_x/y when null). The check
+            // was reading workspace_x/y in both views, which gave false
+            // overlap toasts when only the show position had moved.
+            let x, y;
+            if (useShow) {
+                x = (c.show_workspace_x == null ? (c.workspace_x || 0) : (c.show_workspace_x || 0));
+                y = (c.show_workspace_y == null ? (c.workspace_y || 0) : (c.show_workspace_y || 0));
+            } else {
+                x = c.workspace_x || 0;
+                y = c.workspace_y || 0;
+            }
             return { x, y, w, h };
         };
         const dragged = this.project.canvases.find(c => c && c.id === canvasId);
@@ -11674,10 +11768,10 @@ class LEDRasterApp {
      * project-root mirror. `axis` is 'width' or 'height'; `value` is the new
      * dimension; `isShow` selects show_raster_* vs raster_*.
      *
-     * Auto-link behaviour: when the pixel and show rasters were equal
-     * before this change ("linked"), a pixel-raster edit also updates the
-     * show raster on the same axis so Show Look keeps tracking Pixel Map
-     * until the user explicitly splits them.
+     * v0.8.5.2: Pixel Map and Show Look rasters are fully independent.
+     * Editing one never auto-syncs the other (previously a "linked" edit
+     * on Pixel Map also wrote show_raster_*; that contradicted the design
+     * goal of independent layouts).
      */
     _writeToolbarRasterToActiveCanvas(axis, value, isShow) {
         if (!this.project || !Array.isArray(this.project.canvases)) return;
@@ -11689,17 +11783,8 @@ class LEDRasterApp {
             if (axis === 'width')  patch.show_raster_width  = value;
             if (axis === 'height') patch.show_raster_height = value;
         } else {
-            // Detect linked-state on the *active canvas* before mutating it.
-            const wasLinked = (axis === 'width')
-                ? ((Number(c.raster_width) || 0) === (Number(c.show_raster_width) || 0))
-                : ((Number(c.raster_height) || 0) === (Number(c.show_raster_height) || 0));
-            if (axis === 'width') {
-                patch.raster_width = value;
-                if (wasLinked) patch.show_raster_width = value;
-            } else {
-                patch.raster_height = value;
-                if (wasLinked) patch.show_raster_height = value;
-            }
+            if (axis === 'width')  patch.raster_width  = value;
+            if (axis === 'height') patch.raster_height = value;
         }
         // Optimistic local update so the renderer (which reads from the
         // canvas object via getters) repaints immediately, before the PUT

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -451,8 +451,10 @@ class CanvasRenderer {
             const w = (useShow && c.show_raster_width) || c.raster_width || 0;
             const h = (useShow && c.show_raster_height) || c.raster_height || 0;
             if (w <= 0 || h <= 0) continue;
-            const x = c.workspace_x || 0;
-            const y = c.workspace_y || 0;
+            // v0.8.5.3: Show Look uses its own workspace position when set.
+            const ws = this._canvasWorkspace(c);
+            const x = ws.wx;
+            const y = ws.wy;
             if (worldX >= x && worldX <= x + w && worldY >= y && worldY <= y + h) {
                 return c;
             }
@@ -484,8 +486,10 @@ class CanvasRenderer {
             const w = (useShow && c.show_raster_width) || c.raster_width || 0;
             const h = (useShow && c.show_raster_height) || c.raster_height || 0;
             if (w <= 0 || h <= 0) continue;
-            const x = c.workspace_x || 0;
-            const y = c.workspace_y || 0;
+            // v0.8.5.3: Show Look uses its own workspace position when set.
+            const ws = this._canvasWorkspace(c);
+            const x = ws.wx;
+            const y = ws.wy;
             // Outer bounds (rect + tol on every side)
             if (worldX < x - tol || worldX > x + w + tol) continue;
             if (worldY < y - tol || worldY > y + h + tol) continue;
@@ -526,8 +530,13 @@ class CanvasRenderer {
                 this.draggingCanvasId = edgeCanvas.id;
                 this.canvasDragStartX = worldX;
                 this.canvasDragStartY = worldY;
-                this.canvasDragStartWX = edgeCanvas.workspace_x || 0;
-                this.canvasDragStartWY = edgeCanvas.workspace_y || 0;
+                // v0.8.5.3: drag uses the active view's workspace position
+                // (Show Look has its own show_workspace_x/y).
+                {
+                    const _ws = this._canvasWorkspace(edgeCanvas);
+                    this.canvasDragStartWX = _ws.wx;
+                    this.canvasDragStartWY = _ws.wy;
+                }
                 // saveState moved to canvas-drag END (in updateCanvas .then())
                 // so the snapshot is the POST-drag workspace position. Pre-drag
                 // saveState was off-by-one and made undo skip past the drag.
@@ -927,8 +936,15 @@ class CanvasRenderer {
                         nextX = snapped.x;
                         nextY = snapped.y;
                     }
-                    c.workspace_x = nextX;
-                    c.workspace_y = nextY;
+                    // v0.8.5.3: Show Look canvas drag writes show_workspace
+                    // so Pixel Map's workspace stays put.
+                    if (this.isShowLookView()) {
+                        c.show_workspace_x = nextX;
+                        c.show_workspace_y = nextY;
+                    } else {
+                        c.workspace_x = nextX;
+                        c.workspace_y = nextY;
+                    }
                     this.render();
                 }
             }
@@ -1142,15 +1158,26 @@ class CanvasRenderer {
             if (window.app && window.app.project) {
                 const c = window.app.project.canvases.find(c => c.id === id);
                 if (c) {
-                    const wx = Math.round(c.workspace_x || 0);
-                    const wy = Math.round(c.workspace_y || 0);
-                    c.workspace_x = wx;
-                    c.workspace_y = wy;
+                    // v0.8.5.3: persist to the right field per view.
+                    const isShow = this.isShowLookView();
+                    const _ws = this._canvasWorkspace(c);
+                    const wx = Math.round(_ws.wx);
+                    const wy = Math.round(_ws.wy);
+                    if (isShow) {
+                        c.show_workspace_x = wx;
+                        c.show_workspace_y = wy;
+                    } else {
+                        c.workspace_x = wx;
+                        c.workspace_y = wy;
+                    }
                     if (typeof window.app.updateCanvas === 'function') {
                         // updateCanvas now snapshots POST-mutation state in
                         // its server-response .then() so a single Cmd+Z reverts
                         // exactly this drag. No skipSaveState needed.
-                        window.app.updateCanvas(id, { workspace_x: wx, workspace_y: wy });
+                        const patch = isShow
+                            ? { show_workspace_x: wx, show_workspace_y: wy }
+                            : { workspace_x: wx, workspace_y: wy };
+                        window.app.updateCanvas(id, patch);
                     }
                     if (typeof window.app._checkCanvasOverlapAndToast === 'function') {
                         window.app._checkCanvasOverlapAndToast(id);
@@ -1469,8 +1496,13 @@ class CanvasRenderer {
                             // this, dragging a c2 screen into c1's area
                             // looked like the layer was still in c2's space
                             // (or even way off-screen).
-                            const dxComp = (primaryCanvas.workspace_x || 0) - (targetCanvas.workspace_x || 0);
-                            const dyComp = (primaryCanvas.workspace_y || 0) - (targetCanvas.workspace_y || 0);
+                            // v0.8.5.3: compensation must use the SHOW-LOOK
+                            // workspace of each canvas (the one the layer is
+                            // actually rendered against in this view).
+                            const _ws1 = this._canvasWorkspace(primaryCanvas);
+                            const _ws2 = this._canvasWorkspace(targetCanvas);
+                            const dxComp = _ws1.wx - _ws2.wx;
+                            const dyComp = _ws1.wy - _ws2.wy;
                             movedIds.forEach(id => {
                                 const l = window.app.project.layers.find(x => x.id === id);
                                 if (!l) return;
@@ -1788,6 +1820,25 @@ class CanvasRenderer {
      * behaviour is unchanged.
      */
     /**
+     * v0.8.5.3: which workspace position does this canvas use in the active
+     * view? Show Look (and Data + Power, which render at the show layout)
+     * use `show_workspace_x/y` when set; otherwise mirror `workspace_x/y`.
+     * Pixel Map / Cabinet ID always use `workspace_x/y`. Returns {wx, wy}.
+     */
+    _canvasWorkspace(canvas) {
+        if (!canvas) return { wx: 0, wy: 0 };
+        if (this.isShowLookView()) {
+            const swx = canvas.show_workspace_x;
+            const swy = canvas.show_workspace_y;
+            return {
+                wx: (swx == null ? (canvas.workspace_x || 0) : (swx || 0)),
+                wy: (swy == null ? (canvas.workspace_y || 0) : (swy || 0)),
+            };
+        }
+        return { wx: canvas.workspace_x || 0, wy: canvas.workspace_y || 0 };
+    }
+
+    /**
      * v0.8.5: which canvas does this layer "live in" for the active view?
      * Pixel Map / Cabinet ID always use the processor canvas (canvas_id).
      * Show Look / Data / Power use the layer's `show_canvas_id` override
@@ -1810,7 +1861,8 @@ class CanvasRenderer {
         if (!cid) return { wx: 0, wy: 0 };
         for (const c of arr) {
             if (c && c.id === cid) {
-                return { wx: c.workspace_x || 0, wy: c.workspace_y || 0 };
+                // v0.8.5.3: Show Look uses its own canvas workspace position.
+                return this._canvasWorkspace(c);
             }
         }
         return { wx: 0, wy: 0 };
@@ -2159,7 +2211,8 @@ class CanvasRenderer {
         const _layerWs = (layer) => {
             const cid = this._effectiveLayerCanvasId(layer);
             const c = cid ? _canvasById[cid] : null;
-            return { wx: (c && c.workspace_x) || 0, wy: (c && c.workspace_y) || 0 };
+            // v0.8.5.3: pick the right workspace position per view.
+            return this._canvasWorkspace(c);
         };
         // Helper: returns true if this layer's canvas is hidden (canvas-level
         // eye toggle off). Used to skip every per-layer post-pass for hidden
@@ -2224,8 +2277,10 @@ class CanvasRenderer {
                 // this being a valid drop target. Originally Slice 3 skipped
                 // empty canvases entirely, but that hid them from the
                 // workspace which broke the drop-into-empty-canvas flow.
-                const wx = canvas.workspace_x || 0;
-                const wy = canvas.workspace_y || 0;
+                // v0.8.5.3: in Show Look use the canvas's show workspace pos.
+                const _ws = this._canvasWorkspace(canvas);
+                const wx = _ws.wx;
+                const wy = _ws.wy;
                 const needsCanvasShift = (wx !== 0 || wy !== 0);
                 if (needsCanvasShift) {
                     this.ctx.save();
@@ -2551,8 +2606,10 @@ class CanvasRenderer {
         const useShow = this.isShowLookView();
         let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
         visible.forEach(c => {
-            const wx = c.workspace_x || 0;
-            const wy = c.workspace_y || 0;
+            // v0.8.5.3: workspace bbox uses the active view's canvas position.
+            const ws = this._canvasWorkspace(c);
+            const wx = ws.wx;
+            const wy = ws.wy;
             const w = (useShow && c.show_raster_width) || c.raster_width || 0;
             const h = (useShow && c.show_raster_height) || c.raster_height || 0;
             if (wx < minX) minX = wx;
@@ -2600,7 +2657,11 @@ class CanvasRenderer {
             const zoomCanvasId = this._effectiveLayerCanvasId(layer);
             if (window.app.project && window.app.project.canvases && zoomCanvasId) {
                 const c = window.app.project.canvases.find(c => c.id === zoomCanvasId);
-                if (c) { wx = c.workspace_x || 0; wy = c.workspace_y || 0; }
+                if (c) {
+                    // v0.8.5.3: pick the right workspace position per view.
+                    const ws = this._canvasWorkspace(c);
+                    wx = ws.wx; wy = ws.wy;
+                }
             }
             const layerWidth = bounds.width;
             const layerHeight = bounds.height;
@@ -2649,8 +2710,15 @@ class CanvasRenderer {
         };
         for (const other of window.app.project.canvases) {
             if (!other || other.id === dragged.id || other.visible === false) continue;
-            const ox = other.workspace_x || 0;
-            const oy = other.workspace_y || 0;
+            // v0.8.5.3: snap-to-neighbor in Show Look uses each canvas's
+            // show workspace position (falls back to workspace_x/y when
+            // null). Without this, snapping in Show Look targeted Pixel
+            // Map positions and the just-dropped canvas could trigger a
+            // false "overlap" toast against a neighbor's stale pixel-map
+            // bounds that no longer reflects its show position.
+            const _ws = this._canvasWorkspace(other);
+            const ox = _ws.wx;
+            const oy = _ws.wy;
             const ow = (useShow && other.show_raster_width) || other.raster_width || 0;
             const oh = (useShow && other.show_raster_height) || other.raster_height || 0;
             if (ow <= 0 || oh <= 0) continue;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.5.1</title>
+    <title>LED Raster Designer v0.8.5.3</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5.3</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -399,7 +399,10 @@
                             <input type="text" id="show-offset-y" value="0">
                         </div>
                         <div style="margin-top: 12px;">
-                            <button id="show-look-reset" class="btn" style="width:100%;" data-tooltip="Reset this screen's Show Look position to match its Pixel Map position.">Reset to Pixel Map Position</button>
+                            <button id="show-look-reset" class="btn" style="width:100%;" data-tooltip="Reset this screen's Show Look position to match its Pixel Map position. Also re-links its canvas's Show Look raster to its Pixel Map raster.">Reset to Pixel Map Position</button>
+                        </div>
+                        <div style="margin-top: 6px;">
+                            <button id="show-look-reset-all" class="btn" style="width:100%;" data-tooltip="Reset the ENTIRE Show Look across every canvas: all layer positions, show-canvas overrides, and show-raster sizes snap back to mirror Pixel Map. Undoable.">Reset Entire Show Look</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- Canvas position is now independent per view: new `show_workspace_x/y` per canvas, falls back to `workspace_x/y`. Show Look canvas drags write only show_workspace, Pixel Map drags write only workspace.
- Per-layer `show_canvas_id` + `show_raster_*` are also independent (carried from v0.8.5).
- New **Reset Entire Show Look** button (in addition to the per-layer Reset) re-mirrors every layer position, every show_canvas_id override, every show_workspace, and every show_raster back to Pixel Map in one click.
- Fix: PUT `/api/layer/<id>` writable list was missing `show_canvas_id` (per-layer Reset wasn't actually clearing it server-side).
- Fix: canvas overlap toast and snap-to-neighbor on Show Look were reading `workspace_x/y` instead of `show_workspace_x/y`, producing false overlap warnings while snapping.