### PR TITLE
v0.8.7.3: perspective + drag-select + file-load fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.2.1
+# LED Raster Designer v0.8.7.2.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.2
+# LED Raster Designer v0.8.7.2.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.1
+# LED Raster Designer v0.8.7.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.2.2
+# LED Raster Designer v0.8.7.3
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,29 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.2.2 - May 11, 2026
+----------------------------
+Real root cause for the screen-name "snap back" on perspective toggle.
+
+- FIX: Screen-name labels (and every other client-side-only layer
+  field — label sizes, power voltage/amperage, custom port paths,
+  power circuit colors, etc.) reverted to their pre-drag value any
+  time a canvas-level mutation went through the server: perspective
+  toggle, canvas rename, canvas visibility, canvas resize, etc.
+  _applyProjectUpdate was collecting the pre-update client-side
+  props into savedClientProps and then never applying them; the
+  follow-up `if (data.layers && this.applyClientSideProperties)`
+  branch was guarded on a method that doesn't exist, so the
+  loadClientSideProperties restore was silently skipped on every
+  multi-layer / loaded project. Net effect: the user drags the
+  screen-name label, the offset only lives on the in-memory layer
+  object, then the next canvas PUT round-trip replaces the layer
+  with the server's version (which doesn't track screen-name
+  offsets) and the label snaps back.
+  Fix: actually copy savedClientProps onto the fresh layer objects
+  after `this.project = data`. The Untitled-Project localStorage
+  restore is still called below for the boot path.
+
 v0.8.7.2.1 - May 11, 2026
 ----------------------------
 Follow-up to v0.8.7.2 after preview testing.

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,29 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.2.1 - May 11, 2026
+----------------------------
+Follow-up to v0.8.7.2 after preview testing.
+
+- FIX: Loading a project file silently rewrote the active canvas's
+  raster size. The file-load path blindly wrote projectData.raster_width
+  into canvasRenderer.rasterWidth, but that setter routes to either
+  the active canvas's raster_width or show_raster_width depending on
+  the current tab. When the saved file's root-level raster mirror
+  reflected the Show Look raster (because the user last saved on a
+  Show Look tab), this clobbered the canvas's actual pixel raster
+  with the show value. Now skipped entirely for multi-canvas files —
+  the per-canvas raster on each canvas object is the source of truth
+  and is restored intact via syncRasterFromProject().
+- FIX: Custom drag-select on Data Flow / Power tabs still missed
+  panels on Show Look views (where layers render at showOffsetX/Y,
+  not offset_x/y). The v0.8.7.2 overlay fix applied workspace + mirror
+  but skipped the per-layer Show Look render offset, so highlights
+  landed on the panels' processor positions instead of their show
+  positions. Both selection overlays now share a single helper
+  (_withOverlayLayerTransform) that mirrors the full layer-render
+  transform stack from the main render loop.
+
 v0.8.7.2 - May 11, 2026
 ----------------------------
 Fixes two regressions reported after v0.8.7.1.

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,9 +1,9 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
-v0.8.7.2.2 - May 11, 2026
+v0.8.7.3 - May 11, 2026
 ----------------------------
