### PR TITLE
add GitHub issue templates with app-version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something's broken or behaving unexpectedly
+title: "Issue: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Please include the app version so we can confirm whether your build already has the fix.
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: |
+        Look at the title bar inside the app — it reads "LED Raster Designer v0.X.Y.Z". Or hit `http://127.0.0.1:8050/api/version` while the app is running.
+      placeholder: "e.g. v0.8.7.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen, and what actually happened?
+      placeholder: |
+        Steps to reproduce:
+        1. ...
+        2. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: log-file
+    attributes:
+      label: Log file
+      description: |
+        Attach the app's log file if you have it. On macOS it's at
+        `~/Library/Logs/LED Raster Designer/led_raster_designer.log`.
+        On Windows it's next to the app's `.exe` under `logs/`.
+        Drag the file into this textarea to attach it.
+      placeholder: Drag the log file here, or paste relevant lines.
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or screen recording (optional)
+      placeholder: Drag images / video here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature suggestion
+description: An idea for something new or improved
+title: "Suggestion: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: |
+        Look at the title bar inside the app — it reads "LED Raster Designer v0.X.Y.Z".
+        Helps confirm the suggestion isn't already shipped.
+      placeholder: "e.g. v0.8.7.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: What workflow is awkward or missing today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution (optional)
+      description: How would you imagine it working?
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or sketches (optional)
+      placeholder: Drag images here.


### PR DESCRIPTION
## Summary
- Adds structured issue forms (`.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`) with a **required app-version field** so reporters say which build they're on. Hints point to the in-app title bar or `/api/version`.
- Adds `config.yml` with `blank_issues_enabled: false` so reporters land on a template instead of an empty box.

## Test plan
- [ ] Visit Issues → New issue and confirm both forms render with the App version field marked required.