### PR TITLE
v0.8.7.6: refresh sidebar inputs after layer delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.5
+# LED Raster Designer v0.8.7.6
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,25 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.6 - May 11, 2026
+----------------------------
+Sidebar refresh after deleting a layer.
+
+- FIX: Deleting a layer left the sidebar's panel-property inputs
+  (cabinet_width, cabinet_height, columns, rows, etc.) showing the
+  DELETED layer's values. The next "Update Properties" round-trip
+  read those stale values out of the inputs and wrote them onto the
+  newly-promoted surviving layer, silently clobbering its real
+  panel dimensions while the on-canvas panels stayed sized
+  correctly (panel geometry is already baked into layer.panels).
+  Repro: add a screen from a small-panel preset (e.g. VN 8.3 with
+  60x120 cabinets), delete the default Brompton screen (192x384
+  cabinets), then edit the surviving screen's column count — its
+  cabinet field silently flipped to 192x384.
+  Fix: deleteCurrentLayer now refreshes the layer-property inputs
+  via loadLayerToInputs() after the post-delete currentLayer
+  reassignment, so the sidebar matches the actual surviving layer.
+
 v0.8.7.5 - May 11, 2026
 ----------------------------
 Per-canvas filename override in the export modal.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.5',
-            'CFBundleVersion': '0.8.7.5',
+            'CFBundleShortVersionString': '0.8.7.6',
+            'CFBundleVersion': '0.8.7.6',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -12765,7 +12765,25 @@ class LEDRasterApp {
                             this.lastSelectedLayerId = null;
                             this.selectionAnchorLayerId = null;
                         }
-                        
+
+                        // v0.8.7.6: refresh the layer-property inputs from
+                        // the newly-promoted currentLayer. Without this the
+                        // sidebar keeps showing the DELETED layer's
+                        // cabinet_width / cabinet_height / columns / rows /
+                        // etc., and the next "Update Properties" round-trip
+                        // reads those stale values out of the inputs and
+                        // writes them onto the surviving layer — clobbering
+                        // its actual panel dimensions while the on-canvas
+                        // panels stay sized correctly (because the panel
+                        // geometry is already baked into layer.panels).
+                        // Repro that exposed this: add a VN-8.3 preset
+                        // screen (cabinet 60x120), delete the default
+                        // Brompton screen (cabinet 192x384), edit the
+                        // surviving screen's column count → its cabinet
+                        // silently flipped to 192x384.
+                        if (this.currentLayer && typeof this.loadLayerToInputs === 'function') {
+                            try { this.loadLayerToInputs(); } catch (_) {}
+                        }
                         this.updateUI();
                     })
                     .finally(() => {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.5</title>
+    <title>LED Raster Designer v0.8.7.6</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.5</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.6</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.5) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.6) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">


### PR DESCRIPTION
## Summary
Deleting a layer left the sidebar's panel-property inputs (cabinet width/height, columns, rows, etc.) showing the DELETED layer's values. The next "Update Properties" round-trip read those stale values out of the inputs and wrote them onto the newly-promoted surviving layer — clobbering its real cabinet dimensions and forcing the server to rebuild every panel at the wrong size. The on-canvas screen visually resized as a result.

**Repro**
1. Add a VN 8.3 preset screen (cabinet 60×120)
2. Click the default Brompton screen (cabinet 192×384)
3. Delete it
4. Edit the surviving screen's columns — its cabinet flipped to 192×384 and the panels grew accordingly

**Fix**: `deleteCurrentLayer` now calls `loadLayerToInputs()` after the post-delete `currentLayer` reassignment, so the sidebar inputs come from the surviving layer.

## Test plan
- [ ] Repro above no longer flips cabinet dimensions or panel sizes
- [ ] Single-layer projects (where delete leaves nothing) still handle the empty-state cleanly
- [ ] Multi-select delete still selects a remaining layer and shows its values