-Real root cause for the screen-name "snap back" on perspective toggle.
+Three follow-up fixes after v0.8.7.1 preview testing.
 
 - FIX: Screen-name labels (and every other client-side-only layer
   field — label sizes, power voltage/amperage, custom port paths,
@@ -12,64 +12,40 @@ Real root cause for the screen-name "snap back" on perspective toggle.
   toggle, canvas rename, canvas visibility, canvas resize, etc.
   _applyProjectUpdate was collecting the pre-update client-side
   props into savedClientProps and then never applying them; the
-  follow-up `if (data.layers && this.applyClientSideProperties)`
-  branch was guarded on a method that doesn't exist, so the
-  loadClientSideProperties restore was silently skipped on every
-  multi-layer / loaded project. Net effect: the user drags the
-  screen-name label, the offset only lives on the in-memory layer
-  object, then the next canvas PUT round-trip replaces the layer
-  with the server's version (which doesn't track screen-name
-  offsets) and the label snaps back.
-  Fix: actually copy savedClientProps onto the fresh layer objects
-  after `this.project = data`. The Untitled-Project localStorage
-  restore is still called below for the boot path.
-
-v0.8.7.2.1 - May 11, 2026
-----------------------------
-Follow-up to v0.8.7.2 after preview testing.
-
+  follow-up branch was guarded on a method that doesn't exist
+  (`this.applyClientSideProperties`), so the restore was silently
+  skipped on every multi-layer / loaded project. Net effect: the
+  user dragged the screen-name label, the offset only lived on the
+  in-memory layer object, then the next canvas PUT round-trip
+  replaced the layer with the server's version (which doesn't track
+  screen-name offsets) and the label snapped back. Fix: actually
+  copy savedClientProps onto the fresh layer objects after
+  `this.project = data`. Also includes a per-canvas mirror
+  compensation on the offset so Front<->Back toggling keeps the
+  label visually on the same side of the layer's center.
+- FIX: Custom drag-select on Data Flow / Power tabs showed no
+  panel highlight on multi-canvas projects, on canvases in Back
+  perspective, or on Show Look views. selectPanelsInRect /
+  selectPowerPanelsInRect already mapped the marquee correctly
+  into panel coords, but the render-time overlay drew the
+  highlight fills at workspace (0,0) without the layer's canvas
+  workspace offset, perspective mirror, OR per-layer Show Look
+  offset, AND was clipped to the legacy single-canvas raster
+  rectangle, so the highlight ended up off-screen or clipped away.
+  Both overlays now share a single helper
+  (_withOverlayLayerTransform) that wraps the full per-layer
+  render transform stack from the main render loop.
 - FIX: Loading a project file silently rewrote the active canvas's
-  raster size. The file-load path blindly wrote projectData.raster_width
-  into canvasRenderer.rasterWidth, but that setter routes to either
-  the active canvas's raster_width or show_raster_width depending on
-  the current tab. When the saved file's root-level raster mirror
-  reflected the Show Look raster (because the user last saved on a
-  Show Look tab), this clobbered the canvas's actual pixel raster
-  with the show value. Now skipped entirely for multi-canvas files —
-  the per-canvas raster on each canvas object is the source of truth
-  and is restored intact via syncRasterFromProject().
-- FIX: Custom drag-select on Data Flow / Power tabs still missed
-  panels on Show Look views (where layers render at showOffsetX/Y,
-  not offset_x/y). The v0.8.7.2 overlay fix applied workspace + mirror
-  but skipped the per-layer Show Look render offset, so highlights
-  landed on the panels' processor positions instead of their show
-  positions. Both selection overlays now share a single helper
-  (_withOverlayLayerTransform) that mirrors the full layer-render
-  transform stack from the main render loop.
-
-v0.8.7.2 - May 11, 2026
-----------------------------
-Fixes two regressions reported after v0.8.7.1.
-
-- FIX: Screen name label jumped position when toggling Data / Power
-  perspective Front<->Back. The label offset is stored once per view
-  (data-flow / power) but the per-canvas mirror transform was applied
-  to its drawn position, so a label dragged off-center would mirror
-  to the opposite side as soon as the user flipped perspective.
-  Offset is now interpreted in *visual* space, both during drag (the
-  un-mirrored mouse delta is flipped before being added to the offset
-  in Back view) and during render (the offset is negated inside the
-  mirror transform so it cancels out). The label now stays visually
-  put when toggling Front<->Back regardless of how the user dragged it.
-- FIX: Custom drag-select on Data Flow and Power tabs showed no
-  panel highlight on multi-canvas projects (and on canvases in Back
-  perspective). selectPanelsInRect / selectPowerPanelsInRect already
-  mapped the marquee correctly into panel coords, but the render-time
-  overlay drew the highlight fills at workspace (0,0) without the
-  active layer's canvas workspace offset or perspective mirror, AND
-  was clipped to the legacy single-canvas raster rectangle, so the
-  highlight ended up off-screen or clipped away. Overlay now applies
-  the same workspace translate + mirror as the layer it's badging.
+  raster size. The file-load path blindly wrote projectData
+  .raster_width into canvasRenderer.rasterWidth, but that setter
+  routes to either the active canvas's raster_width or
+  show_raster_width depending on the current tab. When the saved
+  file's root-level raster mirror reflected the Show Look raster
+  (because the user last saved on a Show Look tab), this clobbered
+  the canvas's actual pixel raster with the show value. Now
+  skipped entirely for multi-canvas files — the per-canvas raster
+  on each canvas object is the source of truth and is restored
+  intact via syncRasterFromProject().
 
 v0.8.7.1 - May 10, 2026
 ----------------------------

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,30 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.2 - May 11, 2026
+----------------------------
+Fixes two regressions reported after v0.8.7.1.
+
+- FIX: Screen name label jumped position when toggling Data / Power
+  perspective Front<->Back. The label offset is stored once per view
+  (data-flow / power) but the per-canvas mirror transform was applied
+  to its drawn position, so a label dragged off-center would mirror
+  to the opposite side as soon as the user flipped perspective.
+  Offset is now interpreted in *visual* space, both during drag (the
+  un-mirrored mouse delta is flipped before being added to the offset
+  in Back view) and during render (the offset is negated inside the
+  mirror transform so it cancels out). The label now stays visually
+  put when toggling Front<->Back regardless of how the user dragged it.
+- FIX: Custom drag-select on Data Flow and Power tabs showed no
+  panel highlight on multi-canvas projects (and on canvases in Back
+  perspective). selectPanelsInRect / selectPowerPanelsInRect already
+  mapped the marquee correctly into panel coords, but the render-time
+  overlay drew the highlight fills at workspace (0,0) without the
+  active layer's canvas workspace offset or perspective mirror, AND
+  was clipped to the legacy single-canvas raster rectangle, so the
+  highlight ended up off-screen or clipped away. Overlay now applies
+  the same workspace translate + mirror as the layer it's badging.
+
 v0.8.7.1 - May 10, 2026
 ----------------------------
 Polish pass on label readability and the port/circuit override editor.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.2.2',
