### PR TITLE
v0.8.7.7.2: keep size/info bar with dragged screen-name on Pixel Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.7.1
+# LED Raster Designer v0.8.7.7.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,25 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.7.2 - May 31, 2026
+----------------------------
+Dragged screen-name labels keep their size/info bar on Pixel Map.
+
+- FIX: When a Pixel Map screen-name label was dragged far enough
+  that it crossed the layer's edge, the name snapped all the way
+  back to center while the size / "Columns × Rows • Cabinets…"
+  info bar kept the raw (now huge) offset and got clipped off the
+  panel — so the screen looked like it was "missing info" and the
+  name couldn't be nudged. This bit any frame whose name was
+  dragged up to sit above an overlapping window layer (ON SR
+  Frame, Center Frame, ON SL Frame, etc.).
+- FIX: The label now CLAMPS to the layer's edge instead of
+  snapping to center, so a name dragged upward pins to the top of
+  the panel (visible above an overlapping window) and stays there.
+- FIX: The center/size and bottom info bars now follow the name's
+  actual post-clamp position, so the whole label group always
+  moves as one unit and can never be flung off-bounds on its own.
+
 v0.8.7.7.1 - May 11, 2026
 ----------------------------
 Hidden layers are now properly out-of-bounds for editing.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.7.1',
-            'CFBundleVersion': '0.8.7.7.1',
+            'CFBundleShortVersionString': '0.8.7.7.2',
+            'CFBundleVersion': '0.8.7.7.2',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -4349,6 +4349,13 @@ class CanvasRenderer {
         
         // Render Screen Name with WHITE background and BLACK text
         let infoAnchorY = null;
+        // v0.8.7.7.2: the offset actually *applied* to the screen name after
+        // the out-of-bounds clamp below. The center/info label group must use
+        // this same value (not the raw stored offset) so it never diverges
+        // from the name — otherwise a name that snapped back to center leaves
+        // the size/info bar flung off-bounds where it gets clipped away.
+        let _appliedNameOffsetX = 0;
+        let _appliedNameOffsetY = 0;
         if (screenName) {
             // For non-pixel-map modes, use tab-specific offset position
             let screenNameX = centerX;
@@ -4381,12 +4388,22 @@ class CanvasRenderer {
                 // the legacy centered behavior.
                 screenNameX = centerX + screenNameOffsetX;
                 screenNameY = (currentY + screenNameHeight / 2) + screenNameOffsetY;
+                // v0.8.7.7.2: clamp the label to the layer's edges instead of
+                // snapping it back to center when the drag overshoots. Pinning
+                // to the edge is what lets a frame's name sit at the top of the
+                // panel (above an overlapping window layer) while still keeping
+                // the whole label group on-screen. _appliedNameOffset captures
+                // the post-clamp delta so the size/info bar tracks it exactly.
+                const _nameBaseY = currentY + screenNameHeight / 2;
+                const _minNameY = bounds.y + screenNameHeight / 2;
+                const _maxNameY = bounds.y + layerHeight - screenNameHeight / 2;
+                if (screenNameY < _minNameY) screenNameY = _minNameY;
+                else if (screenNameY > _maxNameY) screenNameY = _maxNameY;
                 if (screenNameX < bounds.x || screenNameX > bounds.x + layerWidth) {
                     screenNameX = centerX;
                 }
-                if (screenNameY < bounds.y || screenNameY > bounds.y + layerHeight) {
-                    screenNameY = currentY + screenNameHeight / 2;
-                }
+                _appliedNameOffsetX = screenNameX - centerX;
+                _appliedNameOffsetY = screenNameY - _nameBaseY;
             }
             
             this.ctx.font = `bold ${screenNameSize}px Arial`;
@@ -4460,8 +4477,10 @@ class CanvasRenderer {
         let _labelGroupOffsetY = 0;
         if (screenName) {
             if (this.viewMode === 'pixel-map') {
-                _labelGroupOffsetX = layer.screenNameOffsetXPixelMap || 0;
-                _labelGroupOffsetY = layer.screenNameOffsetYPixelMap || 0;
+                // Use the *applied* (post-clamp) name offset so the info bar
+                // always tracks the name and never gets clipped off-bounds.
+                _labelGroupOffsetX = _appliedNameOffsetX;
+                _labelGroupOffsetY = _appliedNameOffsetY;
             } else if (this.viewMode === 'cabinet-id') {
                 _labelGroupOffsetX = layer.screenNameOffsetXCabinet || 0;
                 _labelGroupOffsetY = layer.screenNameOffsetYCabinet || 0;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.7.1</title>
+    <title>LED Raster Designer v0.8.7.7.2</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7.1</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7.2</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
Fixes screens that appeared to be "missing info" on Pixel Map.

When a screen-name label was dragged far enough up that it crossed the layer's top edge, the **name** snapped all the way back to center (per the old clamp) while the **size / "Columns × Rows • Cabinets…" info bar** kept the raw, now-huge offset and got clipped off the panel. The result: name visible, info gone, and the name couldn't be nudged. This hit any frame whose name had been dragged up to sit above an overlapping window layer (ON SR Frame, Center Frame, ON SL Frame, etc.).

## Changes
- `canvas.js`: clamp the Pixel Map screen-name label to the layer's **edge** instead of snapping it back to center, so a name dragged upward pins to the top of the panel (visible above an overlapping window) and stays there.
- `canvas.js`: drive the center/size and bottom info bars from the name's actual **post-clamp** offset, so the whole label group always moves as one unit and can't be flung off-bounds on its own.
- Version bump to v0.8.7.7.2 (VERSION.txt, README, index.html, spec).

## Test plan
- [x] ON SR / Center / ON SL Frame now show name **and** "W × H" size bar pinned at the top, above their windows (verified in preview).
- [x] No console errors.
- [x] `pytest tests/test_version.py` green.
- [x] `node --check canvas.js` passes.