### PR TITLE
v0.8.7.5: editable canvas name in the export modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.4
+# LED Raster Designer v0.8.7.5
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,22 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.5 - May 11, 2026
+----------------------------
+Per-canvas filename override in the export modal.
+
+- FEATURE: Each canvas row in the export dialog now has a "Name"
+  text input next to the perspective dropdowns. Typing a value
+  there overrides the canvas's project name in the exported
+  filename only — the canvas's stored name (sidebar / project
+  file) is untouched, so the override is a per-export
+  customization rather than a permanent rename. Placeholder shows
+  the canvas's current project name so it's clear what's being
+  replaced. Empty input falls back to the project name. Override
+  also forces the canvas segment to appear in single-canvas
+  exports (otherwise typing a name and seeing no change in the
+  filename would be confusing).
+
 v0.8.7.4 - May 11, 2026
 ----------------------------
 Export filename naming convention.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.4',
-            'CFBundleVersion': '0.8.7.4',
+            'CFBundleShortVersionString': '0.8.7.5',
+            'CFBundleVersion': '0.8.7.5',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -7761,19 +7761,26 @@ class LEDRasterApp {
         }
         const projectCanvases = (this.project && Array.isArray(this.project.canvases))
             ? this.project.canvases : [];
+        // v0.8.7.5: per-canvas Name inputs in the export modal are
+        // prefilled with the canvas's stored name and the user can edit
+        // them in place (same pattern as the view-suffix inputs). The
+        // value is filename-only — the canvas's stored name in the
+        // sidebar / project is untouched. Empty falls back to canvas.name.
+        const nameByCid = {};
+        document.querySelectorAll('.export-canvas-name-override').forEach(inp => {
+            const cid = inp.dataset.canvasId;
+            const v = (inp.value || '').trim();
+            if (cid && v) nameByCid[cid] = v;
+        });
         const canvasNameOf = (cid) => {
             if (!cid) return '';
             const c = projectCanvases.find(x => x && x.id === cid);
-            return c ? this.sanitizeFilename(c.name || 'Canvas') : '';
+            const raw = nameByCid[cid] || (c && c.name) || 'Canvas';
+            return this.sanitizeFilename(raw);
         };
         const multiCanvas = canvasIds.length > 1 && canvasIds[0] !== null;
         const buildName = (cid, suffix, ext) => {
             const cname = canvasNameOf(cid);
-            // v0.8.7.4: underscore-separated, view-before-canvas ordering so
-            // alphabetical sort groups all Pixel Maps together, all Data Maps
-            // together, etc. Internal spaces in user-typed project/canvas
-            // names are kept verbatim — the change is only in the separators
-            // and segment order.
             return (multiCanvas && cname)
                 ? `${projectName}_${suffix}_${cname}.${ext}`
                 : `${projectName}_${suffix}.${ext}`;
@@ -7950,9 +7957,16 @@ class LEDRasterApp {
             const row = document.createElement('div');
             row.className = 'export-view-row';
             const isHidden = c.visible === false;
-            const label = document.createElement('label');
-            label.className = 'export-view-label';
-            label.style.gap = '6px';
+            // v0.8.7.5: col-1 of the row holds checkbox + swatch + an
+            // editable canvas-name input (replacing the previous static
+            // name span). Editing the input changes the canvas segment
+            // in the exported filename only — the canvas's stored name
+            // in the sidebar / project file is untouched. Using a div
+            // (not a label) so clicking the input doesn't toggle the
+            // checkbox.
+            const labelCol = document.createElement('div');
+            labelCol.className = 'export-view-label';
+            labelCol.style.gap = '6px';
             const swatch = document.createElement('span');
             swatch.style.cssText = `display:inline-block;width:10px;height:10px;border-radius:2px;background:${c.color || '#4A90E2'};flex:none;`;
             const checkbox = document.createElement('input');
@@ -7961,13 +7975,27 @@ class LEDRasterApp {
             checkbox.dataset.canvasId = c.id;
             checkbox.className = 'export-canvas-checkbox';
             checkbox.addEventListener('change', () => this.updateExportPreview());
-            const text = document.createElement('span');
-            text.textContent = (c.name || `Canvas ${idx + 1}`) + (isHidden ? '  (hidden)' : '');
-            if (isHidden) text.style.color = '#888';
-            label.appendChild(checkbox);
-            label.appendChild(swatch);
-            label.appendChild(text);
-            row.appendChild(label);
+            const nameInput = document.createElement('input');
+            nameInput.type = 'text';
+            nameInput.className = 'export-canvas-name-override';
+            nameInput.dataset.canvasId = c.id;
+            nameInput.value = c.name || `Canvas ${idx + 1}`;
+            nameInput.title = 'Edit to rename this canvas in the exported filename. Does NOT rename the canvas in the project.';
+            // Inline override so the input stays compact inside the
+            // 140px label column and doesn't pick up the chunky 8px
+            // padding from `.export-view-row input[type="text"]`.
+            nameInput.style.cssText = `flex:1;min-width:60px;padding:2px 6px;font-size:12px;background:#222;color:${isHidden ? '#888' : '#ddd'};border:1px solid #444;border-radius:3px;`;
+            nameInput.addEventListener('input', () => this.updateExportPreview());
+            labelCol.appendChild(checkbox);
+            labelCol.appendChild(swatch);
+            labelCol.appendChild(nameInput);
+            if (isHidden) {
+                const hiddenTag = document.createElement('span');
+                hiddenTag.textContent = '(hidden)';
+                hiddenTag.style.cssText = 'color:#888;font-size:11px;flex:none;';
+                labelCol.appendChild(hiddenTag);
+            }
+            row.appendChild(labelCol);
             // v0.8.6: per-canvas perspective overrides for Data + Power
             // exports. Default to whatever the canvas currently has.
             // These dropdowns set/restore the canvas's perspective during
@@ -8075,6 +8103,16 @@ class LEDRasterApp {
             if (!o) return;
             if (o.data_flow_perspective) c.data_flow_perspective = o.data_flow_perspective;
             if (o.power_perspective) c.power_perspective = o.power_perspective;
+        });
+        // v0.8.7.5: per-canvas Name inputs from the export modal. Each is
+        // prefilled with the canvas's stored name and the user can edit
+        // in place. Filename-only — never written back to the canvas
+        // object. Empty entries fall back to canvas.name below.
+        const nameOverridesByCid = {};
+        document.querySelectorAll('.export-canvas-name-override').forEach(inp => {
+            const cid = inp.dataset.canvasId;
+            const v = (inp.value || '').trim();
+            if (cid && v) nameOverridesByCid[cid] = v;
         });
 
         const exportCanvas = document.createElement('canvas');
@@ -8184,13 +8222,18 @@ class LEDRasterApp {
 
                     const dataUrl = exportCanvas.toDataURL('image/png');
                     const suffix = this.getExportSuffixForView(view, suffixes, viewNames, targetCanvas);
+                    // v0.8.7.5: per-canvas Name input from the export modal
+                    // takes precedence over targetCanvas.name when present.
+                    // Empty / whitespace = fall back to canvas name.
+                    const overrideRaw = nameOverridesByCid[cid];
                     const canvasName = targetCanvas
-                        ? this.sanitizeFilename(targetCanvas.name || 'Canvas')
+                        ? this.sanitizeFilename(overrideRaw || targetCanvas.name || 'Canvas')
                         : null;
                     // Filename: include canvas token only when exporting
-                    // more than one. v0.8.7.4: underscore-separated and
-                    // view-before-canvas ordering so alphabetical sort
-                    // groups all Pixel Maps, all Data Maps, etc. together.
+                    // more than one canvas (v0.8.7.4). Single-canvas
+                    // exports keep `Project_View.ext`; the Name input on
+                    // a single-canvas export only matters if you happen
+                    // to also have a hidden sibling canvas selected.
                     const fileBase = (multiCanvas && canvasName)
                         ? `${projectName}_${suffix}_${canvasName}`
                         : `${projectName}_${suffix}`;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.4</title>
+    <title>LED Raster Designer v0.8.7.5</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.5</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.4) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.5) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">


### PR DESCRIPTION
## Summary
Each canvas row in the export dialog now has an editable text input in the leftmost slot (replacing the static name span). The field is prefilled with the canvas's stored name and the user can rename it in place — same pattern as the existing Pixel Map / Data Map view-suffix inputs.

Edits only affect the exported filename's canvas segment. The canvas's stored name in the sidebar / project file is untouched, so the rename is a per-export customization without polluting project state.

## Test plan
- [ ] Open the export modal on a multi-canvas project. Each canvas row has an editable name input prefilled with the canvas name.
- [ ] Type a new name in one row → filename preview updates live.
- [ ] Close and re-open the modal → fields reset to canvas's stored name (override is modal-local, not persisted).
- [ ] Sidebar canvas list and project save are unchanged by the override.
- [ ] Blank the input → exported filename uses the canvas's stored name.