### PR TITLE
v0.8.6: per-canvas wiring perspective

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.5.4
+# LED Raster Designer v0.8.6
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,27 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.6 - May 5, 2026
+----------------------------
+- FEATURE: Per-canvas wiring perspective. Front / Back perspective is now
+  truly independent per canvas in Data Flow and Power views — c1 can show
+  Front while c2 shows Back at the same time on screen. Previously the
+  perspective field was per-canvas in data, but the renderer applied a
+  single global mirror to the whole workspace based on the active canvas,
+  so toggling Back on one canvas visually flipped them all (or none).
+- FEATURE: Per-canvas perspective overrides in the Export dialog. Each
+  canvas row in the Canvases section now has Data: Front/Back and
+  Power: Front/Back dropdowns. Set them per canvas before export — the
+  values are applied just for the export pass and then restored.
+  Defaults to whatever the canvas currently shows on screen.
+- CHANGE: BACK VIEW badge anchors to each mirrored canvas's top-right
+  corner instead of the global viewport corner. Mixed-perspective
+  workspaces show one badge per back-view canvas.
+- INTERNAL: Hit-testing (Shift+Drag, marquee, right-click on Data /
+  Power) now picks the mirror axis from the canvas under the cursor
+  instead of the workspace bounding box, so cross-canvas drags land
+  correctly when canvases are in different perspectives.
+
 v0.8.5.4 - May 4, 2026
 ----------------------------
 - FIX: Multi-view export (PNG / PSD / PDF) on Show Look / Data / Power

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.5.4',
-            'CFBundleVersion': '0.8.5.4',
+            'CFBundleShortVersionString': '0.8.6',
+            'CFBundleVersion': '0.8.6',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7786,16 +7786,22 @@ class LEDRasterApp {
         };
     }
 
