### PR TITLE
v0.8.7.7.1: hidden layers locked + bolder hidden indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.7
+# LED Raster Designer v0.8.7.7.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,31 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.7.1 - May 11, 2026
+----------------------------
+Hidden layers are now properly out-of-bounds for editing.
+
+- FIX: Hiding a layer now immediately removes it from the selection
+  (and demotes it as currentLayer if it was active). Without this,
+  a hidden layer stayed as currentLayer and the user could keep
+  click-dragging its (invisible) screen-name label, scratching the
+  cached _screenNameHitRect against stale geometry and leaving the
+  offset in a borked state when the layer was re-shown. Sidebar
+  property edits could also flow into a hidden layer. After the
+  fix, the moment a layer is hidden it's deselected; the
+  currentLayer is promoted to the next still-visible selected
+  layer, or the first visible layer in the project, or null.
+- FIX: The screen-name mousedown hit-test now also short-circuits
+  for layers with visible === false, so even if the cached rect
+  hangs around briefly it can't fire a drag. (And the cache is
+  cleared on hide.)
+- UX: Hidden layers in the right-sidebar layer list now carry a
+  much louder visual indicator — red diagonal-stripe overlay, a
+  red "HIDDEN" badge in the info line, strikethrough on the layer
+  name, a red-tinted visibility button showing 🚫 instead of 👁,
+  and the name field + reorder arrows are pointer-locked so the
+  row really reads as "off-limits" at a glance.
+
 v0.8.7.7 - May 11, 2026
 ----------------------------
 Screen-name labels are now grabbable on every tab.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.7',
