### PR TITLE
v0.8.7.1: BACK badge + label edge-shift + override editor width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7
+# LED Raster Designer v0.8.7.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,30 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.1 - May 10, 2026
+----------------------------
+Polish pass on label readability and the port/circuit override editor.
+
+- FIX: BACK VIEW badge sized for any zoom. The fixed-size badge would
+  cover ~25% of a small canvas at zoom-out and felt undersized when
+  zoomed in. Now scales with the canvas's on-screen pixel width
+  (~10%, capped 9-13px font), and is hidden entirely when the canvas
+  is smaller than ~110px on screen so it can't dominate. Label
+  shortened to "BACK" for compactness.
+- FIX: Power circuit + Data port labels overflowing the screen edge
+  now shift their center inward to stay fully visible instead of
+  getting clipped. The user-set label size is rendered as-is (slider
+  works freely up to its 200px max), the circle grows with text width
+  so labels are never clipped by the circle, and the only constraint
+  is the screen's outer edge — when a label would extend past it, the
+  label slides inward so it stays fully on the screen.
+- UI: Port / Circuit override editor uses the full sidebar width.
+  Replaced the wide "Port N" / "Circuit N" text with a compact bold
+  monospace number column, removed list/input padding, and broke the
+  list out of the panel-content padding with negative margins. The
+  primary + backup inputs are now ~80px each (was ~38px), so labels
+  like "SL-B1" fit without truncation.
+
 v0.8.7 - May 5, 2026
 ----------------------------
 - FEATURE: PSD export Resolution Scale option (1x / 2x / 4x / 8x).

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7',
-            'CFBundleVersion': '0.8.7',
+            'CFBundleShortVersionString': '0.8.7.1',
+            'CFBundleVersion': '0.8.7.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -10064,6 +10064,18 @@ class LEDRasterApp {
             });
         }
         list.innerHTML = '';