-    getExportSuffixForView(view, suffixes, viewNames) {
+    getExportSuffixForView(view, suffixes, viewNames, canvas) {
         const raw = (suffixes && typeof suffixes[view] === 'string') ? suffixes[view].trim() : '';
         let suffix = raw || viewNames[view];
-        // Append _back when this view is in back perspective
-        if (this.project) {
-            const perspectiveKey = view === 'data-flow' ? 'data_flow_perspective'
-                : view === 'power' ? 'power_perspective'
-                : null;
-            if (perspectiveKey && this.project[perspectiveKey] === 'back') {
-                if (!/_back$/i.test(suffix)) suffix = `${suffix}_back`;
+        // v0.8.6: perspective is per-canvas. When exporting a specific
+        // canvas, read THAT canvas's perspective (not the project-root
+        // legacy field). For legacy single-canvas projects (canvas=null)
+        // fall back to the project root field.
+        const perspectiveKey = view === 'data-flow' ? 'data_flow_perspective'
+            : view === 'power' ? 'power_perspective'
+            : null;
+        if (perspectiveKey) {
+            const value = canvas
+                ? canvas[perspectiveKey]
+                : (this.project && this.project[perspectiveKey]);
+            if (value === 'back' && !/_back$/i.test(suffix)) {
+                suffix = `${suffix}_back`;
             }
         }
         return suffix;
@@ -7869,6 +7875,38 @@ class LEDRasterApp {
             label.appendChild(swatch);
             label.appendChild(text);
             row.appendChild(label);
+            // v0.8.6: per-canvas perspective overrides for Data + Power
+            // exports. Default to whatever the canvas currently has.
+            // These dropdowns set/restore the canvas's perspective during
+            // export only — they don't persist back to the project.
+            const persp = document.createElement('div');
+            persp.style.cssText = 'display:flex;gap:8px;margin-left:22px;font-size:11px;color:#aaa;align-items:center;';
+            const mkSel = (kind, current) => {
+                const wrap = document.createElement('span');
+                wrap.style.cssText = 'display:inline-flex;gap:4px;align-items:center;';
+                const lbl = document.createElement('span');
+                lbl.textContent = kind === 'data' ? 'Data:' : 'Power:';
+                const sel = document.createElement('select');
+                sel.className = `export-canvas-perspective export-canvas-perspective-${kind}`;
+                sel.dataset.canvasId = c.id;
+                sel.dataset.kind = kind;
+                sel.style.cssText = 'background:#222;color:#ddd;border:1px solid #444;border-radius:3px;padding:1px 4px;font-size:11px;';
+                ['front', 'back'].forEach(v => {
+                    const o = document.createElement('option');
+                    o.value = v;
+                    o.textContent = v === 'front' ? 'Front' : 'Back';
+                    if (v === current) o.selected = true;
+                    sel.appendChild(o);
+                });
+                wrap.appendChild(lbl);
+                wrap.appendChild(sel);
+                return wrap;
+            };
+            const curData = (c.data_flow_perspective === 'back') ? 'back' : 'front';
+            const curPower = (c.power_perspective === 'back') ? 'back' : 'front';
+            persp.appendChild(mkSel('data', curData));
+            persp.appendChild(mkSel('power', curPower));
+            row.appendChild(persp);
             list.appendChild(row);
         });
     }
@@ -7917,6 +7955,31 @@ class LEDRasterApp {
         const canvases = (this.project && Array.isArray(this.project.canvases))
             ? this.project.canvases : [];
         const visibilitySnapshot = canvases.map(c => ({ id: c.id, visible: c.visible }));
+        // v0.8.6: snapshot every canvas's perspective so we can apply the
+        // export-dialog overrides per pass and restore at the end. Read
+        // the per-canvas perspective dropdowns once up-front.
+        const perspectiveSnapshot = canvases.map(c => ({
+            id: c.id,
+            data_flow_perspective: c.data_flow_perspective,
+            power_perspective: c.power_perspective,
+        }));
+        const perspectiveOverrides = {};
+        document.querySelectorAll('.export-canvas-perspective').forEach(sel => {
+            const cid = sel.dataset.canvasId;
+            const kind = sel.dataset.kind;
+            if (!cid || !kind) return;
+            if (!perspectiveOverrides[cid]) perspectiveOverrides[cid] = {};
+            const key = kind === 'data' ? 'data_flow_perspective' : 'power_perspective';
+            perspectiveOverrides[cid][key] = (sel.value === 'back') ? 'back' : 'front';
+        });
+        // Apply overrides to every canvas BEFORE the per-canvas/per-view
+        // loop so each render call sees the user's chosen perspective.
+        canvases.forEach(c => {
+            const o = perspectiveOverrides[c.id];
+            if (!o) return;
+            if (o.data_flow_perspective) c.data_flow_perspective = o.data_flow_perspective;
+            if (o.power_perspective) c.power_perspective = o.power_perspective;
+        });
 
         const exportCanvas = document.createElement('canvas');
         const exportCtx = exportCanvas.getContext('2d', { alpha: useTransparentBg });
@@ -7986,7 +8049,7 @@ class LEDRasterApp {
                     window.canvasRenderer.render();
 
                     const dataUrl = exportCanvas.toDataURL('image/png');
-                    const suffix = this.getExportSuffixForView(view, suffixes, viewNames);
+                    const suffix = this.getExportSuffixForView(view, suffixes, viewNames, targetCanvas);
                     const canvasName = targetCanvas
                         ? this.sanitizeFilename(targetCanvas.name || 'Canvas')
                         : null;
@@ -8014,10 +8077,16 @@ class LEDRasterApp {
                 }
             }
         } finally {
-            // Restore canvas visibility, active canvas, renderer state.
+            // Restore canvas visibility, perspective, active canvas, renderer state.
             visibilitySnapshot.forEach(s => {
                 const c = canvases.find(c => c && c.id === s.id);
                 if (c) c.visible = s.visible;
+            });
+            perspectiveSnapshot.forEach(s => {
+                const c = canvases.find(c => c && c.id === s.id);
+                if (!c) return;
+                c.data_flow_perspective = s.data_flow_perspective;
+                c.power_perspective = s.power_perspective;
             });
             if (this.project) this.project.active_canvas_id = originalActiveCanvasId;
             window.canvasRenderer.canvas = mainCanvas;

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -181,22 +181,32 @@ class CanvasRenderer {
      * / _strokeText so they stay readable.
      */
     isMirroredView() {
+        // v0.8.6: perspective is fully per-canvas. The legacy global-mirror
+        // path is gone (each canvas applies its own mirror inside the render
+        // loop). This now answers "is ANY visible canvas mirrored in the
+        // current view" — used to gate the BACK VIEW badge layer and to
+        // short-circuit hit-test unmirror when nothing is mirrored.
+        if (this.viewMode !== 'data-flow' && this.viewMode !== 'power') return false;
         if (!window.app || !window.app.project) return false;
-        // v0.8 Slice 8: perspective is per-canvas. Read from the active
-        // canvas first; fall back to the project root for legacy projects
-        // that haven't been migrated (and the synthetic canvasesToRender
-        // entry built at render() for pre-Slice-1 fallbacks).
         const proj = window.app.project;
-        const active = (typeof window.app._activeCanvas === 'function')
-            ? window.app._activeCanvas() : null;
-        if (this.viewMode === 'data-flow') {
-            const v = (active && active.data_flow_perspective) || proj.data_flow_perspective;
-            return v === 'back';
+        const arr = Array.isArray(proj.canvases) ? proj.canvases : [];
+        if (arr.length === 0) {
+            // Pre-Slice-1 legacy projects: read project-root field.
+            const key = this.viewMode === 'data-flow' ? 'data_flow_perspective' : 'power_perspective';
+            return proj[key] === 'back';
         }
-        if (this.viewMode === 'power') {
-            const v = (active && active.power_perspective) || proj.power_perspective;
-            return v === 'back';
-        }
+        return arr.some(c => c && c.visible !== false && this._isCanvasMirrored(c));
+    }
+
+    /**
+     * v0.8.6: per-canvas perspective check. Each canvas can independently
+     * be in Front or Back view. Used by the per-canvas mirror transform
+     * applied during render and by hit-testing.
+     */
+    _isCanvasMirrored(canvas) {
+        if (!canvas) return false;
+        if (this.viewMode === 'data-flow') return canvas.data_flow_perspective === 'back';
+        if (this.viewMode === 'power') return canvas.power_perspective === 'back';
         return false;
     }
 
@@ -407,30 +417,50 @@ class CanvasRenderer {
         };
     }
     
-    // When the active view is mirrored (Back perspective), the canvas is
-    // flipped horizontally for display only. Mouse coordinates are still in
-    // un-mirrored screen space, so we have to flip them back into layer
-    // coordinates before any hit-testing / drag math.
-    _unmirrorWorldX(worldX) {
+    // When the canvas under the cursor is in Back perspective, its content
+    // is flipped horizontally for display only. Mouse coordinates are still
+    // in un-mirrored screen space, so we have to flip them back into layer
+    // coordinates before any hit-testing / drag math. v0.8.6: per-canvas
+    // — find the canvas under the cursor and mirror around its own right
+    // edge. Points outside any canvas (or over an unmirrored canvas) pass
+    // through unchanged.
+    _unmirrorWorldX(worldX, worldY) {
         if (!this.isMirroredView()) return worldX;
-        // v0.8 Slice 8 fix: mirror axis is the workspace bounds, not the
-        // active canvas's raster, otherwise multi-canvas workspaces flip
-        // off-screen because workspace_x can be far past rasterWidth.
-        const k = this._mirrorAxisX();
-        return k - worldX;
+        // Legacy single-canvas projects: keep the old workspace-bbox mirror.
+        const arr = (window.app && window.app.project && window.app.project.canvases) || [];
+        if (!Array.isArray(arr) || arr.length === 0) {
+            const k = this._mirrorAxisX();
+            return k - worldX;
+        }
+        if (worldY == null) {
+            // Caller didn't pass worldY (legacy callsite). Fall back to the
+            // active canvas, since most interactions happen in it.
+            const active = (window.app && typeof window.app._activeCanvas === 'function')
+                ? window.app._activeCanvas() : null;
+            if (active && this._isCanvasMirrored(active)) {
+                const ws = this._canvasWorkspace(active);
+                const useShow = this.isShowLookView();
+                const w = (useShow && active.show_raster_width) || active.raster_width || 0;
+                return 2 * ws.wx + w - worldX;
+            }
+            return worldX;
+        }
+        const c = this._canvasAtPoint(worldX, worldY);
+        if (!c || !this._isCanvasMirrored(c)) return worldX;
+        const ws = this._canvasWorkspace(c);
+        const useShow = this.isShowLookView();
+        const w = (useShow && c.show_raster_width) || c.raster_width || 0;
+        return 2 * ws.wx + w - worldX;
     }
 
     /**
-     * The Canvas2D translate-X used as the mirror axis when Back perspective
-     * is active. We mirror around the workspace bounding box so points stay
-     * in the same x-range after the flip, single-canvas projects degrade to
-     * mirroring around rasterWidth (legacy behaviour) automatically because
-     * their bbox.x is 0 and bbox.w == rasterWidth.
+     * Legacy mirror axis for pre-Slice-1 single-canvas projects only.
+     * Multi-canvas projects (v0.8+) mirror per-canvas around each canvas's
+     * own right edge — see _unmirrorWorldX and the per-canvas mirror block
+     * inside the render loop.
      */
     _mirrorAxisX() {
         const bb = this._workspaceBounds();
-        // K such that K - x maps left edge to right edge of bbox:
-        //   K - bbox.x = bbox.x + bbox.w  →  K = 2*bbox.x + bbox.w
         return 2 * (bb.x || 0) + (bb.width || this.rasterWidth);
     }
 
@@ -509,8 +539,8 @@ class CanvasRenderer {
         const rect = this.canvas.getBoundingClientRect();
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
-        const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
+        const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom, worldY);
 
         // Slice 5: dragging a canvas's dashed outline edge repositions
         // the canvas in the workspace. Must be checked BEFORE the Slice 4
@@ -914,8 +944,8 @@ class CanvasRenderer {
         const rect = this.canvas.getBoundingClientRect();
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
-        const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom);
         const worldY = (mouseY - this.panY) / this.zoom;
+        const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom, worldY);
 
         // Slice 5: live canvas-drag, update workspace_x/y on every move,
         // but only PUT to the server on mouseup (avoid flooding).
@@ -1374,8 +1404,9 @@ class CanvasRenderer {
             this._crossCanvasDropTarget = null;
 
             if (window.app && window.app.currentLayer) {
-                const dx = Math.round(this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom) - this.dragLayerStartX);
-                const dy = Math.round(((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom - this.dragLayerStartY);
+                const _dropWY = ((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom;
+                const dx = Math.round(this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom, _dropWY) - this.dragLayerStartX);
+                const dy = Math.round(_dropWY - this.dragLayerStartY);
                 
                 let snapDx = dx;
                 let snapDy = dy;
@@ -1453,8 +1484,8 @@ class CanvasRenderer {
                 if (primaryCanvas) {
                     // Mouse cursor world coords at drop (already computed
                     // above for the offset delta).
-                    const cursorWX = this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom);
                     const cursorWY = ((e.clientY - this.canvas.getBoundingClientRect().top) - this.panY) / this.zoom;
+                    const cursorWX = this._unmirrorWorldX(((e.clientX - this.canvas.getBoundingClientRect().left) - this.panX) / this.zoom, cursorWY);
                     const targetCanvas = this._canvasAtPoint(cursorWX, cursorWY);
                     if (targetCanvas && targetCanvas.id !== primaryCanvasId) {
                         const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
@@ -1611,8 +1642,8 @@ class CanvasRenderer {
         // single-panel selection so the menu actions target it.
         if (this.viewMode === 'pixel-map' && window.app.currentLayer) {
             const rect = this.canvas.getBoundingClientRect();
-            const worldX = this._unmirrorWorldX(((e.clientX - rect.left) - this.panX) / this.zoom);
             const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
+            const worldX = this._unmirrorWorldX(((e.clientX - rect.left) - this.panX) / this.zoom, worldY);
             const clicked = this.getPanelAt(worldX, worldY);
             // Right-click works on hidden panels too, the menu shows
             // "Restore From Blank" so they can be brought back.
@@ -2175,18 +2206,23 @@ class CanvasRenderer {
         // Round pan values to prevent sub-pixel anti-aliasing seams between panels
         this.ctx.setTransform(this.zoom, 0, 0, this.zoom, Math.round(this.panX), Math.round(this.panY));
 
-        // Wiring view perspective: in 'back' view, mirror the entire
-        // geometry around the right edge of the raster so techs working
-        // behind the wall see things from their perspective. _fillText /
-        // _strokeText un-mirror text glyphs so labels stay readable. The
-        // _mirror flag drives both the canvas transform and the text
-        // helpers below.
-        this._mirror = this.isMirroredView();
-        if (this._mirror) {
-            // v0.8 Slice 8: mirror axis is the workspace bounding-box right
-            // edge so multi-canvas workspaces stay on-screen when flipped.
-            // Single-canvas legacy projects naturally land at this.rasterWidth
-            // because their bbox is (0, 0, rasterWidth, rasterHeight).
+        // v0.8.6: Wiring-view perspective is per-canvas. Each canvas
+        // independently applies its own mirror transform inside the
+        // per-canvas render loop below (around its own right edge), so c1
+        // can show Front while c2 shows Back simultaneously. The legacy
+        // global-mirror block here used to flip the entire workspace
+        // around the bbox right edge, which forced every canvas into the
+        // same perspective. _fillText / _strokeText still key off
+        // this._mirror — that flag is now toggled on/off per canvas as the
+        // loop enters/exits each canvas's draw scope.
+        this._mirror = false;
+        // Legacy single-canvas projects (no canvases array) keep the old
+        // global mirror so v0.7 fallbacks render correctly.
+        const _legacyNoCanvases = !window.app || !window.app.project
+            || !Array.isArray(window.app.project.canvases)
+            || window.app.project.canvases.length === 0;
+        if (_legacyNoCanvases && this.isMirroredView()) {
+            this._mirror = true;
             this.ctx.translate(this._mirrorAxisX(), 0);
             this.ctx.scale(-1, 1);
         }
@@ -2231,10 +2267,26 @@ class CanvasRenderer {
         const _withLayerWs = (layer, fn) => {
             if (_layerCanvasHidden(layer)) return;
             const { wx, wy } = _layerWs(layer);
-            if (wx || wy) {
+            // v0.8.6: post-passes (capacity error overlay, selection
+            // bounds) run AFTER the per-canvas render loop popped its
+            // mirror, so re-apply the layer's canvas mirror here too —
+            // otherwise overlays render in un-mirrored space and float
+            // detached from the layer they're badging.
+            const _cid = this._effectiveLayerCanvasId(layer);
+            const _c = _cid ? _canvasById[_cid] : null;
+            const _layerMirror = _c && this._isCanvasMirrored(_c);
+            if (wx || wy || _layerMirror) {
                 this.ctx.save();
-                this.ctx.translate(wx, wy);
+                if (wx || wy) this.ctx.translate(wx, wy);
+                if (_layerMirror) {
+                    const _crw = (this.isShowLookView() && _c.show_raster_width)
+                        || _c.raster_width || 0;
+                    this.ctx.translate(_crw, 0);
+                    this.ctx.scale(-1, 1);
+                    this._mirror = true;
+                }
                 fn();
+                if (_layerMirror) this._mirror = false;
                 this.ctx.restore();
             } else {
                 fn();
@@ -2295,6 +2347,20 @@ class CanvasRenderer {
                 // but the tint shows through in empty regions).
                 if (!this.exportMode && canvas.id && canvas.id === _activeCanvasId) {
                     this._drawActiveCanvasTint(canvas);
+                }
+                // v0.8.6: per-canvas mirror. Each canvas applies its own
+                // Front/Back transform around its own right edge so other
+                // canvases are unaffected. _mirror flag drives label
+                // un-mirroring inside _fillText / _strokeText for the
+                // duration of this canvas's layer pass.
+                const _canvasMirror = this._isCanvasMirrored(canvas);
+                if (_canvasMirror) {
+                    this.ctx.save();
+                    const _crw = (this.isShowLookView() && canvas.show_raster_width)
+                        || canvas.raster_width || 0;
+                    this.ctx.translate(_crw, 0);
+                    this.ctx.scale(-1, 1);
+                    this._mirror = true;
                 }
                 // First pass: render all panels and mode-specific content (except labels)
                 layersInCanvas.forEach(layer => {
@@ -2372,6 +2438,13 @@ class CanvasRenderer {
                     if (needsShift) this.ctx.restore();
                 }
                 });
+                // v0.8.6: pop per-canvas mirror so the outline draws in
+                // un-mirrored space (and so the next canvas's mirror
+                // decision is independent).
+                if (_canvasMirror) {
+                    this.ctx.restore();
+                    this._mirror = false;
+                }
                 // Canvas outline drawn LAST so it sits on top of any
                 // layer content that bleeds outside the raster bounds.
                 if (!this.exportMode) {
@@ -4462,20 +4535,47 @@ class CanvasRenderer {
      * Front view shows nothing (clutter-free default; Front is implied).
      */
     renderPerspectiveBadge() {
+        if (this.viewMode !== 'data-flow' && this.viewMode !== 'power') return;
         if (!this.isMirroredView()) return;
         const label = 'BACK VIEW';
+        const arr = (window.app && window.app.project && Array.isArray(window.app.project.canvases))
+            ? window.app.project.canvases : [];
+        // v0.8.6: per-canvas badge so a mixed-perspective workspace makes
+        // it obvious which canvas is flipped. Legacy single-canvas
+        // projects fall back to the original viewport-corner badge.
+        if (arr.length === 0) {
+            this._drawBackBadgeAt(label, this.canvas.width - 20, 20, 'right');
+            return;
+        }
+        const useShow = this.isShowLookView();
+        arr.forEach(c => {
+            if (!c || c.visible === false) return;
+            if (!this._isCanvasMirrored(c)) return;
+            const ws = this._canvasWorkspace(c);
+            const w = (useShow && c.show_raster_width) || c.raster_width || 0;
+            // World top-right of canvas → screen coords (account for pan/zoom).
+            const screenX = (ws.wx + w) * this.zoom + this.panX;
+            const screenY = ws.wy * this.zoom + this.panY;
+            // Anchor to canvas corner with a small inset; clamp so badge
+            // stays visible if the canvas top-right is offscreen.
+            const x = Math.max(20, Math.min(this.canvas.width - 20, screenX - 8));
+            const y = Math.max(20, Math.min(this.canvas.height - 60, screenY + 8));
+            this._drawBackBadgeAt(label, x, y, 'right');
+        });
+    }
+
+    _drawBackBadgeAt(label, anchorX, anchorY, align) {
         this.ctx.save();
         this.ctx.setTransform(1, 0, 0, 1, 0, 0);
-        const padX = 18;
-        const padY = 10;
-        const fontPx = 16;
+        const padX = 14;
+        const padY = 7;
+        const fontPx = 13;
         this.ctx.font = `700 ${fontPx}px -apple-system, "Segoe UI", sans-serif`;
         const textWidth = this.ctx.measureText(label).width;
         const boxW = textWidth + padX * 2;
         const boxH = fontPx + padY * 2;
-        // Top-right corner so it doesn't overlap the selection badge.
-        const x = this.canvas.width - boxW - 20;
-        const y = 20;
+        const x = align === 'right' ? (anchorX - boxW) : anchorX;
+        const y = anchorY;
         this.ctx.fillStyle = 'rgba(217, 80, 0, 0.95)';
         this.ctx.beginPath();
         if (this.ctx.roundRect) this.ctx.roundRect(x, y, boxW, boxH, 6);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.5.4</title>
+    <title>LED Raster Designer v0.8.6</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.5.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.6</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
- Front/Back perspective is now truly independent per canvas in Data Flow and Power views (previously per-canvas in data, but the renderer applied one global mirror based on the active canvas)
- Each canvas applies its own mirror transform inside the render loop around its own right edge
- Hit-testing picks the mirror axis from the canvas under the cursor
- BACK VIEW badge anchors to each mirrored canvas's top-right corner
- Export dialog gains per-canvas Data: Front/Back and Power: Front/Back dropdowns; overrides apply only for that export run

## Test plan
- [ ] In a multi-canvas project on Data Flow, toggle Back on c1 — only c1 flips
- [ ] Toggle Back on c2 — c1 and c2 both flipped, c3 stays Front; one BACK VIEW badge per flipped canvas
- [ ] Shift+Drag a screen on a Back canvas — drags correctly (hit-test picks the canvas's own mirror axis)
- [ ] Open Export, set per-canvas perspective dropdowns, export — PNGs reflect the chosen perspective; canvas state on screen unchanged after export
- [ ] Single-canvas legacy project still mirrors correctly (legacy fallback path)