### PR TITLE
v0.8.7: PSD export scale + pipeline fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.6.3
+# LED Raster Designer v0.8.7
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,46 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7 - May 5, 2026
+----------------------------
+- FEATURE: PSD export Resolution Scale option (1x / 2x / 4x / 8x).
+  When chosen, the PSD is rendered at scale × native raster resolution.
+  Vector content (panels, labels, arrows, text) renders crisp at the
+  higher size — no upscaling artifacts when zooming in or printing
+  large in Photoshop. Image layers will sample up from their source
+  resolution, so they look softer if the source is lower res.
+  PSD layer metadata (offsets / widths / heights) is scaled to match
+  so layer rectangles still line up with the rendered pixels.
+  Scale option is hidden for PNG / PDF / Resolume XML formats.
+  Auto-clamps per canvas + view to keep PSD dimensions under 16000px
+  (browsers cap 2D canvas dimensions at 16384 in Chrome / 32767 in
+  Firefox, so we use the conservative limit; PSD format itself goes
+  to 30000 but the rendered image has to fit in a browser canvas
+  first). A status message reports the actual scale used if it had
+  to be reduced.
+- FIX: Pillow's default 89-megapixel "decompression bomb" guard was
+  rejecting large PSD scale exports server-side. Disabled for our own
+  trusted renderer input.
+- FIX: Per-canvas Front/Back perspective dropdowns in the Export modal
+  now update the filename preview live (was reading the underlying
+  canvas state, ignoring the user's modal override).
+- FIX: Screen-name labels on Cabinet ID / Data Flow / Power were
+  snapping back to their previous position whenever the user clicked a
+  layer in a different canvas. `setActiveCanvas` was overwriting the
+  whole `this.project` object with the server response (which doesn't
+  carry the client-side-only `screenNameOffset*` per-view fields), so
+  the freshly-dragged label position got wiped every canvas switch.
+  Now syncs only `active_canvas_id` from that response.
+- FIX: Native-save-dialog file write was failing on large PSD blobs
+  (26 MB+) because the client was JSON-encoding the entire base64 data
+  URI and the resulting ~36 MB JSON string allocation either OOM'd or
+  arrived at the server with an empty body (logged as
+  `has_data: false`). Switched to multipart/form-data so the blob
+  streams to the server without the giant string allocation.
+- FIX: PSD export errors now surface the actual server error message
+  (e.g., dimension limit, out-of-memory) instead of a generic
+  "Failed to create PSD".
+
 v0.8.6.3 - May 5, 2026
 ----------------------------
 Audit follow-ups for the Show Look canvas-membership refactor. Several

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,14 @@ import subprocess
 from PIL import Image
 import numpy as np
 
+# v0.8.7: Pillow's default decompression-bomb guard refuses images larger
+# than ~89 megapixels. Our PSD scale feature legitimately produces images
+# up to PSD's 30000×30000 limit (~900 megapixels), and the input is our
+# own renderer (no untrusted file path). Disable the guard so high-scale
+# PSD exports don't fail with "Image size exceeds limit ... could be
+# decompression bomb DOS attack".
+Image.MAX_IMAGE_PIXELS = None
+
 # Support PyInstaller --onedir bundle: resolve templates/static from _MEIPASS
 if getattr(sys, 'frozen', False):
     BASE_DIR = sys._MEIPASS
@@ -2583,15 +2591,38 @@ def native_dialog_select_directory():
 
 @app.route('/api/native-dialog/write-file', methods=['POST'])
 def native_dialog_write_file():
-    data = request.get_json() or {}
-    file_path = data.get('path')
-    data_url = data.get('data_url')
-    if not file_path or not data_url:
-        log_event('native_dialog_write_file_invalid', {'has_path': bool(file_path), 'has_data': bool(data_url)})
-        return jsonify({'ok': False, 'error': 'path and data_url are required'}), 400
+    """Write blob bytes to a chosen path on disk.
+
+    Accepts EITHER:
+      - JSON body with {path, data_url} where data_url is a base64 data URI
+        (legacy v0.8.6 path; works for small blobs but blows up JSON.stringify
+        on the client when the blob exceeds ~25 MB).
+      - multipart/form-data with `path` field and `file` field (v0.8.7+).
+        This skips the JSON string allocation and is the only path large PSD
+        exports survive — the client streams the raw blob to the server.
+    """
+    file_path = None
+    content = None
+    if request.content_type and request.content_type.startswith('multipart/form-data'):
+        file_path = request.form.get('path')
+        f = request.files.get('file')
+        if f is not None:
+            content = f.read()
+    else:
+        data = request.get_json(silent=True) or {}
+        file_path = data.get('path')
+        data_url = data.get('data_url')
+        if data_url:
+            try:
+                content = decode_base64_bytes(data_url)
+            except Exception as e:
+                log_event('native_dialog_write_file_decode_error', {'error': str(e)})
+                content = None
+    if not file_path or content is None:
+        log_event('native_dialog_write_file_invalid', {'has_path': bool(file_path), 'has_data': content is not None})
+        return jsonify({'ok': False, 'error': 'path and file/data_url are required'}), 400
     try:
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
-        content = decode_base64_bytes(data_url)
         with open(file_path, 'wb') as f:
             f.write(content)
         exists = os.path.exists(file_path)

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.6.3',
-            'CFBundleVersion': '0.8.6.3',
+            'CFBundleShortVersionString': '0.8.7',
+            'CFBundleVersion': '0.8.7',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -3890,6 +3890,10 @@ class LEDRasterApp {
             // Slice 11: rebuild canvas checklist on every open so renames /
             // additions / deletions show up. Visible canvases default-checked.
             this.populateExportCanvasesList();
+            // v0.8.7: re-evaluate Scale row visibility on open (the user
+            // may have changed format last session and reopened later).
+            const _f = document.getElementById('export-format');
+            if (_f) _f.dispatchEvent(new Event('change'));
             // Update preview
             this.updateExportPreview();
         });
