### PR TITLE
v0.8.7.4: export filename naming (underscore + project_view_canvas)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.3
+# LED Raster Designer v0.8.7.4
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,22 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.4 - May 11, 2026
+----------------------------
+Export filename naming convention.
+
+- CHANGE: Export filenames now use underscore separators and order
+  segments as project_view_canvas (was project - canvas - view with
+  spaced hyphens). Alphabetical sort in the export folder now groups
+  files by view: all Pixel Maps cluster, then all Data Maps, then
+  all Power Maps, etc. — far easier to hand a tech a folder of 20+
+  exports. Internal spaces in user-typed project / canvas / view
+  names are preserved.
+  - Single-canvas:  "MyProject_Pixel Map.psd"
+  - Multi-canvas:   "MyProject_Pixel Map_SR Beach.psd"
+  PDF page labels (used inside the document, not as filenames) are
+  unchanged.
+
 v0.8.7.3 - May 11, 2026
 ----------------------------
 Three follow-up fixes after v0.8.7.1 preview testing.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.3',
-            'CFBundleVersion': '0.8.7.3',
+            'CFBundleShortVersionString': '0.8.7.4',
+            'CFBundleVersion': '0.8.7.4',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7769,9 +7769,14 @@ class LEDRasterApp {
         const multiCanvas = canvasIds.length > 1 && canvasIds[0] !== null;
         const buildName = (cid, suffix, ext) => {
             const cname = canvasNameOf(cid);
+            // v0.8.7.4: underscore-separated, view-before-canvas ordering so
+            // alphabetical sort groups all Pixel Maps together, all Data Maps
+            // together, etc. Internal spaces in user-typed project/canvas
+            // names are kept verbatim — the change is only in the separators
+            // and segment order.
             return (multiCanvas && cname)
-                ? `${projectName} - ${cname} - ${suffix}.${ext}`
-                : `${projectName} ${suffix}.${ext}`;
+                ? `${projectName}_${suffix}_${cname}.${ext}`
+                : `${projectName}_${suffix}.${ext}`;
         };
 
         // v0.8.7.1: read per-canvas perspective dropdowns so the filename
@@ -8183,11 +8188,12 @@ class LEDRasterApp {
                         ? this.sanitizeFilename(targetCanvas.name || 'Canvas')
                         : null;
                     // Filename: include canvas token only when exporting
-                    // more than one. Single-canvas exports keep the v0.7
-                    // naming so existing user workflows aren't disrupted.
+                    // more than one. v0.8.7.4: underscore-separated and
+                    // view-before-canvas ordering so alphabetical sort
+                    // groups all Pixel Maps, all Data Maps, etc. together.
                     const fileBase = (multiCanvas && canvasName)
-                        ? `${projectName} - ${canvasName} - ${suffix}`
-                        : `${projectName} ${suffix}`;
+                        ? `${projectName}_${suffix}_${canvasName}`
+                        : `${projectName}_${suffix}`;
                     // PDF page label includes canvas + view when multi.
                     const pdfLabel = (multiCanvas && canvasName)
                         ? `${canvasName}, ${suffix}`

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.3</title>
+    <title>LED Raster Designer v0.8.7.4</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.4</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.3) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.4) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">


### PR DESCRIPTION
## Summary
Renames the export filename convention so a folder of 20+ exports sorts into useful groups in any file manager.

- **Before:** \`MyProject - SR Beach - Pixel Map.psd\` (spaced hyphens, canvas-before-view)
- **After (single canvas):** \`MyProject_Pixel Map.psd\`
- **After (multi canvas):** \`MyProject_Pixel Map_SR Beach.psd\`

Alphabetical sort now groups all Pixel Maps, then all Data Maps, then all Power Maps, etc. Internal spaces in user-typed project / canvas / view names are preserved verbatim — only the segment separators changed.

PDF page labels (used inside the document, not as a filename) are unchanged.

## Test plan
- [ ] Single-canvas project: PSD/PNG/PDF exports use \`Project_View.ext\`.
- [ ] Multi-canvas project: PSD/PNG exports use \`Project_View_Canvas.ext\`, files sort by view in Finder/Explorer.
- [ ] Export preview pane in the modal matches the actual emitted filenames.
- [ ] PDF page labels inside the multi-page PDF still read "Canvas, View" (unchanged).