### PR TITLE
v0.8.7.7: click-to-drag screen name labels on every tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Half-tiles count as **0.5 panel** for data/port math and **0.65 panel** for powe
 | **Spacebar + Drag** | Pan the canvas |
 | **Scroll Wheel** | Zoom in/out |
 | **Shift + Drag a screen** | Move the screen (in Pixel Map = processor position; in Show Look = stage position) |
+| **Click & Drag a screen-name label** | Reposition the screen's white name label on any tab. The associated info bar (port/circuit stats, or "Columns × Rows • Cabinets…" on Pixel Map) moves with it. Per-tab position. |
 | **Drag-select on empty space** | Marquee-select layers (Pixel Map) or panels (when starting on a current-layer panel) |
 | **Magnetic Snap toggle** | Snap dragged screens to other screens' edges and to raster bounds |
 | **Fit / 1:1 buttons** | Fit raster to view, or reset to 100% zoom |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.6
+# LED Raster Designer v0.8.7.7
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,28 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.7 - May 11, 2026
+----------------------------
+Screen-name labels are now grabbable on every tab.
+
+- FEATURE: Click directly on a screen's name label (the white
+  box) and drag to reposition. Works on Pixel Map, Cabinet ID,
+  Data Flow, and Power — no Shift modifier required. The label
+  rect is hit-tested in workspace coords so it lines up across
+  multi-canvas layouts, Back-perspective canvases, and Show Look
+  offsets. Plain Shift+drag still moves the whole layer on Pixel
+  Map (its primary layer-position gesture), unchanged.
+- The associated label group moves with the screen name as one
+  unit: on Data Flow / Power the "X Mains, Y Backups | Z Ports"
+  or "X Multi, Y Circuits | A1ph / A3ph" center info follows; on
+  Pixel Map the "Columns × Rows • Cabinets • Resolution • Aspect
+  Ratio • Weight" info bar at the bottom shifts by the same
+  offset.
+- Position persists per-tab. Pixel Map gets its own
+  screenNameOffsetXPixelMap / screenNameOffsetYPixelMap fields
+  alongside the existing Cabinet / Data / Power offsets, so each
+  view keeps its own label arrangement.
+
 v0.8.7.6 - May 11, 2026
 ----------------------------
 Sidebar refresh after deleting a layer.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.6',