-            'CFBundleVersion': '0.8.7.7',
+            'CFBundleShortVersionString': '0.8.7.7.1',
+            'CFBundleVersion': '0.8.7.7.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -123,6 +123,48 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 .layer-item:hover { background: #2a2a2a; }
 .layer-item.active { border-color: #4A90E2; background: #1a2a3a; }
 .layer-item.primary { border-color: #00ccff; box-shadow: inset 0 0 0 1px rgba(0, 204, 255, 0.35); }
+/* v0.8.7.7.1: hidden layers — clearly dimmed + diagonal stripe so the
+   state is unmistakable in the sidebar, and inputs are click-locked. */
+.layer-item.hidden {
+    opacity: 0.55;
+    background:
+        repeating-linear-gradient(
+            135deg,
+            rgba(255, 80, 80, 0.06) 0px,
+            rgba(255, 80, 80, 0.06) 6px,
+            transparent 6px,
+            transparent 12px
+        ),
+        #141414;
+    border-color: #5a2a2a;
+}
+.layer-item.hidden .layer-name-input {
+    text-decoration: line-through;
+    color: #888;
+    pointer-events: none;
+}
+.layer-item.hidden .layer-info { color: #888; }
+.layer-item.hidden .layer-move-up,
+.layer-item.hidden .layer-move-down {
+    opacity: 0.4;
+    pointer-events: none;
+}
+.layer-visibility-btn.is-hidden {
+    background: #5a1f1f;
+    border-color: #b04040 !important;
+    color: #ffb0b0;
+}
+.layer-hidden-badge {
+    display: inline-block;
+    background: #b04040;
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 1px 6px;
+    border-radius: 3px;
+    letter-spacing: 0.5px;
+    margin-right: 4px;
+}
 #toggle-lock-selected {
     width: 36px;
     min-width: 36px;

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -6294,15 +6294,56 @@ class LEDRasterApp {
     
     toggleLayerVisibility(layerId) {
         const layer = this.project.layers.find(l => l.id === layerId);
-        if (layer) {
-            layer.visible = !layer.visible;
-            sendClientLog('toggle_visibility', {
-                id: layer.id,
-                name: layer.name,
-                visible: layer.visible
-            });
-            window.canvasRenderer.render();
-            this.renderLayers();
+        if (!layer) return;
+        layer.visible = !layer.visible;
+        sendClientLog('toggle_visibility', {
+            id: layer.id,
+            name: layer.name,
+            visible: layer.visible
+        });
+        // v0.8.7.7.1: when a layer is hidden, drop it from selection
+        // immediately so it can't be edited / dragged / sidebar-tweaked
+        // through stale references. Without this you could (e.g.) hide
+        // a layer and still drag its cached screen-name label, leaving
+        // the offset in a bad state when the layer was later re-shown.
+        if (!layer.visible) {
+            // Clear stale per-layer caches that mousedown / drag handlers
+            // hit-test against. The render loop will re-populate these
+            // for visible layers on the next frame.
+            if (layer._screenNameHitRect) layer._screenNameHitRect = null;
+
+            const wasSelected = this.selectedLayerIds && this.selectedLayerIds.has(layer.id);
+            const wasCurrent = this.currentLayer && this.currentLayer.id === layer.id;
+            if (wasSelected && this.selectedLayerIds.size > 0) {
+                this.selectedLayerIds.delete(layer.id);
+            }
+            if (wasCurrent) {
+                // Promote the next still-visible selected layer (if any),
+                // otherwise pick the first visible layer in the project,
+                // otherwise leave currentLayer null.
+                let promoted = null;
+                if (this.selectedLayerIds && this.selectedLayerIds.size > 0) {
+                    for (const id of this.selectedLayerIds) {
+                        const l = this.project.layers.find(x => x.id === id);
+                        if (l && l.visible !== false) { promoted = l; break; }
+                    }
+                }
+                if (!promoted) {
+                    promoted = this.project.layers.find(l => l.visible !== false && l.id !== layer.id) || null;
+                    if (promoted) this.selectedLayerIds = new Set([promoted.id]);
+                    else this.selectedLayerIds = new Set();
+                }
+                this.currentLayer = promoted;
+                this.lastSelectedLayerId = promoted ? promoted.id : null;
+                if (typeof this.loadLayerToInputs === 'function' && promoted) {
+                    try { this.loadLayerToInputs(); } catch (_) {}
+                }
+            }
+        }
+        window.canvasRenderer.render();
+        this.renderLayers();
+        if (typeof this.updateUI === 'function') {
+            try { this.updateUI(); } catch (_) {}
         }
     }
 
@@ -11078,6 +11119,10 @@ class LEDRasterApp {
             if (this.currentLayer && this.currentLayer.id === layer.id) {
                 layerDiv.classList.add('primary');
             }
+            // v0.8.7.7.1: visually distinguish hidden layers in the sidebar.
+            if (layer.visible === false) {
+                layerDiv.classList.add('hidden');
+            }
             
             const layerType = layer.type || 'screen';
             const isImage = layerType === 'image';
@@ -11109,13 +11154,13 @@ class LEDRasterApp {
                             <button class="layer-btn layer-move-up" data-layer-id="${layer.id}" title="Move up within canvas">▲</button>
                             <button class="layer-btn layer-move-down" data-layer-id="${layer.id}" title="Move down within canvas">▼</button>
                         </div>
-                        <button class="layer-btn" onclick="app.toggleLayerVisibility(${layer.id})" title="Toggle Visibility">
-                            ${layer.visible ? '👁' : '👁‍🗨'}
+                        <button class="layer-btn layer-visibility-btn ${layer.visible === false ? 'is-hidden' : ''}" onclick="app.toggleLayerVisibility(${layer.id})" title="${layer.visible === false ? 'Hidden — click to show' : 'Visible — click to hide'}">
+                            ${layer.visible === false ? '🚫' : '👁'}
                         </button>
                     </div>
                 </div>
                 <div class="layer-info">
-                    ${infoText}
+                    ${layer.visible === false ? '<span class="layer-hidden-badge">HIDDEN</span> ' : ''}${infoText}
                 </div>
             `;
             

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -553,6 +553,11 @@ class CanvasRenderer {
                 && !e.metaKey && !e.ctrlKey
                 && window.app && window.app.currentLayer
                 && (window.app.currentLayer.type || 'screen') === 'screen'
+                // v0.8.7.7.1: don't fire on a hidden layer even if the
+                // hit-rect cache is stale from before the visibility
+                // toggle. toggleLayerVisibility now clears the cache too,
+                // but this guard makes the rule explicit.
+                && window.app.currentLayer.visible !== false
                 && this.viewMode !== 'show-look') {
             const _r = window.app.currentLayer._screenNameHitRect;
             if (_r && _r.viewMode === this.viewMode

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.7</title>
+    <title>LED Raster Designer v0.8.7.7.1</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7.1</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1444,7 +1444,7 @@
                 </select>
             </div>
 
-            <!-- Export Scale (v0.8.7.7) — multiplies output resolution. Vector
+            <!-- Export Scale (v0.8.7.7.1) — multiplies output resolution. Vector
                  content (panels, labels, arrows, text) stays crisp; bitmap
                  image layers will sample up. Resolume XML ignores scale. -->
             <div style="margin-bottom: 18px;" id="export-scale-row">

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -148,14 +148,15 @@ def test_api_update_check_force(client):
 # ── Version consistency across all sources ────────────────────────
 
 def _extract_version(text):
-    """Extract a version like 1.0, 0.6.5, or 0.6.3.6 from text (with or without v prefix).
-    Tries v-prefixed first (most reliable), then falls back to 3+ part versions."""
-    # Try v-prefixed version first (e.g. v0.6.5, v1.0)
-    m = re.search(r'v(\d+\.\d+(?:\.\d+){0,2})', text)
+    """Extract a version like 1.0, 0.6.5, 0.6.3.6, or 0.8.7.7.1 from text
+    (with or without v prefix). Allows up to 5 parts so hotfix-of-a-hotfix
+    naming (e.g. 0.8.7.7.1) parses cleanly."""
+    # Try v-prefixed version first (e.g. v0.6.5, v1.0, v0.8.7.7.1)
+    m = re.search(r'v(\d+\.\d+(?:\.\d+){0,3})', text)
     if m:
         return m.group(1)
     # Fall back to non-prefixed 3+ part versions to avoid matching CSS like "0.6em"
-    m = re.search(r'(\d+\.\d+\.\d+(?:\.\d+)?)', text)
+    m = re.search(r'(\d+\.\d+\.\d+(?:\.\d+){0,2})', text)
     return m.group(1) if m else None
 
 
@@ -170,12 +171,13 @@ def _read_version_from_file(rel_path, line_number=None):
 
 
 def test_version_txt_is_valid():
-    """VERSION.txt must use a 2, 3, or 4-part version (e.g. 1.0, 0.6.5, or 0.6.3.6)."""
+    """VERSION.txt must use a 2 to 5-part version (e.g. 1.0, 0.6.5, 0.6.3.6,
+    or hotfix-of-a-hotfix like 0.8.7.7.1)."""
     version = _read_version_from_file('src/VERSION.txt')
     assert version is not None, "No version found in VERSION.txt"
     parts = version.split('.')
-    assert len(parts) in (2, 3, 4), (
-        f"VERSION.txt has {len(parts)}-part version '{version}', expected 2-4 parts (e.g. 1.0, 0.6.5, or 0.6.3.6)"
+    assert 2 <= len(parts) <= 5, (
+        f"VERSION.txt has {len(parts)}-part version '{version}', expected 2-5 parts"
     )
 
 


### PR DESCRIPTION
## Summary
- Hiding a layer immediately deselects it and promotes the next visible selected (or first visible) layer to currentLayer, clearing the cached screen-name hit-rect so a hidden layer can't catch a stray drag.
- Sidebar layer list gets a much louder hidden-state: red diagonal stripe overlay, "HIDDEN" badge, name strikethrough, red 🚫 visibility button, pointer-locked name field and reorder arrows.
- Screen-name mousedown hit-test also short-circuits for `visible === false`.
- Version sync (README/VERSION/index.html/spec) bumped, test regex extended to accept 5-part versions.

## Test plan
- [ ] Hide a layer → it deselects and currentLayer falls back to next visible.
- [ ] Sidebar row is unmistakably "off" (stripe, badge, strikethrough, 🚫).
- [ ] Try clicking screen-name on a hidden layer → nothing happens.
- [ ] Unhide → row returns to normal, layer can be edited again.
- [ ] `pytest tests/test_version.py` green.