### PR TITLE
v0.8.6.2: marquee select uses view-effective canvas in Show Look

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.6.1
+# LED Raster Designer v0.8.6.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,20 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.6.2 - May 5, 2026
+----------------------------
+- FIX: Marquee select on Show Look / Data Flow / Power was hit-testing
+  layers using their Pixel Map canvas position instead of their Show
+  Look canvas position. Result: drawing a selection rect inside one
+  canvas could pick up layers that visually live in different canvases
+  (because their processor coords overlap once you collapse the
+  workspace). The hit-test now routes through `show_canvas_id` and
+  `show_workspace_x/y`, and adds the per-layer `showOffsetX/Y`, so the
+  rect math matches what's drawn on screen.
+- FIX: Same routing applied to per-panel marquee selection on Data
+  Flow custom-flow mode and Power custom-power mode (they use the same
+  workspace-offset helper internally).
+
 v0.8.6.1 - May 5, 2026
 ----------------------------
 - FIX: Screens sidebar (right panel) was always grouping layers by

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.6.1',
-            'CFBundleVersion': '0.8.6.1',
+            'CFBundleShortVersionString': '0.8.6.2',
+            'CFBundleVersion': '0.8.6.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -5911,15 +5911,46 @@ class LEDRasterApp {
     // rect-test that compares workspace-coord rectangles against panel-coord
     // (canvas-relative) panel positions. Returns {wx:0, wy:0} for legacy
     // single-canvas projects so existing math is unaffected.
+    // v0.8.6.2: in Show Look / Data / Power, route through the layer's
+    // effective canvas (show_canvas_id || canvas_id) and the canvas's
+    // show_workspace_x/y so marquee hit-test lines up with what's drawn.
+    // Also includes the per-layer showOffset since show views render at
+    // processor offset + showOffset.
     _getLayerWorkspaceOffset(layer) {
         if (!layer || !this.project) return { wx: 0, wy: 0 };
+        const isShowView = !!(window.canvasRenderer && window.canvasRenderer.isShowLookView
+            && window.canvasRenderer.isShowLookView());
         const arr = this.project.canvases;
-        if (!Array.isArray(arr) || arr.length === 0) return { wx: 0, wy: 0 };
-        const cid = layer.canvas_id;
-        if (!cid) return { wx: 0, wy: 0 };
-        for (const c of arr) {
-            if (c && c.id === cid) return { wx: c.workspace_x || 0, wy: c.workspace_y || 0 };
+        if (Array.isArray(arr) && arr.length > 0) {
+            const cid = isShowView
+                ? (layer.show_canvas_id || layer.canvas_id)
+                : layer.canvas_id;
+            const c = cid ? arr.find(x => x && x.id === cid) : null;
+            if (c) {
+                let wx, wy;
+                if (isShowView) {
+                    wx = (c.show_workspace_x == null ? (c.workspace_x || 0) : (c.show_workspace_x || 0));
+                    wy = (c.show_workspace_y == null ? (c.workspace_y || 0) : (c.show_workspace_y || 0));
+                } else {
+                    wx = c.workspace_x || 0;
+                    wy = c.workspace_y || 0;
+                }
+                if (isShowView) {
+                    // Show Look render offset is (showOffset - layer.offset),
+                    // not raw showOffset, because getLayerBounds returns
+                    // panel coords that already include layer.offset_x/y.
+                    // Mirrors canvas.js getLayerRenderOffset.
+                    const procX = Number(layer.offset_x) || 0;
+                    const procY = Number(layer.offset_y) || 0;
+                    const showX = (layer.showOffsetX != null) ? Number(layer.showOffsetX) : procX;
+                    const showY = (layer.showOffsetY != null) ? Number(layer.showOffsetY) : procY;
+                    wx += (showX - procX);
+                    wy += (showY - procY);
+                }
+                return { wx, wy };
+            }
         }
+        // Pre-Slice-1 / orphan-layer fallback: no canvases array.
         return { wx: 0, wy: 0 };
     }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.6.1</title>
+    <title>LED Raster Designer v0.8.6.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.6.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.6.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
- Marquee select on Show Look / Data Flow / Power was using Pixel Map canvas position + canvas_id, so a rect drawn inside one canvas could pick up layers belonging to other canvases (their processor coords overlapped at the same workspace origin).
- Workspace-offset helper now routes through `show_canvas_id`, `show_workspace_x/y`, and applies the renderer's `(showOffset - layer.offset)` shift.
- Same fix applies to per-panel marquee on Data Flow custom-flow and Power custom-power.

## Test plan
- [x] Multi-canvas Show Look, marquee inside one canvas only selects that canvas's layers
- [x] Pixel Map marquee unchanged