-            'CFBundleVersion': '0.8.7.6',
+            'CFBundleShortVersionString': '0.8.7.7',
+            'CFBundleVersion': '0.8.7.7',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1228,6 +1228,8 @@ class LEDRasterApp {
             screenNameSizeCabinet: layer.screenNameSizeCabinet,
             screenNameSizeDataFlow: layer.screenNameSizeDataFlow,
             screenNameSizePower: layer.screenNameSizePower,
+            screenNameOffsetXPixelMap: layer.screenNameOffsetXPixelMap,
+            screenNameOffsetYPixelMap: layer.screenNameOffsetYPixelMap,
             screenNameOffsetXCabinet: layer.screenNameOffsetXCabinet,
             screenNameOffsetYCabinet: layer.screenNameOffsetYCabinet,
             screenNameOffsetXDataFlow: layer.screenNameOffsetXDataFlow,
@@ -1428,6 +1430,8 @@ class LEDRasterApp {
                         if (layerProps.screenNameSizePower !== undefined) layer.screenNameSizePower = layerProps.screenNameSizePower;
                         if (layerProps.showDataFlowPortInfo !== undefined) layer.showDataFlowPortInfo = layerProps.showDataFlowPortInfo;
                         if (layerProps.showPowerCircuitInfo !== undefined) layer.showPowerCircuitInfo = layerProps.showPowerCircuitInfo;
+                        if (layerProps.screenNameOffsetXPixelMap !== undefined) layer.screenNameOffsetXPixelMap = layerProps.screenNameOffsetXPixelMap;
+                        if (layerProps.screenNameOffsetYPixelMap !== undefined) layer.screenNameOffsetYPixelMap = layerProps.screenNameOffsetYPixelMap;
                         if (layerProps.screenNameOffsetXCabinet !== undefined) layer.screenNameOffsetXCabinet = layerProps.screenNameOffsetXCabinet;
                         if (layerProps.screenNameOffsetYCabinet !== undefined) layer.screenNameOffsetYCabinet = layerProps.screenNameOffsetYCabinet;
                         if (layerProps.screenNameOffsetXDataFlow !== undefined) layer.screenNameOffsetXDataFlow = layerProps.screenNameOffsetXDataFlow;
@@ -1626,6 +1630,8 @@ class LEDRasterApp {
                 screenNameSizePower: layer.screenNameSizePower,
                 
                 // Tab-specific screen name positions
+                screenNameOffsetXPixelMap: layer.screenNameOffsetXPixelMap,
+                screenNameOffsetYPixelMap: layer.screenNameOffsetYPixelMap,
                 screenNameOffsetXCabinet: layer.screenNameOffsetXCabinet,
                 screenNameOffsetYCabinet: layer.screenNameOffsetYCabinet,
                 screenNameOffsetXDataFlow: layer.screenNameOffsetXDataFlow,
@@ -6399,6 +6405,8 @@ class LEDRasterApp {
                 const preservedProps = {
                     screenNameOffsetX: this.currentLayer.screenNameOffsetX,
                     screenNameOffsetY: this.currentLayer.screenNameOffsetY,
+                    screenNameOffsetXPixelMap: this.currentLayer.screenNameOffsetXPixelMap,
+                    screenNameOffsetYPixelMap: this.currentLayer.screenNameOffsetYPixelMap,
                     screenNameOffsetXCabinet: this.currentLayer.screenNameOffsetXCabinet,
                     screenNameOffsetYCabinet: this.currentLayer.screenNameOffsetYCabinet,
                     screenNameOffsetXDataFlow: this.currentLayer.screenNameOffsetXDataFlow,
@@ -6520,6 +6528,8 @@ class LEDRasterApp {
                 showOffsetY: layer.showOffsetY,
                 screenNameOffsetX: layer.screenNameOffsetX,
                 screenNameOffsetY: layer.screenNameOffsetY,
+                screenNameOffsetXPixelMap: layer.screenNameOffsetXPixelMap,
+                screenNameOffsetYPixelMap: layer.screenNameOffsetYPixelMap,
                 screenNameOffsetXCabinet: layer.screenNameOffsetXCabinet,
                 screenNameOffsetYCabinet: layer.screenNameOffsetYCabinet,
                 screenNameOffsetXDataFlow: layer.screenNameOffsetXDataFlow,
@@ -13035,6 +13045,8 @@ class LEDRasterApp {
             screenNameSizeCabinet: layer.screenNameSizeCabinet,
             screenNameSizeDataFlow: layer.screenNameSizeDataFlow,
             screenNameSizePower: layer.screenNameSizePower,
+            screenNameOffsetXPixelMap: layer.screenNameOffsetXPixelMap,
+            screenNameOffsetYPixelMap: layer.screenNameOffsetYPixelMap,
             screenNameOffsetXCabinet: layer.screenNameOffsetXCabinet,
             screenNameOffsetYCabinet: layer.screenNameOffsetYCabinet,
             screenNameOffsetXDataFlow: layer.screenNameOffsetXDataFlow,

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -542,6 +542,47 @@ class CanvasRenderer {
         const worldY = (mouseY - this.panY) / this.zoom;
         const worldX = this._unmirrorWorldX((mouseX - this.panX) / this.zoom, worldY);
 
+        // v0.8.7.7: plain-click directly on a screen-name label starts a
+        // screen-name drag (no modifier needed). This is the universal
+        // "grab the label" gesture across every tab — Pixel Map, Cabinet
+        // ID, Data Flow, Power. The label rect is cached on the layer by
+        // renderLayerLabels at draw time so this hit-test stays in sync
+        // with what's drawn. Only checks the active currentLayer's label
+        // — clicking some other layer's label still needs Shift / etc.
+        if (e.button === 0 && !this.spacePressed && !e.altKey && !e.shiftKey
+                && !e.metaKey && !e.ctrlKey
+                && window.app && window.app.currentLayer
+                && (window.app.currentLayer.type || 'screen') === 'screen'
+                && this.viewMode !== 'show-look') {
+            const _r = window.app.currentLayer._screenNameHitRect;
+            if (_r && _r.viewMode === this.viewMode
+                    && worldX >= _r.x1 && worldX <= _r.x2
+                    && worldY >= _r.y1 && worldY <= _r.y2) {
+                this.isDraggingScreenName = true;
+                this.dragScreenNameStartX = worldX;
+                this.dragScreenNameStartY = worldY;
+                let currentOffsetX = 0;
+                let currentOffsetY = 0;
+                const layer = window.app.currentLayer;
+                if (this.viewMode === 'pixel-map') {
+                    currentOffsetX = layer.screenNameOffsetXPixelMap || 0;
+                    currentOffsetY = layer.screenNameOffsetYPixelMap || 0;
+                } else if (this.viewMode === 'cabinet-id') {
+                    currentOffsetX = layer.screenNameOffsetXCabinet || 0;
+                    currentOffsetY = layer.screenNameOffsetYCabinet || 0;
+                } else if (this.viewMode === 'data-flow') {
+                    currentOffsetX = layer.screenNameOffsetXDataFlow || 0;
+                    currentOffsetY = layer.screenNameOffsetYDataFlow || 0;
+                } else if (this.viewMode === 'power') {
+                    currentOffsetX = layer.screenNameOffsetXPower || 0;
+                    currentOffsetY = layer.screenNameOffsetYPower || 0;
+                }
+                this.screenNameStartOffset = { x: currentOffsetX, y: currentOffsetY };
+                this.canvas.style.cursor = 'move';
+                return;
+            }
+        }
+
         // Slice 5: dragging a canvas's dashed outline edge repositions
         // the canvas in the workspace. Must be checked BEFORE the Slice 4
         // panel/canvas-activate block so edge-drag wins over body-click
@@ -653,11 +694,14 @@ class CanvasRenderer {
                     this.isDraggingScreenName = true;
                     this.dragScreenNameStartX = worldX;
                     this.dragScreenNameStartY = worldY;
-                    
+
                     let currentOffsetX = 0;
                     let currentOffsetY = 0;
-                    
-                    if (this.viewMode === 'cabinet-id') {
+
+                    if (this.viewMode === 'pixel-map') {
+                        currentOffsetX = window.app.currentLayer.screenNameOffsetXPixelMap || 0;
+                        currentOffsetY = window.app.currentLayer.screenNameOffsetYPixelMap || 0;
+                    } else if (this.viewMode === 'cabinet-id') {
                         currentOffsetX = window.app.currentLayer.screenNameOffsetXCabinet || 0;
                         currentOffsetY = window.app.currentLayer.screenNameOffsetYCabinet || 0;
                     } else if (this.viewMode === 'data-flow') {
@@ -667,7 +711,7 @@ class CanvasRenderer {
                         currentOffsetX = window.app.currentLayer.screenNameOffsetXPower || 0;
                         currentOffsetY = window.app.currentLayer.screenNameOffsetYPower || 0;
                     }
-                    
+
                     this.screenNameStartOffset = { x: currentOffsetX, y: currentOffsetY };
                     return;
                 }
@@ -1164,7 +1208,10 @@ class CanvasRenderer {
                 }
                 
                 // Store in tab-specific properties
-                if (this.viewMode === 'cabinet-id') {
+                if (this.viewMode === 'pixel-map') {
+                    layer.screenNameOffsetXPixelMap = newOffsetX;
+                    layer.screenNameOffsetYPixelMap = newOffsetY;
+                } else if (this.viewMode === 'cabinet-id') {
                     layer.screenNameOffsetXCabinet = newOffsetX;
                     layer.screenNameOffsetYCabinet = newOffsetY;
                 } else if (this.viewMode === 'data-flow') {
@@ -1621,7 +1668,10 @@ class CanvasRenderer {
                 let currentOffsetX = 0;
                 let currentOffsetY = 0;
 
-                if (this.viewMode === 'cabinet-id') {
+                if (this.viewMode === 'pixel-map') {
+                    currentOffsetX = layer.screenNameOffsetXPixelMap || 0;
+                    currentOffsetY = layer.screenNameOffsetYPixelMap || 0;
+                } else if (this.viewMode === 'cabinet-id') {
                     currentOffsetX = layer.screenNameOffsetXCabinet || 0;
                     currentOffsetY = layer.screenNameOffsetYCabinet || 0;
                 } else if (this.viewMode === 'data-flow') {
@@ -4030,6 +4080,12 @@ class CanvasRenderer {
     }
     
     renderLayerLabels(layer) {
+        // v0.8.7.7: clear any stale screen-name hit rect from a previous
+        // render; the if-block below resets it when the label is actually
+        // drawn, but layers with showLabelName off (or tab-specific
+        // toggles like showLabelNameCabinet) need a clean slate so a
+        // mousedown doesn't catch the ghost.
+        if (layer && layer._screenNameHitRect) layer._screenNameHitRect = null;
         if ((layer.type || 'screen') === 'image') {
             return;
         }
@@ -4238,7 +4294,14 @@ class CanvasRenderer {
         let screenNameOffsetX = 0;
         let screenNameOffsetY = 0;
         
-        if (this.viewMode === 'cabinet-id') {
+        if (this.viewMode === 'pixel-map') {
+            // v0.8.7.7: Pixel Map screen-name size stays tied to the
+            // legacy labelsFontSize slider (the default for pixel-map),
+            // but the X/Y offset is now read from per-view fields so the
+            // user can Shift+Alt+drag the name out of the center stack.
+            screenNameOffsetX = layer.screenNameOffsetXPixelMap || 0;
+            screenNameOffsetY = layer.screenNameOffsetYPixelMap || 0;
+        } else if (this.viewMode === 'cabinet-id') {
             screenNameSize = layer.screenNameSizeCabinet || 14;
             screenNameOffsetX = layer.screenNameOffsetXCabinet || 0;
             screenNameOffsetY = layer.screenNameOffsetYCabinet || 0;
@@ -4306,8 +4369,19 @@ class CanvasRenderer {
                     screenNameY = centerY;
                 }
             } else {
-                // Pixel map mode - keep original center position
-                screenNameY = currentY + screenNameHeight / 2;
+                // Pixel map mode — default to centered in the label stack
+                // (with the info line below). v0.8.7.7: if the user has
+                // shifted the name via Shift+Alt+drag, apply the stored
+                // offset on top of the stacked baseline. Offset 0/0 keeps
+                // the legacy centered behavior.
+                screenNameX = centerX + screenNameOffsetX;
+                screenNameY = (currentY + screenNameHeight / 2) + screenNameOffsetY;
+                if (screenNameX < bounds.x || screenNameX > bounds.x + layerWidth) {
+                    screenNameX = centerX;
+                }
+                if (screenNameY < bounds.y || screenNameY > bounds.y + layerHeight) {
+                    screenNameY = currentY + screenNameHeight / 2;
+                }
             }
             
             this.ctx.font = `bold ${screenNameSize}px Arial`;
@@ -4317,10 +4391,31 @@ class CanvasRenderer {
             const metrics = this.ctx.measureText(screenName);
             const nameWidth = metrics.width + padding * 2;
             const nameHeight = screenNameLineHeight + padding * 2;
-            
+
             const nameX = screenNameX - nameWidth / 2;
             const nameY = screenNameY - nameHeight / 2;
-            
+
+            // v0.8.7.7: cache the label rect in workspace (un-mirrored)
+            // coords so a plain mousedown can hit-test it and start a
+            // screen-name drag without needing a Shift modifier. Includes
+            // the layer's canvas workspace offset and the per-layer Show
+            // Look translate (this._renderDx / this._renderDy) so the
+            // rect lines up with where the label is actually drawn on
+            // screen across multi-canvas / Show Look views.
+            if (!this.exportMode) {
+                const _wsOff = (typeof this._layerCanvasOffset === 'function')
+                    ? this._layerCanvasOffset(layer) : { wx: 0, wy: 0 };
+                const _ldx = (typeof this._renderDx === 'number') ? this._renderDx : 0;
+                const _ldy = (typeof this._renderDy === 'number') ? this._renderDy : 0;
+                layer._screenNameHitRect = {
+                    x1: _wsOff.wx + _ldx + nameX,
+                    y1: _wsOff.wy + _ldy + nameY,
+                    x2: _wsOff.wx + _ldx + nameX + nameWidth,
+                    y2: _wsOff.wy + _ldy + nameY + nameHeight,
+                    viewMode: this.viewMode,
+                };
+            }
+
             // Clip to layer bounds so labels don't overflow the screen edge
             this.ctx.save();
             this.ctx.beginPath();
@@ -4349,6 +4444,34 @@ class CanvasRenderer {
                 infoAnchorY = nameY + nameHeight + 5;
             }
         }
+
+        // v0.8.7.7: when the user has dragged the screen-name label off
+        // its default center position, the other identification labels
+        // (port/circuit stats above, "Columns × Rows • Cabinets..." info
+        // bar at the bottom) shift by the same offset so the whole label
+        // group moves as one unit. Falls back to 0/0 when the layer has
+        // no offset for the current view OR no screen name is shown.
+        let _labelGroupOffsetX = 0;
+        let _labelGroupOffsetY = 0;
+        if (screenName) {
+            if (this.viewMode === 'pixel-map') {
+                _labelGroupOffsetX = layer.screenNameOffsetXPixelMap || 0;
+                _labelGroupOffsetY = layer.screenNameOffsetYPixelMap || 0;
+            } else if (this.viewMode === 'cabinet-id') {
+                _labelGroupOffsetX = layer.screenNameOffsetXCabinet || 0;
+                _labelGroupOffsetY = layer.screenNameOffsetYCabinet || 0;
+            } else if (this.viewMode === 'data-flow') {
+                _labelGroupOffsetX = layer.screenNameOffsetXDataFlow || 0;
+                _labelGroupOffsetY = layer.screenNameOffsetYDataFlow || 0;
+            } else if (this.viewMode === 'power') {
+                _labelGroupOffsetX = layer.screenNameOffsetXPower || 0;
+                _labelGroupOffsetY = layer.screenNameOffsetYPower || 0;
+            }
+            // Mirror compensation for Back-perspective canvases (Data /
+            // Power). Matches the same negation applied to the screen-name
+            // X above so the group stays visually together.
+            if (this._mirror) _labelGroupOffsetX = -_labelGroupOffsetX;
+        }
         
         // Render other center labels with dark background (regular style)
         if (centerLines.length > 0) {
@@ -4364,9 +4487,15 @@ class CanvasRenderer {
             
             const bgWidth = maxWidth + padding * 2;
             const bgHeight = centerLines.length * lineHeight + padding * 2;
-            const bgX = centerX - bgWidth / 2;
-            const bgY = this.viewMode === 'pixel-map' ? currentY : (infoAnchorY ?? currentY);
-            
+            // v0.8.7.7: shift the center-info group horizontally by the
+            // same offset the screen-name moved (Y is already tracked
+            // via infoAnchorY for non-pixel-map, and via _labelGroupOffsetY
+            // applied below for pixel-map).
+            const bgX = (centerX + _labelGroupOffsetX) - bgWidth / 2;
+            const bgY = (this.viewMode === 'pixel-map'
+                ? currentY + _labelGroupOffsetY
+                : (infoAnchorY ?? currentY));
+
             // Clip to layer bounds so labels don't bleed through higher layers
             this.ctx.save();
             this.ctx.beginPath();
@@ -4382,7 +4511,7 @@ class CanvasRenderer {
             this.ctx.fillStyle = layer.labelsColor || '#ffffff';
             let yPos = bgY + padding + lineHeight / 2;
             centerLines.forEach(line => {
-                this._fillText(line, this.snap(centerX), this.snap(yPos));
+                this._fillText(line, this.snap(centerX + _labelGroupOffsetX), this.snap(yPos));
                 yPos += lineHeight;
             });
 
@@ -4405,9 +4534,12 @@ class CanvasRenderer {
             
             const bgWidth = maxWidth + padding * 2;
             const bgHeight = infoLines.length * infoLineHeight + padding * 2;
-            const bgX = centerX - bgWidth / 2;
-            const bgY = bottomY - bgHeight - padding;
-            
+            // v0.8.7.7: bottom-anchored info bar follows the screen-name
+            // offset so the whole label group moves together when the
+            // user drags.
+            const bgX = (centerX + _labelGroupOffsetX) - bgWidth / 2;
+            const bgY = (bottomY + _labelGroupOffsetY) - bgHeight - padding;
+
             // Draw background
             this.ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
             const snappedInfoRect = this.snapRect(bgX, bgY, bgWidth, bgHeight);
@@ -4417,7 +4549,7 @@ class CanvasRenderer {
             this.ctx.fillStyle = layer.labelsColor || '#ffffff';
             let yPos = bgY + padding + infoLineHeight;
             infoLines.forEach(line => {
-                this._fillText(line, this.snap(centerX), this.snap(yPos));
+                this._fillText(line, this.snap(centerX + _labelGroupOffsetX), this.snap(yPos));
                 yPos += infoLineHeight;
             });
         }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -300,7 +300,7 @@
                             <input type="number" id="screen-name-size-cabinet" value="30" min="8" max="200" autocomplete="off" style="width: 60px;">
                         </div>
                         
-                        <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Shift+drag screen name to reposition</p>
+                        <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Click & drag the screen name to reposition</p>
                         
                         <div class="info-row checkbox-row" data-tooltip="Show Cabinet ID, Display the column-row identifier label on each cabinet panel.">
                             <input type="checkbox" id="show-numbers" checked>
@@ -436,7 +436,7 @@
                             <label for="show-data-flow-port-info">Show Port Info</label>
                         </div>
                         
-                        <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Shift+drag screen name to reposition</p>
+                        <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Click & drag the screen name to reposition</p>
                         
                         <!-- Port Capacity Settings -->
                         <div style="margin-top: 15px; padding: 12px; background: #1a1a1a; border-radius: 6px; border: 1px solid #333;">
@@ -835,7 +835,7 @@
                             <label for="show-power-circuit-info">Show Circuit Info</label>
                         </div>
                         
-                        <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Shift+drag screen name to reposition</p>
+                        <p style="font-size: 11px; color: #888; margin: 4px 0 12px 0;">Click & drag the screen name to reposition</p>
 
                         <div class="info-row" data-tooltip="Voltage, Supply voltage for circuit capacity calculations.">
                             <label>Voltage (V)</label>
@@ -1670,6 +1670,7 @@
                     <tr><td style="padding: 4px 0;">Pan Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Space + Drag</td></tr>
                     <tr><td style="padding: 4px 0;">Zoom In / Out</td><td style="padding: 4px 0; text-align: right; color: #666;">Scroll Wheel</td></tr>
                     <tr><td style="padding: 4px 0;">Move Layer</td><td style="padding: 4px 0; text-align: right; color: #666;">Shift + Drag</td></tr>
+                    <tr><td style="padding: 4px 0;">Move Screen Name Label</td><td style="padding: 4px 0; text-align: right; color: #666;">Click & Drag the label</td></tr>
                     <tr><td style="padding: 4px 0;">Move Layer to Another Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Shift + Drag onto Canvas</td></tr>
                     <tr><td style="padding: 4px 0;">Duplicate Layer to Another Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Cmd/Alt + Shift + Drag onto Canvas</td></tr>
                     <tr><td style="padding: 4px 0;">Move a Canvas</td><td style="padding: 4px 0; text-align: right; color: #666;">Drag the canvas's dashed outline</td></tr>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.6</title>
+    <title>LED Raster Designer v0.8.7.7</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.6</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.6) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.7) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">


### PR DESCRIPTION
## Summary
Click directly on a screen's name label (the white box) and drag it to reposition — no modifier keys needed. Works on Pixel Map, Cabinet ID, Data Flow, and Power. Plain Shift+drag on Pixel Map / Show Look still moves the whole layer, unchanged.

The label rect is cached in workspace (un-mirrored) coords during render so the hit-test stays in sync across multi-canvas projects, Back-perspective canvases, and Show Look offsets.

The associated label group moves with the screen name as one unit:
- Data Flow / Power center info ("X Mains, Y Backups | Z Ports" / "X Multi, Y Circuits | A1φ / A3φ") follows
- Pixel Map bottom info bar ("Columns × Rows • Cabinets • Resolution • Aspect Ratio • Weight") follows

Position persists per-tab. Pixel Map gets its own `screenNameOffsetXPixelMap` / `Y` fields alongside the existing Cabinet / Data / Power offset fields.

## Test plan
- [ ] Click on the white screen-name label on each tab → drag-to-move works without Shift
- [ ] Plain Shift+drag on Pixel Map still moves the whole layer
- [ ] Plain Shift+drag on Cabinet / Data / Power still moves the screen name (existing path, unchanged)
- [ ] On Data Flow / Power, the "Mains/Backups/Ports" center info follows the screen name when dragged
- [ ] On Pixel Map, the "Columns × Rows • Cabinets …" info bar at the bottom of the layer follows the screen name when dragged
- [ ] Front↔Back perspective toggle on Data / Power: drag direction stays consistent
- [ ] Per-tab positions persist — drag on Pixel Map doesn't affect Cabinet / Data / Power positions