+        // v0.8.7.3: force the list's grid to 1fr so each row stretches
+        // the full list width instead of collapsing to content width
+        // (which left ~12px of dead space on the right after the
+        // backup input). Also tighten the list's own padding to claw
+        // back another ~8px for the inputs. Negative margins break the
+        // list out of the panel-content's 12px L+R padding so the
+        // inputs can extend the full sidebar interior — claws back
+        // another 24px (12 on each side).
+        list.style.gridTemplateColumns = '1fr';
+        list.style.padding = '4px';
+        list.style.marginLeft = '-12px';
+        list.style.marginRight = '-12px';
 
         if (portsRequired <= 0) {
             const empty = document.createElement('div');
@@ -10077,29 +10089,45 @@ class LEDRasterApp {
         for (let portNum = 1; portNum <= portsRequired; portNum++) {
             const row = document.createElement('div');
             row.style.display = 'grid';
-            row.style.gridTemplateColumns = '20px 40px 1fr 1fr';
-            row.style.gap = '6px';
+            // v0.8.7.3: compact "1" / "2" number column instead of the
+            // full "Port N" text — saves ~40px in the narrow 260px
+            // sidebar so both inputs get more width. Row stretches to
+            // fill its container with no right-side gap.
+            row.style.gridTemplateColumns = '18px 14px 1fr 1fr';
+            row.style.gap = '4px';
             row.style.alignItems = 'center';
+            row.style.width = '100%';
 
             const cb = document.createElement('input');
             cb.type = 'checkbox';
             cb.setAttribute('data-port', String(portNum));
+            cb.title = `Port ${portNum}`;
+            cb.style.margin = '0';
 
-            const label = document.createElement('div');
-            label.style.fontSize = '11px';
-            label.style.color = '#ccc';
-            label.textContent = `Port ${portNum}`;
+            const numLabel = document.createElement('div');
+            numLabel.style.fontSize = '13px';
+            numLabel.style.fontWeight = '700';
+            numLabel.style.color = '#ccc';
+            numLabel.style.textAlign = 'center';
+            numLabel.style.fontFamily = 'monospace';
+            numLabel.textContent = String(portNum);
 
             const primaryInput = document.createElement('input');
             primaryInput.type = 'text';
             primaryInput.value = (this.currentLayer.portLabelOverridesPrimary && this.currentLayer.portLabelOverridesPrimary[portNum]) || '';
             primaryInput.placeholder = this.getPortLabelText(this.currentLayer, portNum, 'primary');
-            primaryInput.style.padding = '4px 6px';
+            primaryInput.style.padding = '3px 4px';
             primaryInput.style.background = '#0d0d0d';
             primaryInput.style.border = '1px solid #333';
             primaryInput.style.color = '#fff';
             primaryInput.style.borderRadius = '4px';
             primaryInput.style.fontFamily = 'monospace';
+            // v0.8.7.3: fill the grid column instead of using the input's
+            // default intrinsic width (was leaving wasted space to the
+            // right of each input). Power editor already does this.
+            primaryInput.style.width = '100%';
+            primaryInput.style.minWidth = '0';
+            primaryInput.style.boxSizing = 'border-box';
 
             primaryInput.addEventListener('change', () => {
                 const val = primaryInput.value.trim();
@@ -10121,12 +10149,15 @@ class LEDRasterApp {
             returnInput.type = 'text';
             returnInput.value = (this.currentLayer.portLabelOverridesReturn && this.currentLayer.portLabelOverridesReturn[portNum]) || '';
             returnInput.placeholder = this.getPortLabelText(this.currentLayer, portNum, 'return');
-            returnInput.style.padding = '4px 6px';
+            returnInput.style.padding = '3px 4px';
             returnInput.style.background = '#0d0d0d';
             returnInput.style.border = '1px solid #333';
             returnInput.style.color = '#fff';
             returnInput.style.borderRadius = '4px';
             returnInput.style.fontFamily = 'monospace';
+            returnInput.style.width = '100%';
+            returnInput.style.minWidth = '0';
+            returnInput.style.boxSizing = 'border-box';
 
             returnInput.addEventListener('change', () => {
                 const val = returnInput.value.trim();
@@ -10145,7 +10176,7 @@ class LEDRasterApp {
             });
 
             row.appendChild(cb);
-            row.appendChild(label);
+            row.appendChild(numLabel);
             row.appendChild(primaryInput);
             row.appendChild(returnInput);
             list.appendChild(row);
@@ -10172,6 +10203,12 @@ class LEDRasterApp {
         }
 
         list.innerHTML = '';
+        // v0.8.7.3: stretch each row to full list width, trim padding,
+        // and extend past panel-content padding for more input room.
+        list.style.gridTemplateColumns = '1fr';
+        list.style.padding = '4px';
+        list.style.marginLeft = '-12px';
+        list.style.marginRight = '-12px';
         if (circuitsRequired <= 0) {
             const empty = document.createElement('div');
             empty.style.color = '#888';
@@ -10184,25 +10221,32 @@ class LEDRasterApp {
         for (let circuitNum = 1; circuitNum <= circuitsRequired; circuitNum++) {
             const row = document.createElement('div');
             row.style.display = 'grid';
-            row.style.gridTemplateColumns = '20px 72px 1fr';
-            row.style.gap = '6px';
+            // v0.8.7.3: compact "1" / "2" number column, same as port
+            // editor. Row stretches to fill its container width.
+            row.style.gridTemplateColumns = '18px 18px 1fr';
+            row.style.gap = '4px';
             row.style.alignItems = 'center';
-            row.style.maxWidth = '100%';
+            row.style.width = '100%';
 
             const cb = document.createElement('input');
             cb.type = 'checkbox';
             cb.setAttribute('data-circuit', String(circuitNum));
+            cb.title = `Circuit ${circuitNum}`;
+            cb.style.margin = '0';
 
-            const label = document.createElement('div');
-            label.style.fontSize = '11px';
-            label.style.color = '#ccc';
-            label.textContent = `Circuit ${circuitNum}`;
+            const numLabel = document.createElement('div');
+            numLabel.style.fontSize = '13px';
+            numLabel.style.fontWeight = '700';
+            numLabel.style.color = '#ccc';
+            numLabel.style.textAlign = 'center';
+            numLabel.style.fontFamily = 'monospace';
+            numLabel.textContent = String(circuitNum);
 
             const input = document.createElement('input');
             input.type = 'text';
             input.value = (this.currentLayer.powerLabelOverrides && this.currentLayer.powerLabelOverrides[circuitNum]) || '';
             input.placeholder = this.getPowerCircuitLabel(this.currentLayer, circuitNum);
-            input.style.padding = '4px 6px';
+            input.style.padding = '3px 4px';
             input.style.background = '#0d0d0d';
             input.style.border = '1px solid #333';
             input.style.color = '#fff';
@@ -10229,7 +10273,7 @@ class LEDRasterApp {
             });
 
             row.appendChild(cb);
-            row.appendChild(label);
+            row.appendChild(numLabel);
             row.appendChild(input);
             list.appendChild(row);
         }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3239,7 +3239,15 @@ class CanvasRenderer {
 
         this.ctx.lineCap = 'round';
         this.ctx.lineJoin = 'round';
-        
+
+        // v0.8.7.4: layer bounds in panel-local coords, used to shift
+        // port labels inward when they'd overflow the screen edge.
+        const layerBoundsForPort = this.getLayerBounds(layer);
+        const layerLeft = layerBoundsForPort.x;
+        const layerTop = layerBoundsForPort.y;
+        const layerRight = layerBoundsForPort.x + layerBoundsForPort.width;
+        const layerBottom = layerBoundsForPort.y + layerBoundsForPort.height;
+
         const drawPort = (portPanels, portNum) => {
             if (portPanels.length === 0) return;
             
@@ -3295,22 +3303,53 @@ class CanvasRenderer {
             }
             
             const firstPanel = portPanels[0];
-            let px = this.snap(firstPanel.x + firstPanel.width / 2);
-            let py = this.snap(firstPanel.y + firstPanel.height / 2);
             const lastPanel = portPanels[portPanels.length - 1];
-            let rx = this.snap(lastPanel.x + lastPanel.width / 2);
-            let ry = this.snap(lastPanel.y + lastPanel.height / 2);
             const primaryLabel = window.app ? window.app.getPortLabelText(layer, portNum, 'primary') : `P${portNum}`;
             const returnLabel = window.app ? window.app.getPortLabelText(layer, portNum, 'return') : `R${portNum}`;
-            
+
+            // v0.8.7.4: render at user's labelSize directly. Circle grows
+            // to fit text width so the label is never clipped. If the
+            // label would overflow the screen edge, shift the CENTER
+            // inward so it stays fully inside the screen.
+            const sizeLabel = (label) => {
+                this.ctx.font = `bold ${labelSize}px Arial`;
+                const textWidth = this.ctx.measureText(label).width;
+                const padding = Math.max(4, labelSize * 0.2);
+                const radius = Math.max(labelSize * 1.2, textWidth / 2 + padding);
+                return { size: labelSize, radius };
+            };
+            const primaryFit = sizeLabel(primaryLabel);
+            const returnFit = sizeLabel(returnLabel);
+
+            const shiftIntoBounds = (px, py, radius) => {
+                if (px - radius < layerLeft) px = layerLeft + radius;
+                if (px + radius > layerRight) px = layerRight - radius;
+                if (py - radius < layerTop) py = layerTop + radius;
+                if (py + radius > layerBottom) py = layerBottom - radius;
+                return { px: this.snap(px), py: this.snap(py) };
+            };
+
+            const primaryPos = shiftIntoBounds(
+                firstPanel.x + firstPanel.width / 2,
+                firstPanel.y + firstPanel.height / 2,
+                primaryFit.radius
+            );
+            const returnPos = shiftIntoBounds(
+                lastPanel.x + lastPanel.width / 2,
+                lastPanel.y + lastPanel.height / 2,
+                returnFit.radius
+            );
+            const px = primaryPos.px, py = primaryPos.py;
+            const rx = returnPos.px, ry = returnPos.py;
+
             // If the port has only one panel, draw backup first so primary is on top.
             if (portPanels.length === 1) {
                 this.ctx.fillStyle = backupColor;
                 this.ctx.beginPath();
-                this.ctx.arc(rx, ry, circleRadius, 0, Math.PI * 2);
+                this.ctx.arc(rx, ry, returnFit.radius, 0, Math.PI * 2);
                 this.ctx.fill();
                 this.ctx.fillStyle = backupTextColor;
-                this.ctx.font = `bold ${labelSize}px Arial`;
+                this.ctx.font = `bold ${returnFit.size}px Arial`;
                 this.ctx.textAlign = 'center';
                 this.ctx.textBaseline = 'middle';
                 this._fillText(returnLabel, rx, ry);
@@ -3318,11 +3357,11 @@ class CanvasRenderer {
 
             this.ctx.fillStyle = primaryColor;
             this.ctx.beginPath();
-            this.ctx.arc(px, py, circleRadius, 0, Math.PI * 2);
+            this.ctx.arc(px, py, primaryFit.radius, 0, Math.PI * 2);
             this.ctx.fill();
 
             this.ctx.fillStyle = primaryTextColor;
-            this.ctx.font = `bold ${labelSize}px Arial`;
+            this.ctx.font = `bold ${primaryFit.size}px Arial`;
             this.ctx.textAlign = 'center';
             this.ctx.textBaseline = 'middle';
             this._fillText(primaryLabel, px, py);
@@ -3330,10 +3369,11 @@ class CanvasRenderer {
             if (portPanels.length > 1) {
                 this.ctx.fillStyle = backupColor;
                 this.ctx.beginPath();
-                this.ctx.arc(rx, ry, circleRadius, 0, Math.PI * 2);
+                this.ctx.arc(rx, ry, returnFit.radius, 0, Math.PI * 2);
                 this.ctx.fill();
 
                 this.ctx.fillStyle = backupTextColor;
+                this.ctx.font = `bold ${returnFit.size}px Arial`;
                 this._fillText(returnLabel, rx, ry);
             }
         };
@@ -3488,14 +3528,36 @@ class CanvasRenderer {
             '#BB8FCE', '#85C1E9', '#F8B500', '#00CED1'
         ];
 
+        // v0.8.7.4: layer bounds in panel-local coords, used to shift
+        // labels inward when they'd overflow the screen edge.
+        const layerBounds = this.getLayerBounds(layer);
+        const layerLeft = layerBounds.x;
+        const layerTop = layerBounds.y;
+        const layerRight = layerBounds.x + layerBounds.width;
+        const layerBottom = layerBounds.y + layerBounds.height;
+
         const drawCircuitLabel = (panelStart, panelNext, circuitNum) => {
             const label = window.app ? window.app.getPowerCircuitLabel(layer, circuitNum) : `S1-${circuitNum}`;
-            const px = this.snap(panelStart.x + panelStart.width / 2);
-            const py = this.snap(panelStart.y + panelStart.height / 2);
+            // v0.8.7.4: render at the user's labelSize directly (no
+            // fit-to-panel cap — that was overriding the size slider).
+            // Circle grows to fit text width so labels never get clipped.
+            // If the label would overflow the screen edge, shift the
+            // CENTER inward so the label stays fully inside the screen
+            // bounds. Long labels overflow into neighboring panels but
+            // never beyond the screen.
             this.ctx.font = `bold ${labelSize}px Arial`;
             const textWidth = this.ctx.measureText(label).width;
             const padding = Math.max(6, labelSize * 0.25);
             const circleRadius = Math.max(labelSize * 0.7, lineWidth * 1.4, textWidth / 2 + padding);
+            let px = panelStart.x + panelStart.width / 2;
+            let py = panelStart.y + panelStart.height / 2;
+            // Shift to keep circle fully within screen bounds.
+            if (px - circleRadius < layerLeft) px = layerLeft + circleRadius;
+            if (px + circleRadius > layerRight) px = layerRight - circleRadius;
+            if (py - circleRadius < layerTop) py = layerTop + circleRadius;
+            if (py + circleRadius > layerBottom) py = layerBottom - circleRadius;
+            px = this.snap(px);
+            py = this.snap(py);
 
             this.ctx.fillStyle = powerLabelBgColor;
             this.ctx.beginPath();
@@ -4557,14 +4619,14 @@ class CanvasRenderer {
     renderPerspectiveBadge() {
         if (this.viewMode !== 'data-flow' && this.viewMode !== 'power') return;
         if (!this.isMirroredView()) return;
-        const label = 'BACK VIEW';
+        const label = 'BACK';
         const arr = (window.app && window.app.project && Array.isArray(window.app.project.canvases))
             ? window.app.project.canvases : [];
         // v0.8.6: per-canvas badge so a mixed-perspective workspace makes
         // it obvious which canvas is flipped. Legacy single-canvas
         // projects fall back to the original viewport-corner badge.
         if (arr.length === 0) {
-            this._drawBackBadgeAt(label, this.canvas.width - 20, 20, 'right');
+            this._drawBackBadgeAt(label, this.canvas.width - 20, 20, 'right', this.canvas.width);
             return;
         }
         const useShow = this.isShowLookView();
@@ -4576,20 +4638,38 @@ class CanvasRenderer {
             // World top-right of canvas → screen coords (account for pan/zoom).
             const screenX = (ws.wx + w) * this.zoom + this.panX;
             const screenY = ws.wy * this.zoom + this.panY;
+            // v0.8.7.1: badge scales with the canvas's on-screen size so it
+            // doesn't dominate small/zoomed-out canvases. Pass the canvas's
+            // screen-pixel width to _drawBackBadgeAt; it picks a font/pad
+            // proportional to that (clamped to min/max so it stays
+            // readable at extreme zooms).
+            const canvasScreenW = w * this.zoom;
+            // v0.8.7.2: skip the badge when the canvas is so small on
+            // screen that the badge would dominate it. The dashed canvas
+            // outline + flipped content already telegraph back-view at
+            // any zoom; the badge is just a confirmation tag for normal
+            // zoom levels.
+            if (canvasScreenW < 110) return;
             // Anchor to canvas corner with a small inset; clamp so badge
             // stays visible if the canvas top-right is offscreen.
-            const x = Math.max(20, Math.min(this.canvas.width - 20, screenX - 8));
-            const y = Math.max(20, Math.min(this.canvas.height - 60, screenY + 8));
-            this._drawBackBadgeAt(label, x, y, 'right');
+            const x = Math.max(20, Math.min(this.canvas.width - 20, screenX - 4));
+            const y = Math.max(8, Math.min(this.canvas.height - 24, screenY + 4));
+            this._drawBackBadgeAt(label, x, y, 'right', canvasScreenW);
         });
     }
 
-    _drawBackBadgeAt(label, anchorX, anchorY, align) {
+    _drawBackBadgeAt(label, anchorX, anchorY, align, canvasScreenW) {
         this.ctx.save();
         this.ctx.setTransform(1, 0, 0, 1, 0, 0);
-        const padX = 14;
-        const padY = 7;
-        const fontPx = 13;
+        // v0.8.7.2: badge size is purely proportional to canvas screen
+        // width — no minimum clamp, since at extreme zoom-out the canvas
+        // itself shrinks faster than the badge would. Caller skips the
+        // badge entirely when canvasScreenW falls below the
+        // "too small to label" threshold.
+        const targetW = Math.min(110, (canvasScreenW || 600) * 0.10);
+        const fontPx = Math.max(9, Math.min(13, Math.round(targetW / 5.2)));
+        const padX = Math.max(4, Math.round(fontPx * 0.6));
+        const padY = Math.max(2, Math.round(fontPx * 0.35));
         this.ctx.font = `700 ${fontPx}px -apple-system, "Segoe UI", sans-serif`;
         const textWidth = this.ctx.measureText(label).width;
         const boxW = textWidth + padX * 2;
@@ -4598,7 +4678,8 @@ class CanvasRenderer {
         const y = anchorY;
         this.ctx.fillStyle = 'rgba(217, 80, 0, 0.95)';
         this.ctx.beginPath();
-        if (this.ctx.roundRect) this.ctx.roundRect(x, y, boxW, boxH, 6);
+        const radius = Math.max(3, Math.round(fontPx * 0.4));
+        if (this.ctx.roundRect) this.ctx.roundRect(x, y, boxW, boxH, radius);
         else this.ctx.rect(x, y, boxW, boxH);
         this.ctx.fill();
         this.ctx.fillStyle = '#fff';

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7</title>
+    <title>LED Raster Designer v0.8.7.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.1) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">


### PR DESCRIPTION
## Summary
- BACK VIEW badge scales with the canvas's on-screen width; hides at extreme zoom-out so it doesn't dominate.
- Power/Data labels respect the user-set size, but if they'd overflow the screen edge they shift inward to stay fully visible.
- Port/Circuit override editor uses the full sidebar width — labels like \"SL-B1\" fit without truncation.

## Test plan
- [x] BACK badge tiny at zoom 0.01, scales up smoothly to a max
- [x] Power label at size 50 grows visibly; edge labels shift inward
- [x] Port label override input fits \"SL-B1\" comfortably