@@ -3909,6 +3913,20 @@ class LEDRasterApp {
                 });
             }
         });
+
+        // v0.8.7: PSD-only Resolution Scale row. Hide it for any other
+        // format so the option only surfaces when it actually applies.
+        const _toggleScaleRow = () => {
+            const formatEl = document.getElementById('export-format');
+            const scaleRow = document.getElementById('export-scale-row');
+            if (!formatEl || !scaleRow) return;
+            scaleRow.style.display = (formatEl.value === 'psd') ? '' : 'none';
+        };
+        const _formatEl = document.getElementById('export-format');
+        if (_formatEl) {
+            _formatEl.addEventListener('change', _toggleScaleRow);
+            _toggleScaleRow();
+        }
         
         document.getElementById('export-cancel').addEventListener('click', () => {
             document.getElementById('export-modal').style.display = 'none';
@@ -7756,6 +7774,26 @@ class LEDRasterApp {
                 : `${projectName} ${suffix}.${ext}`;
         };
 
+        // v0.8.7.1: read per-canvas perspective dropdowns so the filename
+        // preview reflects the user's modal override, not the underlying
+        // canvas state. Build a synthetic canvas object per cid with the
+        // override applied for the suffix calculation.
+        const overrideByCid = {};
+        document.querySelectorAll('.export-canvas-perspective').forEach(sel => {
+            const cid = sel.dataset.canvasId;
+            const kind = sel.dataset.kind;
+            if (!cid || !kind) return;
+            if (!overrideByCid[cid]) overrideByCid[cid] = {};
+            const key = kind === 'data' ? 'data_flow_perspective' : 'power_perspective';
+            overrideByCid[cid][key] = (sel.value === 'back') ? 'back' : 'front';
+        });
+        const canvasForSuffix = (cid) => {
+            if (!cid) return null;
+            const c = (this.project && this.project.canvases || []).find(x => x && x.id === cid);
+            if (!c) return null;
+            return Object.assign({}, c, overrideByCid[cid] || {});
+        };
+
         if (format === 'pdf') {
             const pageCount = canvasIds.length * views.length;
             preview.textContent = `${projectName}.pdf (${pageCount} page${pageCount > 1 ? 's' : ''})`;
@@ -7763,8 +7801,9 @@ class LEDRasterApp {
             const ext = format;
             const lines = [];
             for (const cid of canvasIds) {
+                const cForSuffix = canvasForSuffix(cid);
                 for (const v of views) {
-                    const suffix = this.getExportSuffixForView(v, suffixes, viewNames);
+                    const suffix = this.getExportSuffixForView(v, suffixes, viewNames, cForSuffix);
                     lines.push(buildName(cid, suffix, ext));
                 }
             }
@@ -7947,6 +7986,9 @@ class LEDRasterApp {
                     if (v === current) o.selected = true;
                     sel.appendChild(o);
                 });
+                // v0.8.7.1: refresh filename preview when this dropdown
+                // changes so the user sees _back / no-suffix instantly.
+                sel.addEventListener('change', () => this.updateExportPreview());
                 wrap.appendChild(lbl);
                 wrap.appendChild(sel);
                 return wrap;
@@ -8034,7 +8076,24 @@ class LEDRasterApp {
         const exportCtx = exportCanvas.getContext('2d', { alpha: useTransparentBg });
         window.canvasRenderer.canvas = exportCanvas;
         window.canvasRenderer.ctx = exportCtx;
-        window.canvasRenderer.zoom = 1.0;
+        // v0.8.7: optional resolution-scale multiplier (PSD only). Native
+        // scale = 1 (existing behavior for PNG/PDF). Higher values render
+        // PSD at scale × native raster so vector content (panels, labels,
+        // arrows, text) stays crisp at higher zoom in Photoshop. PNG/PDF
+        // skip the scale (their use cases don't benefit and the larger
+        // file sizes would surprise users).
+        // The actual scale used is clamped per pass to keep PSD dimensions
+        // under PSD format's 30000×30000 hard limit (PSB is bigger but
+        // pytoshop only writes classic PSD). Computed inside the loop.
+        const scaleSel = document.getElementById('export-scale');
+        const requestedScale = scaleSel ? Math.max(1, Math.min(8, Number(scaleSel.value) || 1)) : 1;
+        // v0.8.7: PSD format max dimension is 30000px, but browsers cap
+        // 2D canvas at much lower (Chrome: 16384, Safari/FF higher). The
+        // toDataURL on an oversized canvas silently returns "data:," and
+        // the server can't parse the empty image. Use 16000 to stay
+        // within Chrome's hard cap with a safety margin.
+        const PSD_MAX_DIM = 16000;
+        let scaleClampedAnywhere = false;
         window.canvasRenderer.exportMode = true;
         window.canvasRenderer.exportTransparentBg = useTransparentBg;
 
@@ -8067,8 +8126,25 @@ class LEDRasterApp {
                     // show-look (so Show Look exports at its own resolution).
                     const rasterWidth = window.canvasRenderer.rasterWidth || 1920;
                     const rasterHeight = window.canvasRenderer.rasterHeight || 1080;
-                    exportCanvas.width = rasterWidth;
-                    exportCanvas.height = rasterHeight;
+                    // v0.8.7: per-pass PSD scale, clamped so the resulting
+                    // image dimensions stay under PSD's 30000×30000 hard
+                    // limit. PNG/PDF always run at 1x. If the user picked
+                    // 8x but the canvas is too big, we silently use the
+                    // largest scale that fits and surface a single status
+                    // message after the export completes.
+                    let exportScale = (format === 'psd') ? requestedScale : 1;
+                    if (exportScale > 1) {
+                        const maxScaleByWidth = Math.floor(PSD_MAX_DIM / rasterWidth);
+                        const maxScaleByHeight = Math.floor(PSD_MAX_DIM / rasterHeight);
+                        const maxSafe = Math.max(1, Math.min(maxScaleByWidth, maxScaleByHeight));
+                        if (exportScale > maxSafe) {
+                            exportScale = maxSafe;
+                            scaleClampedAnywhere = true;
+                        }
+                    }
+                    window.canvasRenderer.zoom = exportScale;
+                    exportCanvas.width = rasterWidth * exportScale;
+                    exportCanvas.height = rasterHeight * exportScale;
                     // Translate the workspace so this canvas's top-left
                     // (workspace_x, workspace_y) lands at (0, 0) in the
                     // export canvas. Legacy: pan to 0,0.
@@ -8092,8 +8168,12 @@ class LEDRasterApp {
                             wsy = targetCanvas.workspace_y || 0;
                         }
                     }
-                    window.canvasRenderer.panX = -wsx;
-                    window.canvasRenderer.panY = -wsy;
+                    // v0.8.7: panX/panY are in screen pixels. With zoom =
+                    // exportScale the workspace origin needs to land at
+                    // -wsx*scale screen pixels for the canvas's top-left
+                    // to render at (0, 0) of the export image.
+                    window.canvasRenderer.panX = -wsx * exportScale;
+                    window.canvasRenderer.panY = -wsy * exportScale;
 
                     window.canvasRenderer.render();
 
@@ -8120,8 +8200,9 @@ class LEDRasterApp {
                         fileBase,
                         pdfLabel,
                         dataUrl,
-                        width: rasterWidth,
-                        height: rasterHeight,
+                        width: rasterWidth * exportScale,
+                        height: rasterHeight * exportScale,
+                        scale: exportScale,
                     });
                 }
             }
@@ -8147,6 +8228,23 @@ class LEDRasterApp {
             window.canvasRenderer.panX = originalPanX;
             window.canvasRenderer.panY = originalPanY;
             window.canvasRenderer.render();
+        }
+
+        // v0.8.7: notify the user if any pass had to clamp the requested
+        // PSD scale to fit PSD's 30000×30000 dimension limit. We don't
+        // block — we just report the actual scale used so the file lands
+        // and the user knows.
+        if (scaleClampedAnywhere) {
+            const usedScales = [...new Set(renderedItems.map(i => i.scale))].sort((a, b) => a - b);
+            const status = document.getElementById('status-message');
+            if (status) {
+                status.textContent = `PSD scale reduced (max ${usedScales[usedScales.length - 1]}x) — PSD format max is 30000px`;
+                setTimeout(() => { if (status.textContent.startsWith('PSD scale')) status.textContent = 'Ready'; }, 6000);
+            }
+            sendClientLog && sendClientLog('export_psd_scale_clamped', {
+                requested: requestedScale,
+                used: usedScales,
+            });
         }
 
         // Dispatch to format-specific writer. Multi-canvas just means
@@ -8219,11 +8317,18 @@ class LEDRasterApp {
     }
 
     async nativeWriteFile(path, blob) {
-        const dataUrl = await this.blobToDataUrl(blob);
+        // v0.8.7: send the blob as raw multipart bytes instead of a base64
+        // data URI. The old JSON path JSON.stringify-ed a ~36MB base64
+        // string for a 26MB PSD, which blows up to "out of memory" or
+        // sends an empty body on some browsers (we saw `has_data: false`
+        // in server logs for 8x PSD exports). FormData streams the blob
+        // directly without a giant string allocation.
+        const fd = new FormData();
+        fd.append('path', path);
+        fd.append('file', blob);
         const response = await fetch('/api/native-dialog/write-file', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ path, data_url: dataUrl })
+            body: fd,
         });
         if (!response.ok) return false;
         const data = await response.json();
