### PR TITLE
v0.8.6.1: Screens sidebar groups by view-effective canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.6
+# LED Raster Designer v0.8.6.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,24 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.6.1 - May 5, 2026
+----------------------------
+- FIX: Screens sidebar (right panel) was always grouping layers by
+  Pixel Map canvas membership (`canvas_id`), even on Show Look / Data /
+  Power. So after shift+dragging a layer to a different canvas in
+  Show Look, the canvas correctly redrew under the new canvas's outline
+  but the sidebar still showed it under the old canvas — making it look
+  like the move didn't take. Now the sidebar groups by the layer's
+  view-effective canvas (`show_canvas_id || canvas_id` in Show Look,
+  `canvas_id` in Pixel Map), and re-renders on tab switch so it always
+  matches what's on screen.
+- FIX: Sidebar layer count badge per canvas now reflects the same
+  view-effective grouping, so the count matches the rows shown.
+- FIX: Dropping a layer onto another canvas's group header in the
+  sidebar while on Show Look / Data / Power now sets `show_canvas_id`
+  (the Show Look override) instead of rewriting `canvas_id`. Pixel Map
+  / Cabinet ID drops still rewrite `canvas_id` as before.
+
 v0.8.6 - May 5, 2026
 ----------------------------
 - FEATURE: Per-canvas wiring perspective. Front / Back perspective is now

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.6',
-            'CFBundleVersion': '0.8.6',
+            'CFBundleShortVersionString': '0.8.6.1',
+            'CFBundleVersion': '0.8.6.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2227,6 +2227,12 @@ class LEDRasterApp {
                 });
                 
                 window.canvasRenderer.setViewMode(mode);
+                // v0.8.6.1: re-render the Screens sidebar so groups reflect
+                // the view-effective canvas (Show Look groups by
+                // show_canvas_id; Pixel Map groups by canvas_id).
+                if (typeof this.renderLayers === 'function') {
+                    try { this.renderLayers(); } catch (_) {}
+                }
                 sendClientLog('tab_switch', {
                     tab: mode,
                     currentLayer: this.currentLayer ? { id: this.currentLayer.id, name: this.currentLayer.name } : null,
@@ -10991,6 +10997,14 @@ class LEDRasterApp {
         });
         container.innerHTML = '';
 
+        // v0.8.6.1: pick the layer's view-effective canvas so the sidebar
+        // grouping matches what the canvas is rendering. Show Look / Data /
+        // Power group by `show_canvas_id || canvas_id`; Pixel Map / Cabinet
+        // ID group by `canvas_id`.
+        const isShowView = !!(window.canvasRenderer && window.canvasRenderer.isShowLookView
+            && window.canvasRenderer.isShowLookView());
+        const layerCanvasId = (l) => (isShowView && l.show_canvas_id) ? l.show_canvas_id : l.canvas_id;
+
         // Sidebar shows canvases in array order, with each canvas's
         // (reverse-ordered) layers underneath, matches the existing
         // newest-on-top convention.
@@ -11003,7 +11017,7 @@ class LEDRasterApp {
             // (Photoshop style, newest on top).
             const reversed = [...project.layers].reverse();
             reversed.forEach(layer => {
-                if (layer.canvas_id !== canvas.id) return;
+                if (layerCanvasId(layer) !== canvas.id) return;
                 const node = layerNodes.get(layer.id);
                 if (node) body.appendChild(node);
             });
@@ -11017,7 +11031,13 @@ class LEDRasterApp {
         wrap.dataset.canvasId = canvas.id;
         wrap.style.setProperty('--canvas-color', canvas.color || '#4A90E2');
 
-        const layerCount = (this.project.layers || []).filter(l => l.canvas_id === canvas.id).length;
+        // v0.8.6.1: count by view-effective canvas so the header count
+        // matches the layers actually shown under this group in the
+        // current view (Show Look uses show_canvas_id when set).
+        const _isShowView = !!(window.canvasRenderer && window.canvasRenderer.isShowLookView
+            && window.canvasRenderer.isShowLookView());
+        const _effCid = (l) => (_isShowView && l.show_canvas_id) ? l.show_canvas_id : l.canvas_id;
+        const layerCount = (this.project.layers || []).filter(l => _effCid(l) === canvas.id).length;
         wrap.innerHTML = `
             <div class="canvas-group-header" draggable="true" title="Click to activate · Drag to reorder">
                 <span class="canvas-drag-handle" title="Drag to reorder">⋮⋮</span>
@@ -11139,10 +11159,27 @@ class LEDRasterApp {
                 const onLayerItem = e.target.closest && e.target.closest('.layer-item');
                 if (onLayerItem) return;
                 const draggedLayer = (this.project.layers || []).find(l => l.id === this.dragLayerId);
-                if (draggedLayer && draggedLayer.canvas_id !== canvas.id) {
+                if (!draggedLayer) return;
+                // v0.8.6.1: in Show Look / Data / Power, dropping onto a
+                // canvas group rewrites show_canvas_id (Show Look layer
+                // membership) so Pixel Map's canvas_id stays untouched.
+                // Pixel Map / Cabinet ID drops still rewrite canvas_id.
+                const _isShowView = !!(window.canvasRenderer
+                    && window.canvasRenderer.isShowLookView
+                    && window.canvasRenderer.isShowLookView());
+                const effCid = _isShowView
+                    ? (draggedLayer.show_canvas_id || draggedLayer.canvas_id)
+                    : draggedLayer.canvas_id;
+                if (effCid !== canvas.id) {
                     e.preventDefault();
-                    const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
-                    this.moveLayerToCanvas(draggedLayer.id, canvas.id, mode);
+                    if (_isShowView) {
+                        if (typeof this.moveLayerShowCanvas === 'function') {
+                            this.moveLayerShowCanvas(draggedLayer.id, canvas.id);
+                        }
+                    } else {
+                        const mode = (e.metaKey || e.altKey) ? 'duplicate' : 'move';
+                        this.moveLayerToCanvas(draggedLayer.id, canvas.id, mode);
+                    }
                 }
             }
         });

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.6</title>
+    <title>LED Raster Designer v0.8.6.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.6</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.6.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
- Right Screens panel was always grouping by Pixel Map `canvas_id`, even on Show Look / Data / Power. After shift+dragging a layer cross-canvas in Show Look the canvas updated correctly but the sidebar didn't, making it look like the move didn't take.
- Sidebar now groups by `show_canvas_id || canvas_id` on Show Look / Data / Power and by `canvas_id` on Pixel Map / Cabinet ID. Re-renders on tab switch.
- Per-group layer-count badge uses the same effective grouping.
- Dropping a layer onto another group's header on Show Look writes `show_canvas_id` (override) instead of rewriting `canvas_id`.

## Test plan
- [x] Multi-canvas project on Show Look: shift+drag layer cross-canvas, sidebar updates immediately
- [x] Switch to Pixel Map: original groupings come back
- [x] Sidebar drag-drop onto another canvas header on Show Look only changes Show Look membership