-            'CFBundleVersion': '0.8.7.2.2',
+            'CFBundleShortVersionString': '0.8.7.3',
+            'CFBundleVersion': '0.8.7.3',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.2',
-            'CFBundleVersion': '0.8.7.2',
+            'CFBundleShortVersionString': '0.8.7.2.1',
+            'CFBundleVersion': '0.8.7.2.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.2.1',
-            'CFBundleVersion': '0.8.7.2.1',
+            'CFBundleShortVersionString': '0.8.7.2.2',
+            'CFBundleVersion': '0.8.7.2.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.1',
-            'CFBundleVersion': '0.8.7.1',
+            'CFBundleShortVersionString': '0.8.7.2',
+            'CFBundleVersion': '0.8.7.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -11435,10 +11435,27 @@ class LEDRasterApp {
             });
         }
         this.project = data;
-        if (data.layers && this.applyClientSideProperties) {
-            // re-apply localStorage-side overrides if available
-            try { this.loadClientSideProperties && this.loadClientSideProperties({ skipPreferences: true }); } catch (_) {}
+        // v0.8.7.2.1: actually re-apply the in-memory client-side props
+        // collected above. The previous code referenced a non-existent
+        // `applyClientSideProperties` method, so the if-branch was always
+        // false and client-side fields (screen-name offsets, label sizes,
+        // power voltage, custom port paths, etc.) silently reverted to
+        // whatever the server response carried. Repro: drag a screen-name
+        // label, toggle Front<->Back perspective, label snaps back to its
+        // pre-drag position because the perspective PUT response wipes the
+        // layer object and nothing restores the just-dragged offset.
+        if (data.layers && Object.keys(savedClientProps).length > 0) {
+            data.layers.forEach(layer => {
+                const props = savedClientProps[layer.id];
+                if (!props) return;
+                Object.keys(props).forEach(key => {
+                    if (props[key] !== undefined) layer[key] = props[key];
+                });
+            });
         }
+        // Also re-run the localStorage restore for the "Untitled Project"
+        // boot path (shouldUseSavedClientProps gate handles the rest).
+        try { this.loadClientSideProperties && this.loadClientSideProperties({ skipPreferences: true }); } catch (_) {}
         // If the active canvas's properties changed, sync raster size for
         // the workspace toolbar (Slice 4 will deepen this, Slice 2 just
         // keeps the sidebar consistent).

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -12275,7 +12275,24 @@ class LEDRasterApp {
                             });
                         }
 