@@ -8484,6 +8589,13 @@ class LEDRasterApp {
                     x1 += dx; x2 += dx;
                     y1 += dy; y2 += dy;
                 }
+                // v0.8.7: when PSD export is rendered at scale > 1, the
+                // image is scale × native; layer rectangles must scale to
+                // match or they'll cover only the top-left corner.
+                const s = Number(view.scale) || 1;
+                if (s !== 1) {
+                    x1 *= s; x2 *= s; y1 *= s; y2 *= s;
+                }
                 return {
                     name: l.name,
                     offset_x: x1,
@@ -8505,7 +8617,17 @@ class LEDRasterApp {
                     layers: psdLayers
                 })
             });
-            if (!response.ok) throw new Error('Failed to create PSD');
+            if (!response.ok) {
+                // v0.8.7: surface the server error so the user sees what
+                // actually went wrong (e.g. PSD dimension limits, OOM)
+                // instead of a generic message.
+                let detail = '';
+                try {
+                    const j = await response.clone().json();
+                    if (j && j.error) detail = `: ${j.error}`;
+                } catch (_) {}
+                throw new Error(`Failed to create PSD${detail}`);
+            }
             const blob = await response.blob();
             files.push({ filename: `${view.fileBase}.psd`, blob });
         }
@@ -9513,7 +9635,11 @@ class LEDRasterApp {
     openExportModalWithFormat(format) {
         const modal = document.getElementById('export-modal');
         const formatSelect = document.getElementById('export-format');
-        if (formatSelect) formatSelect.value = format;
+        if (formatSelect) {
+            formatSelect.value = format;
+            // v0.8.7: re-evaluate the PSD-only Scale row visibility.
+            formatSelect.dispatchEvent(new Event('change'));
+        }
         if (modal) {
             modal.style.display = 'block';
             document.getElementById('export-name').value = this.project.name || 'Untitled Project';
@@ -11635,8 +11761,19 @@ class LEDRasterApp {
         }
         return fetch(`/api/canvas/${canvasId}/active`, { method: 'PUT' })
             .then(r => r.json()).then(data => {
-                // Quietly absorb server state without re-rendering twice.
-                if (data && data.canvases) this.project = data;
+                // v0.8.7: previously did `this.project = data` here, which
+                // wiped client-side-only properties (screenNameOffsetX/Y
+                // per view, etc.) every time the user activated a different
+                // canvas — visible as the screen-name label snapping back
+                // to its previous spot the moment you clicked away after
+                // dragging it. The PUT only changes active_canvas_id; just
+                // sync that one field instead of clobbering the whole
+                // project. _applyProjectUpdate-style merges aren't needed
+                // because we already optimistically updated this.project
+                // before the fetch.
+                if (data && data.active_canvas_id) {
+                    this.project.active_canvas_id = data.active_canvas_id;
+                }
             });
     }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.6.3</title>
+    <title>LED Raster Designer v0.8.7</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.6.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1442,6 +1442,20 @@
                     <option value="pdf">PDF (All views combined)</option>
                     <option value="resolume-xml">Resolume XML (Advanced Output)</option>
                 </select>
+            </div>
+
+            <!-- Export Scale (v0.8.7) — multiplies output resolution. Vector
+                 content (panels, labels, arrows, text) stays crisp; bitmap
+                 image layers will sample up. Resolume XML ignores scale. -->
+            <div style="margin-bottom: 18px;" id="export-scale-row">
+                <label style="display: block; margin-bottom: 6px; color: #ccc; font-size: 13px;">Resolution Scale:</label>
+                <select id="export-scale" style="width: 100%; padding: 10px; background: #1a1a1a; border: 1px solid #3a3a3a; color: #fff; border-radius: 4px;">
+                    <option value="1">1x (native raster)</option>
+                    <option value="2">2x</option>
+                    <option value="4">4x</option>
+                    <option value="8">8x</option>
+                </select>
+                <div style="margin-top: 4px; font-size: 11px; color: #777;">Renders the PSD at higher resolution for cleaner Photoshop / print output. Auto-clamped to keep dimensions under PSD's 30000px limit (a status message tells you if a smaller scale was used).</div>
             </div>
             
             <!-- File naming preview -->


### PR DESCRIPTION
## Summary
- Adds PSD export Resolution Scale (1x / 2x / 4x / 8x), auto-clamped to 16000px per dimension to fit browser canvas + PSD limits.
- Fixes Pillow decompression-bomb guard rejecting scaled exports.
- Switches native-save-dialog write to multipart so large PSD blobs (26MB+) go through (the JSON+base64 path was blowing up in memory and sending empty bodies).
- Export-modal per-canvas Front/Back dropdowns now update the filename preview live.
- Screen-name label position no longer snaps back when clicking a layer in a different canvas (\`setActiveCanvas\` was wiping the whole project from the server response, losing client-side-only \`screenNameOffset*\` fields).
- PSD export errors surface the actual server message instead of a generic \"Failed to create PSD\".

## Test plan
- [x] PSD at 8x on a 6000-wide canvas auto-clamps to 2x and writes a working file
- [x] Large PSDs save through native dialog (multipart)
- [x] Filename preview reacts to per-canvas perspective dropdowns
- [x] Screen-name drag stays put after clicking a layer in another canvas
- [x] Status message tells user when scale was clamped