### PR TITLE
v0.8.7.7.4: per-canvas breakdown in Data/Power Totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.7.3
+# LED Raster Designer v0.8.7.7.4
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,23 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.7.4 - June 16, 2026
+----------------------------
+Data/Power Totals now break down per canvas instead of one ambiguous
+"active canvas" column.
+
+- FIX: the "This Canvas" totals column keyed off the active canvas,
+  which is ambiguous on Data/Power (a layer has both a processor
+  canvas and a show canvas, and the active-canvas tracker flips
+  between them). Selecting a screen on one canvas could show another
+  canvas's numbers. Replaced it with a per-canvas breakdown.
+- FEATURE: the Totals panel on both Data and Power now lists every
+  visible canvas individually (by name) plus the "All Canvases"
+  grand total. Each canvas's numbers are grouped by its show-canvas,
+  matching where the screens actually render on those tabs. Hidden
+  canvases are excluded; single-canvas projects just show the one
+  "All Canvases" total.
+
 v0.8.7.7.3 - May 31, 2026
 ----------------------------
 Screen-name labels: self-healing offsets + Show Look support.

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.7.3',
-            'CFBundleVersion': '0.8.7.7.3',
+            'CFBundleShortVersionString': '0.8.7.7.4',
+            'CFBundleVersion': '0.8.7.7.4',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -2107,30 +2107,66 @@ class LEDRasterApp {
             const el = document.getElementById(id);
             if (el) el.textContent = value;
         };
-        const active = (typeof this._activeCanvas === 'function') ? this._activeCanvas() : null;
-        const activeId = active ? active.id : null;
-        const activeName = active ? `(${active.name || 'Canvas'})` : '(no active canvas)';
-        // Data Flow totals
-        const dataCanvas = activeId ? this.getPortCounts(activeId) : { primary: 0, backup: 0 };
-        const dataProject = this.getPortCounts();
-        setText('data-totals-canvas-name', activeName);
-        setText('data-totals-canvas-primary', dataCanvas.primary);
-        setText('data-totals-canvas-backup', dataCanvas.backup);
-        setText('data-totals-project-primary', dataProject.primary);
-        setText('data-totals-project-backup', dataProject.backup);
-        // Power totals, show "0" cleanly when there's no active canvas / no
-        // load yet. Amps formatted to 2 decimals to match the per-layer
-        // capacity readout.
-        const pwrCanvas = activeId ? this.getPowerCounts(activeId)
-            : { circuits: 0, totalWatts: 0, singlePhaseAmps: 0, threePhaseAmps: 0 };
-        const pwrProject = this.getPowerCounts();
         const fmtAmps = (a) => (a > 0) ? `${a.toFixed(2)} A` : '0';
         const fmtWatts = (w) => (w > 0) ? `${Math.round(w).toLocaleString()} W` : '0';
-        setText('power-totals-canvas-name', activeName);
-        setText('power-totals-canvas-watts', fmtWatts(pwrCanvas.totalWatts));
-        setText('power-totals-canvas-circuits', pwrCanvas.circuits);
-        setText('power-totals-canvas-1ph', fmtAmps(pwrCanvas.singlePhaseAmps));
-        setText('power-totals-canvas-3ph', fmtAmps(pwrCanvas.threePhaseAmps));
+
+        // v0.8.7.7.4: list every visible canvas individually instead of a
+        // single "active canvas" column. The old active-canvas readout was
+        // ambiguous on Data/Power (a layer has both a processor canvas and a
+        // show canvas, and the active-canvas tracker flips between them), so a
+        // selection on one canvas could show another canvas's numbers. Listing
+        // each canvas by name removes that guesswork. getPortCounts/
+        // getPowerCounts already group by the show canvas on these tabs and
+        // exclude hidden canvases.
+        const hidden = this._hiddenCanvasIdSet();
+        const canvases = (this.project && Array.isArray(this.project.canvases))
+            ? this.project.canvases.filter(c => c && c.id && !hidden.has(c.id))
+            : [];
+
+        // Build one block per canvas. A single-canvas project is left empty
+        // (the "All Canvases" total below already covers it, no point in
+        // duplicating it).
+        const buildPerCanvas = (containerId, rowsFor) => {
+            const container = document.getElementById(containerId);
+            if (!container) return;
+            container.innerHTML = '';
+            if (canvases.length <= 1) return;
+            canvases.forEach(c => {
+                const block = document.createElement('div');
+                block.style.cssText = 'padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc; margin-bottom: 8px;';
+                const title = document.createElement('div');
+                title.style.cssText = 'font-weight: 600; color: #fff; margin-bottom: 4px;';
+                title.textContent = c.name || 'Canvas';
+                block.appendChild(title);
+                rowsFor(c.id).forEach(([label, value]) => {
+                    const row = document.createElement('div');
+                    row.textContent = `${label}: ${value}`;
+                    block.appendChild(row);
+                });
+                container.appendChild(block);
+            });
+        };
+
+        // Data Flow totals
+        buildPerCanvas('data-totals-per-canvas', (cid) => {
+            const d = this.getPortCounts(cid);
+            return [['Primary Ports', d.primary], ['Backup Ports', d.backup]];
+        });
+        const dataProject = this.getPortCounts();
+        setText('data-totals-project-primary', dataProject.primary);
+        setText('data-totals-project-backup', dataProject.backup);
+
+        // Power totals
+        buildPerCanvas('power-totals-per-canvas', (cid) => {
+            const p = this.getPowerCounts(cid);
+            return [
+                ['Watts', fmtWatts(p.totalWatts)],
+                ['Circuits', p.circuits],
+                ['Amps (1φ)', fmtAmps(p.singlePhaseAmps)],
+                ['Amps (3φ)', fmtAmps(p.threePhaseAmps)],
+            ];
+        });
+        const pwrProject = this.getPowerCounts();
         setText('power-totals-project-watts', fmtWatts(pwrProject.totalWatts));
         setText('power-totals-project-circuits', pwrProject.circuits);
         setText('power-totals-project-1ph', fmtAmps(pwrProject.singlePhaseAmps));

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.7.3</title>
+    <title>LED Raster Designer v0.8.7.7.4</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7.3</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7.4</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -759,16 +759,14 @@
                      tab, broken out per active canvas + project. Numbers
                      respect canvas visibility (hidden canvases excluded). -->
                 <div class="panel tab-panel" data-tab="data-flow" style="display: none;">
