### PR TITLE
v0.8.5.4: export pan uses show_workspace for Show Look / Data / Power

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.5.3
+# LED Raster Designer v0.8.5.4
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,15 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.5.4 - May 4, 2026
+----------------------------
+- FIX: Multi-view export (PNG / PSD / PDF) on Show Look / Data / Power
+  was panning the export viewport by canvas.workspace_x/y instead of
+  show_workspace_x/y when those tabs render. Result: every Show Look /
+  Data / Power export came out shifted to the left from where the user
+  positioned the canvas in Show Look. Now the export pan uses the same
+  workspace position the renderer uses on screen for that view.
+
 v0.8.5.3 - May 4, 2026
 ----------------------------
 - FIX: Dragging a canvas in Show Look also moved it on Pixel Map.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.5.3',
-            'CFBundleVersion': '0.8.5.3',
+            'CFBundleShortVersionString': '0.8.5.4',
+            'CFBundleVersion': '0.8.5.4',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7960,8 +7960,26 @@ class LEDRasterApp {
                     // Translate the workspace so this canvas's top-left
                     // (workspace_x, workspace_y) lands at (0, 0) in the
                     // export canvas. Legacy: pan to 0,0.
-                    const wsx = targetCanvas ? (targetCanvas.workspace_x || 0) : 0;
-                    const wsy = targetCanvas ? (targetCanvas.workspace_y || 0) : 0;
+                    // v0.8.5.3 fix: Show Look / Data / Power views render
+                    // each canvas at its show_workspace_x/y (when set) —
+                    // the export pan must match or the captured PNG comes
+                    // out shifted and missing layers that live at
+                    // negative-relative show positions.
+                    const isShowExport = (view === 'show-look' || view === 'data-flow' || view === 'power');
+                    let wsx = 0, wsy = 0;
+                    if (targetCanvas) {
+                        if (isShowExport) {
+                            wsx = (targetCanvas.show_workspace_x == null
+                                ? (targetCanvas.workspace_x || 0)
+                                : (targetCanvas.show_workspace_x || 0));
+                            wsy = (targetCanvas.show_workspace_y == null
+                                ? (targetCanvas.workspace_y || 0)
+                                : (targetCanvas.show_workspace_y || 0));
+                        } else {
+                            wsx = targetCanvas.workspace_x || 0;
+                            wsy = targetCanvas.workspace_y || 0;
+                        }
+                    }
                     window.canvasRenderer.panX = -wsx;
                     window.canvasRenderer.panY = -wsy;
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.5.3</title>
+    <title>LED Raster Designer v0.8.5.4</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5.4</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
- Multi-view export (PNG / PSD / PDF) on Show Look / Data / Power views now pans by the canvas's `show_workspace_x/y` (matching the on-screen renderer) instead of `workspace_x/y`. Fixes exports being shifted to the left and clipping layers that lived past the show-only edge.