-                        if (projectData.raster_width && projectData.raster_height) {
+                        // v0.8.7.2.1: ONLY trust root-level raster fields for
+                        // legacy (pre-v0.8, no canvases array) files. Multi-
+                        // canvas files keep the source-of-truth on each canvas
+                        // object, and writing the root value into
+                        // canvasRenderer.rasterWidth would clobber the active
+                        // canvas's per-canvas raster (the setter routes to
+                        // either raster_width or show_raster_width depending
+                        // on the current tab). Bug repro: the file's root
+                        // raster_width was a mirror of the active canvas's
+                        // *show* raster (because the user last saved on Show
+                        // Look), so opening the file overwrote the active
+                        // canvas's pixel-map raster with its show raster
+                        // value. syncRasterFromProject below reads from each
+                        // canvas directly so multi-canvas projects are
+                        // unaffected by skipping this block.
+                        const _hasCanvases = Array.isArray(projectData.canvases)
+                            && projectData.canvases.length > 0;
+                        if (!_hasCanvases && projectData.raster_width && projectData.raster_height) {
                             window.canvasRenderer.rasterWidth = projectData.raster_width;
                             window.canvasRenderer.rasterHeight = projectData.raster_height;
                             document.getElementById('toolbar-raster-width').value = projectData.raster_width;

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1115,8 +1115,26 @@ class CanvasRenderer {
                 // Calculate raw offset from drag
                 const dx = worldX - this.dragScreenNameStartX;
                 const dy = worldY - this.dragScreenNameStartY;
-                
-                let newOffsetX = this.screenNameStartOffset.x + dx;
+
+                // v0.8.7.2: screen-name offsets are stored in *visual* (viewer)
+                // space so toggling Front<->Back keeps the label visually in
+                // place instead of mirror-jumping across the screen. When the
+                // active layer's canvas is mirrored, the mouse delta in world
+                // (un-mirrored) space points the opposite direction from what
+                // the user sees, so negate X here to keep "drag right = +X
+                // visually" regardless of perspective.
+                const _mirrorActive = (() => {
+                    const layer = window.app && window.app.currentLayer;
+                    if (!layer || typeof this._effectiveLayerCanvasId !== 'function') return false;
+                    const cid = this._effectiveLayerCanvasId(layer);
+                    const arr = window.app.project && window.app.project.canvases;
+                    if (!Array.isArray(arr)) return false;
+                    const c = arr.find(c => c && c.id === cid);
+                    return !!(c && this._isCanvasMirrored && this._isCanvasMirrored(c));
+                })();
+                const _visualDx = _mirrorActive ? -dx : dx;
+
+                let newOffsetX = this.screenNameStartOffset.x + _visualDx;
                 let newOffsetY = this.screenNameStartOffset.y + dy;
                 
                 // Only snap if magnetic snap is enabled
@@ -4269,10 +4287,17 @@ class CanvasRenderer {
             let screenNameY = centerY;
             
             if (this.viewMode !== 'pixel-map') {
-                // Apply tab-specific screen name offset (relative to center)
-                screenNameX = centerX + screenNameOffsetX;
+                // Apply tab-specific screen name offset (relative to center).
+                // v0.8.7.2: offsets are stored in *visual* space. When the
+                // canvas is mirrored (Back perspective), the per-canvas scale(
+                // -1, 1) transform that wraps this render would flip the X
+                // position, so negate offsetX here to undo the mirror and keep
+                // the label visually at the user-set position regardless of
+                // Front/Back perspective.
+                const _visualOffsetX = this._mirror ? -screenNameOffsetX : screenNameOffsetX;
+                screenNameX = centerX + _visualOffsetX;
                 screenNameY = centerY + screenNameOffsetY;
-                
+
                 // If offset pushes label outside layer bounds, reset to center
                 if (screenNameX < bounds.x || screenNameX > bounds.x + layerWidth) {
                     screenNameX = centerX;
@@ -4501,23 +4526,38 @@ class CanvasRenderer {
         const layer = window.app.currentLayer;
         if (!window.app.isCustomFlow(layer)) return;
 
-        this.ctx.save();
-        this.ctx.beginPath();
-        this.ctx.rect(0, 0, this.rasterWidth, this.rasterHeight);
-        this.ctx.clip();
-
         const selection = window.app.customSelection || new Set();
-        if (selection.size > 0) {
-            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
-            selection.forEach(key => {
-                const [row, col] = key.split(',').map(n => parseInt(n, 10));
-                const panel = window.app.getPanelByRowCol(layer, row, col);
-                if (!panel) return;
-                this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-            });
+        if (selection.size === 0) return;
+
+        // v0.8.7.2: this overlay runs AFTER the per-canvas render loop has
+        // popped its workspace translate AND its perspective mirror, so apply
+        // both here. Without this, on multi-canvas projects with the active
+        // layer on canvas 2+, the highlight fills draw at workspace (0,0)
+        // (and got clipped by the legacy single-canvas raster-rect clip), so
+        // the user saw no panel highlight during drag-select.
+        const wsOff = (typeof this._layerCanvasOffset === 'function')
+            ? this._layerCanvasOffset(layer) : { wx: 0, wy: 0 };
+        const cid = (typeof this._effectiveLayerCanvasId === 'function')
+            ? this._effectiveLayerCanvasId(layer) : null;
+        const arr = (window.app.project && window.app.project.canvases) || [];
+        const c = Array.isArray(arr) ? arr.find(x => x && x.id === cid) : null;
+        const mirrorActive = !!(c && this._isCanvasMirrored && this._isCanvasMirrored(c));
+
+        this.ctx.save();
+        if (wsOff.wx || wsOff.wy) this.ctx.translate(wsOff.wx, wsOff.wy);
+        if (mirrorActive) {
+            const crw = (this.isShowLookView() && c.show_raster_width) || c.raster_width || 0;
+            this.ctx.translate(crw, 0);
+            this.ctx.scale(-1, 1);
         }
 
-        // No selection rectangle preview (per UX request)
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        selection.forEach(key => {
+            const [row, col] = key.split(',').map(n => parseInt(n, 10));
+            const panel = window.app.getPanelByRowCol(layer, row, col);
+            if (!panel) return;
+            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+        });
 
         this.ctx.restore();
     }
@@ -4527,21 +4567,36 @@ class CanvasRenderer {
         const layer = window.app.currentLayer;
         if (!window.app.isCustomPower(layer)) return;
 
-        this.ctx.save();
-        this.ctx.beginPath();
-        this.ctx.rect(0, 0, this.rasterWidth, this.rasterHeight);
-        this.ctx.clip();
-
         const selection = window.app.powerCustomSelection || new Set();
-        if (selection.size > 0) {
-            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
-            selection.forEach(key => {
-                const [row, col] = key.split(',').map(n => parseInt(n, 10));
-                const panel = window.app.getPanelByRowCol(layer, row, col);
-                if (!panel) return;
-                this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-            });
+        if (selection.size === 0) return;
+
+        // v0.8.7.2: same fix as renderCustomSelectionOverlay — apply the
+        // layer's canvas workspace offset + perspective mirror so drag-select
+        // highlights land on the panels they're targeting on multi-canvas /
+        // Back-perspective projects.
+        const wsOff = (typeof this._layerCanvasOffset === 'function')
+            ? this._layerCanvasOffset(layer) : { wx: 0, wy: 0 };
+        const cid = (typeof this._effectiveLayerCanvasId === 'function')
+            ? this._effectiveLayerCanvasId(layer) : null;
+        const arr = (window.app.project && window.app.project.canvases) || [];
+        const c = Array.isArray(arr) ? arr.find(x => x && x.id === cid) : null;
+        const mirrorActive = !!(c && this._isCanvasMirrored && this._isCanvasMirrored(c));
+
+        this.ctx.save();
+        if (wsOff.wx || wsOff.wy) this.ctx.translate(wsOff.wx, wsOff.wy);
+        if (mirrorActive) {
+            const crw = (this.isShowLookView() && c.show_raster_width) || c.raster_width || 0;
+            this.ctx.translate(crw, 0);
+            this.ctx.scale(-1, 1);
         }
+
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        selection.forEach(key => {
+            const [row, col] = key.split(',').map(n => parseInt(n, 10));
+            const panel = window.app.getPanelByRowCol(layer, row, col);
+            if (!panel) return;
+            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+        });
 
         this.ctx.restore();
     }

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -4529,37 +4529,22 @@ class CanvasRenderer {
         const selection = window.app.customSelection || new Set();
         if (selection.size === 0) return;
 
-        // v0.8.7.2: this overlay runs AFTER the per-canvas render loop has
-        // popped its workspace translate AND its perspective mirror, so apply
-        // both here. Without this, on multi-canvas projects with the active
-        // layer on canvas 2+, the highlight fills draw at workspace (0,0)
-        // (and got clipped by the legacy single-canvas raster-rect clip), so
-        // the user saw no panel highlight during drag-select.
-        const wsOff = (typeof this._layerCanvasOffset === 'function')
-            ? this._layerCanvasOffset(layer) : { wx: 0, wy: 0 };
-        const cid = (typeof this._effectiveLayerCanvasId === 'function')
-            ? this._effectiveLayerCanvasId(layer) : null;
-        const arr = (window.app.project && window.app.project.canvases) || [];
-        const c = Array.isArray(arr) ? arr.find(x => x && x.id === cid) : null;
-        const mirrorActive = !!(c && this._isCanvasMirrored && this._isCanvasMirrored(c));
-
-        this.ctx.save();
-        if (wsOff.wx || wsOff.wy) this.ctx.translate(wsOff.wx, wsOff.wy);
-        if (mirrorActive) {
-            const crw = (this.isShowLookView() && c.show_raster_width) || c.raster_width || 0;
-            this.ctx.translate(crw, 0);
-            this.ctx.scale(-1, 1);
-        }
-
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
-        selection.forEach(key => {
-            const [row, col] = key.split(',').map(n => parseInt(n, 10));
-            const panel = window.app.getPanelByRowCol(layer, row, col);
-            if (!panel) return;
-            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+        // v0.8.7.2.1: this overlay runs AFTER the per-canvas render loop has
+        // popped its workspace translate, perspective mirror, AND per-layer
+        // Show Look offset, so re-apply all three here. Without this, on
+        // multi-canvas projects (or canvases in Back perspective, or any
+        // Show Look view), the highlight fills draw at workspace (0,0) in
+        // raw processor coords, so the user saw no panel highlight during
+        // drag-select.
+        this._withOverlayLayerTransform(layer, () => {
+            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+            selection.forEach(key => {
+                const [row, col] = key.split(',').map(n => parseInt(n, 10));
+                const panel = window.app.getPanelByRowCol(layer, row, col);
+                if (!panel) return;
+                this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+            });
         });
-
-        this.ctx.restore();
     }
 
     renderPowerSelectionOverlay() {
@@ -4570,17 +4555,39 @@ class CanvasRenderer {
         const selection = window.app.powerCustomSelection || new Set();
         if (selection.size === 0) return;
 
-        // v0.8.7.2: same fix as renderCustomSelectionOverlay — apply the
-        // layer's canvas workspace offset + perspective mirror so drag-select
-        // highlights land on the panels they're targeting on multi-canvas /
-        // Back-perspective projects.
+        // v0.8.7.2.1: same fix as renderCustomSelectionOverlay — apply the
+        // layer's canvas workspace + perspective mirror + per-layer show
+        // offset so drag-select highlights land on the panels they're
+        // targeting.
+        this._withOverlayLayerTransform(layer, () => {
+            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+            selection.forEach(key => {
+                const [row, col] = key.split(',').map(n => parseInt(n, 10));
+                const panel = window.app.getPanelByRowCol(layer, row, col);
+                if (!panel) return;
+                this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+            });
+        });
+    }
+
+    /**
+     * v0.8.7.2.1: shared helper for post-render overlays that need to draw
+     * in the same coord frame as the layer they're badging (selection
+     * overlays, active port/circuit badges, etc.). Applies the layer's
+     * canvas workspace translate, the canvas's Front/Back mirror around
+     * its right edge, and the per-layer Show Look offset — exactly the
+     * stack the main render loop wraps a layer in.
+     */
+    _withOverlayLayerTransform(layer, fn) {
         const wsOff = (typeof this._layerCanvasOffset === 'function')
             ? this._layerCanvasOffset(layer) : { wx: 0, wy: 0 };
         const cid = (typeof this._effectiveLayerCanvasId === 'function')
             ? this._effectiveLayerCanvasId(layer) : null;
-        const arr = (window.app.project && window.app.project.canvases) || [];
+        const arr = (window.app && window.app.project && window.app.project.canvases) || [];
         const c = Array.isArray(arr) ? arr.find(x => x && x.id === cid) : null;
         const mirrorActive = !!(c && this._isCanvasMirrored && this._isCanvasMirrored(c));
+        const { dx, dy } = (typeof this.getLayerRenderOffset === 'function')
+            ? this.getLayerRenderOffset(layer) : { dx: 0, dy: 0 };
 
         this.ctx.save();
         if (wsOff.wx || wsOff.wy) this.ctx.translate(wsOff.wx, wsOff.wy);
@@ -4589,16 +4596,8 @@ class CanvasRenderer {
             this.ctx.translate(crw, 0);
             this.ctx.scale(-1, 1);
         }
-
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
-        selection.forEach(key => {
-            const [row, col] = key.split(',').map(n => parseInt(n, 10));
-            const panel = window.app.getPanelByRowCol(layer, row, col);
-            if (!panel) return;
-            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-        });
-
-        this.ctx.restore();
+        if (dx || dy) this.ctx.translate(dx, dy);
+        try { fn(); } finally { this.ctx.restore(); }
     }
 
     renderPixelMapSelectionOverlay() {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.2.1</title>
+    <title>LED Raster Designer v0.8.7.2.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.2.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.2.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.2.1) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.2.2) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.1</title>
+    <title>LED Raster Designer v0.8.7.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.1) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.2) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.2</title>
+    <title>LED Raster Designer v0.8.7.2.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.2</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.2.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.2) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.2.1) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.2.2</title>
+    <title>LED Raster Designer v0.8.7.3</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.2.2</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.3</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.2.2) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.3) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -148,16 +148,14 @@ def test_api_update_check_force(client):
 # ── Version consistency across all sources ────────────────────────
 
 def _extract_version(text):
-    """Extract a version like 1.0, 0.6.5, 0.6.3.6, or 0.8.7.2.2 from text
-    (with or without v prefix).
-    Tries v-prefixed first (most reliable), then falls back to 3+ part versions.
-    Allows up to 6 parts so hotfix-series naming (e.g. 0.8.7.2.2) parses cleanly."""
-    # Try v-prefixed version first (e.g. v0.6.5, v1.0, v0.8.7.2.2)
-    m = re.search(r'v(\d+\.\d+(?:\.\d+){0,4})', text)
+    """Extract a version like 1.0, 0.6.5, or 0.6.3.6 from text (with or without v prefix).
+    Tries v-prefixed first (most reliable), then falls back to 3+ part versions."""
+    # Try v-prefixed version first (e.g. v0.6.5, v1.0)
+    m = re.search(r'v(\d+\.\d+(?:\.\d+){0,2})', text)
     if m:
         return m.group(1)
     # Fall back to non-prefixed 3+ part versions to avoid matching CSS like "0.6em"
-    m = re.search(r'(\d+\.\d+\.\d+(?:\.\d+){0,3})', text)
+    m = re.search(r'(\d+\.\d+\.\d+(?:\.\d+)?)', text)
     return m.group(1) if m else None
 
 
@@ -172,13 +170,12 @@ def _read_version_from_file(rel_path, line_number=None):
 
 
 def test_version_txt_is_valid():
-    """VERSION.txt must use a 2 to 6-part version (e.g. 1.0, 0.6.5, 0.6.3.6,
-    or hotfix-series like 0.8.7.2.2)."""
+    """VERSION.txt must use a 2, 3, or 4-part version (e.g. 1.0, 0.6.5, or 0.6.3.6)."""
     version = _read_version_from_file('src/VERSION.txt')
     assert version is not None, "No version found in VERSION.txt"
     parts = version.split('.')
-    assert 2 <= len(parts) <= 6, (
-        f"VERSION.txt has {len(parts)}-part version '{version}', expected 2-6 parts (e.g. 1.0, 0.6.5, 0.6.3.6, or 0.8.7.2.2)"
+    assert len(parts) in (2, 3, 4), (
+        f"VERSION.txt has {len(parts)}-part version '{version}', expected 2-4 parts (e.g. 1.0, 0.6.5, or 0.6.3.6)"
     )
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -148,14 +148,16 @@ def test_api_update_check_force(client):
 # ── Version consistency across all sources ────────────────────────
 
 def _extract_version(text):
-    """Extract a version like 1.0, 0.6.5, or 0.6.3.6 from text (with or without v prefix).
-    Tries v-prefixed first (most reliable), then falls back to 3+ part versions."""
-    # Try v-prefixed version first (e.g. v0.6.5, v1.0)
-    m = re.search(r'v(\d+\.\d+(?:\.\d+){0,2})', text)
+    """Extract a version like 1.0, 0.6.5, 0.6.3.6, or 0.8.7.2.2 from text
+    (with or without v prefix).
+    Tries v-prefixed first (most reliable), then falls back to 3+ part versions.
+    Allows up to 6 parts so hotfix-series naming (e.g. 0.8.7.2.2) parses cleanly."""
+    # Try v-prefixed version first (e.g. v0.6.5, v1.0, v0.8.7.2.2)
+    m = re.search(r'v(\d+\.\d+(?:\.\d+){0,4})', text)
     if m:
         return m.group(1)
     # Fall back to non-prefixed 3+ part versions to avoid matching CSS like "0.6em"
-    m = re.search(r'(\d+\.\d+\.\d+(?:\.\d+)?)', text)
+    m = re.search(r'(\d+\.\d+\.\d+(?:\.\d+){0,3})', text)
     return m.group(1) if m else None
 
 
@@ -170,12 +172,13 @@ def _read_version_from_file(rel_path, line_number=None):
 
 
 def test_version_txt_is_valid():
-    """VERSION.txt must use a 2, 3, or 4-part version (e.g. 1.0, 0.6.5, or 0.6.3.6)."""
+    """VERSION.txt must use a 2 to 6-part version (e.g. 1.0, 0.6.5, 0.6.3.6,
+    or hotfix-series like 0.8.7.2.2)."""
     version = _read_version_from_file('src/VERSION.txt')
     assert version is not None, "No version found in VERSION.txt"
     parts = version.split('.')
-    assert len(parts) in (2, 3, 4), (
-        f"VERSION.txt has {len(parts)}-part version '{version}', expected 2-4 parts (e.g. 1.0, 0.6.5, or 0.6.3.6)"
+    assert 2 <= len(parts) <= 6, (
+        f"VERSION.txt has {len(parts)}-part version '{version}', expected 2-6 parts (e.g. 1.0, 0.6.5, 0.6.3.6, or 0.8.7.2.2)"
     )
 
 


### PR DESCRIPTION
## Summary
Three follow-up fixes to v0.8.7.1, shipped as v0.8.7.2 → v0.8.7.2.2 across three commits on this branch.

- **Screen-name labels snap back on canvas mutations.** `_applyProjectUpdate` was collecting client-side props into `savedClientProps` but never applying them — the follow-up branch was guarded on `applyClientSideProperties`, a method that doesn't exist, so on every canvas PUT (perspective toggle, rename, resize, visibility) the server response wiped client-side-only fields (screen-name offsets, label sizes, custom port paths, power voltage, etc.). Fix actually copies the preserved props onto the fresh layer objects.
- **Custom drag-select highlight missing on multi-canvas / Back / Show Look views.** `renderCustomSelectionOverlay` and `renderPowerSelectionOverlay` drew at workspace (0,0) under the legacy single-canvas raster clip, so highlights on canvas 2+, mirrored canvases, or Show Look (where layers render at showOffsetX/Y) landed off-screen or got clipped. Both overlays now share a `_withOverlayLayerTransform` helper that replicates the per-layer render transform stack (workspace + mirror + show offset).
- **Loading a project corrupted the active canvas raster.** The file-load path blindly wrote `projectData.raster_width` into `canvasRenderer.rasterWidth`. That setter is tab-aware (writes to `raster_width` on Pixel Map / Cabinet ID, `show_raster_width` on Show Look / Data / Power), so a file saved while on a Show Look tab — whose root raster mirror was the active canvas's *show* raster — clobbered the canvas's pixel raster with the show value on reload. Multi-canvas files now skip the legacy root-raster write entirely; `syncRasterFromProject` reads per-canvas values directly.
- Also includes a Front↔Back mirror compensation pass on screen-name offsets so the label's direction-from-layer-center stays consistent when the canvas perspective flips.

## Test plan
- [ ] Drag a screen-name label off-center on Data Flow or Power, toggle perspective Front↔Back — label stays where you put it.
- [ ] Custom drag-select on Data Flow / Power across multi-canvas projects (including Back perspective and Show Look) shows the dark highlight on selected panels live during the drag.
- [ ] Open a saved project that was last saved on a Show Look tab — each canvas's Pixel Map raster matches what it was at save time (not the Show Look raster).
- [ ] Other client-side fields (label sizes, power voltage/amperage, custom port paths, power circuit colors) survive a perspective toggle, canvas rename, visibility toggle, and resize.
- [ ] Front and Back render unchanged for projects that never touched the screen-name offset.