-                    <div class="panel-header" data-tooltip="Aggregated data port counts. 'This Canvas' shows only the active canvas; 'All Canvases' is the project total. Hidden canvases are excluded from both.">
+                    <div class="panel-header" data-tooltip="Aggregated data port counts. Each canvas is listed individually, and 'All Canvases' is the project total. Hidden canvases are excluded.">
                         <h2>Totals</h2>
                     </div>
                     <div class="panel-content">
-                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc; margin-bottom: 8px;">
-                            <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">This Canvas <span id="data-totals-canvas-name" style="color: #888; font-weight: 400;"></span></div>
-                            <div>Primary Ports: <span id="data-totals-canvas-primary">0</span></div>
-                            <div>Backup Ports: <span id="data-totals-canvas-backup">0</span></div>
-                        </div>
-                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc;">
+                        <!-- Per-canvas breakdown, one block per visible canvas,
+                             populated by refreshTotalsSidebar(). -->
+                        <div id="data-totals-per-canvas"></div>
+                        <div style="padding: 8px; background: #111; border: 1px solid #4a4a4a; border-radius: 4px; font-size: 12px; color: #ccc;">
                             <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">All Canvases</div>
                             <div>Primary Ports: <span id="data-totals-project-primary">0</span></div>
                             <div>Backup Ports: <span id="data-totals-project-backup">0</span></div>
@@ -1106,18 +1104,14 @@
                      tab, broken out per active canvas + project. Numbers
                      respect canvas visibility (hidden canvases excluded). -->
                 <div class="panel tab-panel" data-tab="power" style="display: none;">
-                    <div class="panel-header" data-tooltip="Aggregated power load. 'This Canvas' shows only the active canvas; 'All Canvases' is the project total. Hidden canvases are excluded from both.">
+                    <div class="panel-header" data-tooltip="Aggregated power load. Each canvas is listed individually, and 'All Canvases' is the project total. Hidden canvases are excluded.">
                         <h2>Totals</h2>
                     </div>
                     <div class="panel-content">
-                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc; margin-bottom: 8px;">
-                            <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">This Canvas <span id="power-totals-canvas-name" style="color: #888; font-weight: 400;"></span></div>
-                            <div>Watts: <span id="power-totals-canvas-watts">0</span></div>
-                            <div>Circuits: <span id="power-totals-canvas-circuits">0</span></div>
-                            <div>Amps (1φ): <span id="power-totals-canvas-1ph">0</span></div>
-                            <div>Amps (3φ): <span id="power-totals-canvas-3ph">0</span></div>
-                        </div>
-                        <div style="padding: 8px; background: #111; border: 1px solid #333; border-radius: 4px; font-size: 12px; color: #ccc;">
+                        <!-- Per-canvas breakdown, one block per visible canvas,
+                             populated by refreshTotalsSidebar(). -->
+                        <div id="power-totals-per-canvas"></div>
+                        <div style="padding: 8px; background: #111; border: 1px solid #4a4a4a; border-radius: 4px; font-size: 12px; color: #ccc;">
                             <div style="font-weight: 600; color: #fff; margin-bottom: 4px;">All Canvases</div>
                             <div>Watts: <span id="power-totals-project-watts">0</span></div>
                             <div>Circuits: <span id="power-totals-project-circuits">0</span></div>


### PR DESCRIPTION
## Summary
Fixes the Totals panel showing the wrong canvas's numbers, and adds a per-canvas breakdown.

### Bug
The Totals "This Canvas" column keyed off the **active canvas**, which is ambiguous on Data/Power: a layer has both a processor canvas (`canvas_id`) and a show canvas (`show_canvas_id`), and the active-canvas tracker flips between them. So selecting a screen on one canvas could display another canvas's totals (e.g. "Center Beach" selected → "SR Beach" numbers).

### Fix + feature
Replaced the single ambiguous column with a **per-canvas breakdown** — one block per visible canvas (by name) — plus the existing **All Canvases** grand total, on both Data and Power. Each canvas's numbers are grouped by its **show-canvas** (which `getPortCounts`/`getPowerCounts` already do on these tabs), so totals land where the screens actually render. Hidden canvases are excluded; single-canvas projects just show the All total.

## Test plan (verified in preview)
- [x] Two-canvas scenario: a layer whose show-canvas is "SR Beach" counts under SR Beach, not its processor canvas — Power and Data both correct.
- [x] "All Canvases" total equals the sum of the per-canvas blocks.
- [x] Single-canvas project shows only the All total (no redundant block).
- [x] No console errors; `pytest tests/test_version.py` green; `node --check` passes.