### PR TITLE
v0.8.8.0: gradients + multi-color cabinet palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.8
+# LED Raster Designer v0.8.8.0
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.8.7.7.4
+# LED Raster Designer v0.8.7.8
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,32 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.8.7.8 - June 17, 2026
+----------------------------
+Gradients + multi-color cabinet palettes (Photoshop-style).
+
+- FEATURE: Gradient overlay on screens (Pixel Map / Show Look /
+  Cabinet ID). Composited on top of the checkerboard test pattern.
+  - Multi-stop editor: click the bar to add a stop, drag markers to
+    move, typeable hex + position per stop.
+  - Linear (typeable angle) and Radial.
+  - Spread: Whole screen, or Each panel (gradient repeated on every
+    cabinet). "Alternate panels" mirrors every other COLUMN for a
+    woven wave look.
+  - Typeable Opacity, and the full Photoshop blend-mode set
+    (Normal, Multiply, Screen, Overlay, Darken, Lighten, Color
+    Dodge/Burn, Hard/Soft Light, Difference, Exclusion, Hue,
+    Saturation, Color, Luminosity).
+  - Preset library with live color swatches: 22 built-ins (Spectrum,
+    Fire, Chrome, Copper, Sunset, etc.) plus Save current… for your
+    own; saved presets are per-browser.
+- FEATURE: Multi-color cabinet palette. Pattern modes — Checkerboard
+  (default, unchanged), Diagonal wave, Cycle/sweep, By row, By
+  column — distribute an N-color palette across cabinets. Existing
+  screens stay on the 2-color checkerboard until changed.
+- All new gradient/palette settings persist with the project and the
+  live server round-trip; they bulk-apply across a multi-selection.
+
 v0.8.7.7.4 - June 16, 2026
 ----------------------------
 Data/Power Totals now break down per canvas instead of one ambiguous

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,7 +1,7 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
-v0.8.7.8 - June 17, 2026
+v0.8.8.0 - June 17, 2026
 ----------------------------
 Gradients + multi-color cabinet palettes (Photoshop-style).
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -9,7 +9,8 @@ Gradients + multi-color cabinet palettes (Photoshop-style).
   Cabinet ID). Composited on top of the checkerboard test pattern.
   - Multi-stop editor: click the bar to add a stop, drag markers to
     move, typeable hex + position per stop.
-  - Linear (typeable angle) and Radial.
+  - Linear (typeable angle) and Radial with a movable center
+    (Center X/Y) and adjustable Size.
   - Spread: Whole screen, or Each panel (gradient repeated on every
     cabinet). "Alternate panels" mirrors every other COLUMN for a
     woven wave look.
@@ -19,7 +20,9 @@ Gradients + multi-color cabinet palettes (Photoshop-style).
     Saturation, Color, Luminosity).
   - Preset library with live color swatches: 22 built-ins (Spectrum,
     Fire, Chrome, Copper, Sunset, etc.) plus Save current… for your
-    own; saved presets are per-browser.
+    own; saved presets are per-browser. Built-in presets re-color the
+    current gradient only (they keep your type/radial/opacity/blend);
+    your own saved presets restore their full settings.
 - FEATURE: Multi-color cabinet palette. Pattern modes — Checkerboard
   (default, unchanged), Diagonal wave, Cycle/sweep, By row, By
   column — distribute an N-color palette across cabinets. Existing

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.7.4',
-            'CFBundleVersion': '0.8.7.7.4',
+            'CFBundleShortVersionString': '0.8.7.8',
+            'CFBundleVersion': '0.8.7.8',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.8.7.8',
-            'CFBundleVersion': '0.8.7.8',
+            'CFBundleShortVersionString': '0.8.8.0',
+            'CFBundleVersion': '0.8.8.0',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -120,7 +120,8 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 
 /* v0.8.7.8: compact number fields (gradient angle/opacity/stop pos) — hide the
    native spinner so 3 digits aren't clipped. */
-#gradient-angle-num, #gradient-opacity-num, #gradient-stop-pos {
+#gradient-angle-num, #gradient-opacity-num, #gradient-stop-pos,
+#gradient-rcx-num, #gradient-rcy-num, #gradient-rsize-num {
     -webkit-appearance: textfield;
     -moz-appearance: textfield;
     appearance: textfield;
@@ -131,7 +132,13 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 #gradient-opacity-num::-webkit-inner-spin-button,
 #gradient-opacity-num::-webkit-outer-spin-button,
 #gradient-stop-pos::-webkit-inner-spin-button,
-#gradient-stop-pos::-webkit-outer-spin-button {
+#gradient-stop-pos::-webkit-outer-spin-button,
+#gradient-rcx-num::-webkit-inner-spin-button,
+#gradient-rcx-num::-webkit-outer-spin-button,
+#gradient-rcy-num::-webkit-inner-spin-button,
+#gradient-rcy-num::-webkit-outer-spin-button,
+#gradient-rsize-num::-webkit-inner-spin-button,
+#gradient-rsize-num::-webkit-outer-spin-button {
     -webkit-appearance: none;
     appearance: none;
     display: none;

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -118,6 +118,25 @@ body { font-family: Arial, sans-serif; background: #1a1a1a; color: #e0e0e0; over
 .checkbox-row input[type="checkbox"] { margin: 0; }
 .checkbox-row label { color: #e0e0e0; font-size: 12px; margin: 0; text-transform: none; cursor: pointer; }
 
+/* v0.8.7.8: compact number fields (gradient angle/opacity/stop pos) — hide the
+   native spinner so 3 digits aren't clipped. */
+#gradient-angle-num, #gradient-opacity-num, #gradient-stop-pos {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+    text-align: center;
+}
+#gradient-angle-num::-webkit-inner-spin-button,
+#gradient-angle-num::-webkit-outer-spin-button,
+#gradient-opacity-num::-webkit-inner-spin-button,
+#gradient-opacity-num::-webkit-outer-spin-button,
+#gradient-stop-pos::-webkit-inner-spin-button,
+#gradient-stop-pos::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    display: none;
+    margin: 0;
+}
 #layers-list { margin-bottom: 10px; overflow-y: auto; overflow-x: hidden; scrollbar-gutter: stable; }
 .layer-item { background: #1a1a1a; border: 1px solid #3a3a3a; border-radius: 4px; padding: 10px; margin-bottom: 8px; cursor: pointer; box-sizing: border-box; width: 100%; }
 .layer-item:hover { background: #2a2a2a; }

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1242,6 +1242,9 @@ class LEDRasterApp {
             gradientType: layer.gradientType,
             gradientScope: layer.gradientScope,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientAngle: layer.gradientAngle,
             gradientOpacity: layer.gradientOpacity,
             gradientBlend: layer.gradientBlend,
@@ -1456,6 +1459,9 @@ class LEDRasterApp {
                         if (layerProps.gradientType !== undefined) layer.gradientType = layerProps.gradientType;
                         if (layerProps.gradientScope !== undefined) layer.gradientScope = layerProps.gradientScope;
                         if (layerProps.gradientPanelAlternate !== undefined) layer.gradientPanelAlternate = layerProps.gradientPanelAlternate;
+                        if (layerProps.gradientRadialCenterX !== undefined) layer.gradientRadialCenterX = layerProps.gradientRadialCenterX;
+                        if (layerProps.gradientRadialCenterY !== undefined) layer.gradientRadialCenterY = layerProps.gradientRadialCenterY;
+                        if (layerProps.gradientRadialRadius !== undefined) layer.gradientRadialRadius = layerProps.gradientRadialRadius;
                         if (layerProps.gradientAngle !== undefined) layer.gradientAngle = layerProps.gradientAngle;
                         if (layerProps.gradientOpacity !== undefined) layer.gradientOpacity = layerProps.gradientOpacity;
                         if (layerProps.gradientBlend !== undefined) layer.gradientBlend = layerProps.gradientBlend;
@@ -1668,9 +1674,21 @@ class LEDRasterApp {
                 gradientType: layer.gradientType,
                 gradientScope: layer.gradientScope,
                 gradientPanelAlternate: layer.gradientPanelAlternate,
+                gradientRadialCenterX: layer.gradientRadialCenterX,
+                gradientRadialCenterY: layer.gradientRadialCenterY,
+                gradientRadialRadius: layer.gradientRadialRadius,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientScope: layer.gradientScope,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
                 gradientAngle: layer.gradientAngle,
                 gradientOpacity: layer.gradientOpacity,
                 gradientBlend: layer.gradientBlend,
@@ -1683,6 +1701,9 @@ class LEDRasterApp {
             gradientType: layer.gradientType,
             gradientScope: layer.gradientScope,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientAngle: layer.gradientAngle,
             gradientOpacity: layer.gradientOpacity,
             gradientBlend: layer.gradientBlend,
@@ -5767,6 +5788,9 @@ class LEDRasterApp {
         if (!layer.gradientType) layer.gradientType = 'linear';
         if (!layer.gradientScope) layer.gradientScope = 'screen';       // screen = whole screen, panel = per cabinet
         if (layer.gradientPanelAlternate == null) layer.gradientPanelAlternate = false; // mirror every other cabinet
+        if (layer.gradientRadialCenterX == null) layer.gradientRadialCenterX = 0.5; // radial center, fraction of rect
+        if (layer.gradientRadialCenterY == null) layer.gradientRadialCenterY = 0.5;
+        if (layer.gradientRadialRadius == null) layer.gradientRadialRadius = 1;      // radial size, × base radius
         if (layer.gradientAngle == null) layer.gradientAngle = 0;       // 0 = left→right, 90 = top→bottom
         if (layer.gradientOpacity == null) layer.gradientOpacity = 0.6;
         if (!layer.gradientBlend) layer.gradientBlend = 'normal';       // normal|multiply|screen|overlay|...
@@ -5801,6 +5825,9 @@ class LEDRasterApp {
         if (!layer.gradientType) layer.gradientType = 'linear';
         if (!layer.gradientScope) layer.gradientScope = 'screen';
         if (layer.gradientPanelAlternate == null) layer.gradientPanelAlternate = false;
+        if (layer.gradientRadialCenterX == null) layer.gradientRadialCenterX = 0.5;
+        if (layer.gradientRadialCenterY == null) layer.gradientRadialCenterY = 0.5;
+        if (layer.gradientRadialRadius == null) layer.gradientRadialRadius = 1;
         if (layer.gradientAngle == null) layer.gradientAngle = 0;
         if (layer.gradientOpacity == null) layer.gradientOpacity = 0.6;
         if (!layer.gradientBlend) layer.gradientBlend = 'normal';
@@ -5858,10 +5885,35 @@ class LEDRasterApp {
             if (controls) controls.style.display = enabled.checked ? 'block' : 'none';
         });
 
+        const radialRows = $('gradient-radial-rows');
         if (typeSel) typeSel.addEventListener('change', () => {
             this._applyGradient({ gradientType: typeSel.value }, true);
-            if (angleRow) angleRow.style.display = (typeSel.value === 'radial') ? 'none' : 'block';
+            const isRadial = typeSel.value === 'radial';
+            if (angleRow) angleRow.style.display = isRadial ? 'none' : 'block';
+            if (radialRows) radialRows.style.display = isRadial ? 'block' : 'none';
         });
+
+        // Radial center X/Y and size: each a slider + typeable % field that
+        // maps to a 0–1 fraction (center) or × multiplier (size /100).
+        const wireFrac = (sliderId, numId, key, lo, hi) => {
+            const s = $(sliderId), n = $(numId);
+            const apply = (val, isFinal) => {
+                let v = Math.round(Number(val));
+                if (!Number.isFinite(v)) v = 0;
+                v = Math.min(hi, Math.max(lo, v));
+                if (s) s.value = v;
+                if (n) n.value = v;
+                this._applyGradient({ [key]: v / 100 }, isFinal);
+            };
+            if (s) {
+                s.addEventListener('input', () => apply(s.value, false));
+                s.addEventListener('change', () => apply(s.value, true));
+            }
+            if (n) n.addEventListener('change', () => apply(n.value, true));
+        };
+        wireFrac('gradient-rcx', 'gradient-rcx-num', 'gradientRadialCenterX', -50, 150);
+        wireFrac('gradient-rcy', 'gradient-rcy-num', 'gradientRadialCenterY', -50, 150);
+        wireFrac('gradient-rsize', 'gradient-rsize-num', 'gradientRadialRadius', 10, 400);
 
         const scopeSel = $('gradient-scope');
         const altRow = $('gradient-alternate-row');
@@ -6053,7 +6105,17 @@ class LEDRasterApp {
         if ($('gradient-scope')) $('gradient-scope').value = l.gradientScope || 'screen';
         if ($('gradient-alternate-row')) $('gradient-alternate-row').style.display = (l.gradientScope === 'panel') ? 'flex' : 'none';
         if ($('gradient-panel-alternate')) $('gradient-panel-alternate').checked = !!l.gradientPanelAlternate;
-        if ($('gradient-angle-row')) $('gradient-angle-row').style.display = ((l.gradientType || 'linear') === 'radial') ? 'none' : 'block';
+        const isRadial = (l.gradientType || 'linear') === 'radial';
+        if ($('gradient-angle-row')) $('gradient-angle-row').style.display = isRadial ? 'none' : 'block';
+        if ($('gradient-radial-rows')) $('gradient-radial-rows').style.display = isRadial ? 'block' : 'none';
+        const setPair = (sliderId, numId, frac) => {
+            const v = Math.round(frac * 100);
+            if ($(sliderId)) $(sliderId).value = v;
+            if ($(numId)) $(numId).value = v;
+        };
+        setPair('gradient-rcx', 'gradient-rcx-num', (l.gradientRadialCenterX != null) ? l.gradientRadialCenterX : 0.5);
+        setPair('gradient-rcy', 'gradient-rcy-num', (l.gradientRadialCenterY != null) ? l.gradientRadialCenterY : 0.5);
+        setPair('gradient-rsize', 'gradient-rsize-num', (l.gradientRadialRadius != null) ? l.gradientRadialRadius : 1);
         const ang = Number(l.gradientAngle) || 0;
         if ($('gradient-angle')) $('gradient-angle').value = ang;
         if ($('gradient-angle-num')) $('gradient-angle-num').value = ang;
@@ -6195,20 +6257,23 @@ class LEDRasterApp {
         if (!value) return;
         const [kind, ...rest] = value.split(':');
         const name = rest.join(':');
-        const list = kind === 'user' ? this._userGradientPresets() : this._builtinGradientPresets();
+        const isUser = kind === 'user';
+        const list = isUser ? this._userGradientPresets() : this._builtinGradientPresets();
         const p = list.find(x => x.name === name);
         if (!p) return;
-        // Apply only the fields the preset defines; default the rest sanely.
+        // Built-in presets are just color sets — apply ONLY the stops and keep
+        // the current type/scope/opacity/blend/radial setup (so a radial stays
+        // radial, etc.). User presets carry the full look they were saved with.
         const patch = {
             gradientEnabled: true,
-            gradientType: p.gradientType || 'linear',
-            gradientAngle: (p.gradientAngle != null) ? p.gradientAngle : 0,
             gradientStops: (p.gradientStops || []).map(s => ({ pos: s.pos, color: s.color })),
         };
-        if (p.gradientScope != null) patch.gradientScope = p.gradientScope;
-        if (p.gradientOpacity != null) patch.gradientOpacity = p.gradientOpacity;
-        if (p.gradientBlend != null) patch.gradientBlend = p.gradientBlend;
-        if (p.gradientPanelAlternate != null) patch.gradientPanelAlternate = p.gradientPanelAlternate;
+        if (isUser) {
+            const carry = ['gradientType', 'gradientAngle', 'gradientScope', 'gradientOpacity',
+                'gradientBlend', 'gradientPanelAlternate',
+                'gradientRadialCenterX', 'gradientRadialCenterY', 'gradientRadialRadius'];
+            carry.forEach(k => { if (p[k] != null) patch[k] = p[k]; });
+        }
         this._applyGradient(patch, true);
         this.loadGradientEditor();
     }
@@ -6226,6 +6291,9 @@ class LEDRasterApp {
             gradientOpacity: (l.gradientOpacity != null) ? l.gradientOpacity : 0.6,
             gradientBlend: l.gradientBlend || 'normal',
             gradientPanelAlternate: !!l.gradientPanelAlternate,
+            gradientRadialCenterX: (l.gradientRadialCenterX != null) ? l.gradientRadialCenterX : 0.5,
+            gradientRadialCenterY: (l.gradientRadialCenterY != null) ? l.gradientRadialCenterY : 0.5,
+            gradientRadialRadius: (l.gradientRadialRadius != null) ? l.gradientRadialRadius : 1,
             gradientStops: this._gradientStops().map(s => ({ pos: s.pos, color: s.color })),
         };
         const users = this._userGradientPresets().filter(p => p.name !== name);
@@ -7152,6 +7220,9 @@ class LEDRasterApp {
                     gradientType: this.currentLayer.gradientType,
                     gradientScope: this.currentLayer.gradientScope,
                     gradientPanelAlternate: this.currentLayer.gradientPanelAlternate,
+                    gradientRadialCenterX: this.currentLayer.gradientRadialCenterX,
+                    gradientRadialCenterY: this.currentLayer.gradientRadialCenterY,
+                    gradientRadialRadius: this.currentLayer.gradientRadialRadius,
                     gradientAngle: this.currentLayer.gradientAngle,
                     gradientOpacity: this.currentLayer.gradientOpacity,
                     gradientBlend: this.currentLayer.gradientBlend,
@@ -7287,9 +7358,21 @@ class LEDRasterApp {
                 gradientType: layer.gradientType,
                 gradientScope: layer.gradientScope,
                 gradientPanelAlternate: layer.gradientPanelAlternate,
+                gradientRadialCenterX: layer.gradientRadialCenterX,
+                gradientRadialCenterY: layer.gradientRadialCenterY,
+                gradientRadialRadius: layer.gradientRadialRadius,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientScope: layer.gradientScope,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
                 gradientAngle: layer.gradientAngle,
                 gradientOpacity: layer.gradientOpacity,
                 gradientBlend: layer.gradientBlend,
@@ -7302,6 +7385,9 @@ class LEDRasterApp {
             gradientType: layer.gradientType,
             gradientScope: layer.gradientScope,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientAngle: layer.gradientAngle,
             gradientOpacity: layer.gradientOpacity,
             gradientBlend: layer.gradientBlend,
@@ -13838,6 +13924,9 @@ class LEDRasterApp {
             gradientType: layer.gradientType,
             gradientScope: layer.gradientScope,
             gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientRadialCenterX: layer.gradientRadialCenterX,
+            gradientRadialCenterY: layer.gradientRadialCenterY,
+            gradientRadialRadius: layer.gradientRadialRadius,
             gradientAngle: layer.gradientAngle,
             gradientOpacity: layer.gradientOpacity,
             gradientBlend: layer.gradientBlend,

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -1238,6 +1238,16 @@ class LEDRasterApp {
             screenNameOffsetYPower: layer.screenNameOffsetYPower,
             screenNameOffsetXShowLook: layer.screenNameOffsetXShowLook,
             screenNameOffsetYShowLook: layer.screenNameOffsetYShowLook,
+            gradientEnabled: layer.gradientEnabled,
+            gradientType: layer.gradientType,
+            gradientScope: layer.gradientScope,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientAngle: layer.gradientAngle,
+            gradientOpacity: layer.gradientOpacity,
+            gradientBlend: layer.gradientBlend,
+            gradientStops: layer.gradientStops,
+            panelColorMode: layer.panelColorMode,
+            panelColors: layer.panelColors,
             showDataFlowPortInfo: layer.showDataFlowPortInfo,
             showPowerCircuitInfo: layer.showPowerCircuitInfo,
             powerVoltage: layer.powerVoltage,
@@ -1442,6 +1452,16 @@ class LEDRasterApp {
                         if (layerProps.screenNameOffsetYPower !== undefined) layer.screenNameOffsetYPower = layerProps.screenNameOffsetYPower;
                         if (layerProps.screenNameOffsetXShowLook !== undefined) layer.screenNameOffsetXShowLook = layerProps.screenNameOffsetXShowLook;
                         if (layerProps.screenNameOffsetYShowLook !== undefined) layer.screenNameOffsetYShowLook = layerProps.screenNameOffsetYShowLook;
+                        if (layerProps.gradientEnabled !== undefined) layer.gradientEnabled = layerProps.gradientEnabled;
+                        if (layerProps.gradientType !== undefined) layer.gradientType = layerProps.gradientType;
+                        if (layerProps.gradientScope !== undefined) layer.gradientScope = layerProps.gradientScope;
+                        if (layerProps.gradientPanelAlternate !== undefined) layer.gradientPanelAlternate = layerProps.gradientPanelAlternate;
+                        if (layerProps.gradientAngle !== undefined) layer.gradientAngle = layerProps.gradientAngle;
+                        if (layerProps.gradientOpacity !== undefined) layer.gradientOpacity = layerProps.gradientOpacity;
+                        if (layerProps.gradientBlend !== undefined) layer.gradientBlend = layerProps.gradientBlend;
+                        if (Array.isArray(layerProps.gradientStops)) layer.gradientStops = layerProps.gradientStops.map(s => ({ pos: s.pos, color: s.color }));
+                        if (layerProps.panelColorMode !== undefined) layer.panelColorMode = layerProps.panelColorMode;
+                        if (Array.isArray(layerProps.panelColors)) layer.panelColors = layerProps.panelColors.slice();
                     }
                 });
             } catch (e) {
@@ -1644,6 +1664,31 @@ class LEDRasterApp {
                 screenNameOffsetYPower: layer.screenNameOffsetYPower,
                 screenNameOffsetXShowLook: layer.screenNameOffsetXShowLook,
                 screenNameOffsetYShowLook: layer.screenNameOffsetYShowLook,
+                gradientEnabled: layer.gradientEnabled,
+                gradientType: layer.gradientType,
+                gradientScope: layer.gradientScope,
+                gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientScope: layer.gradientScope,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+                gradientAngle: layer.gradientAngle,
+                gradientOpacity: layer.gradientOpacity,
+                gradientBlend: layer.gradientBlend,
+                gradientStops: layer.gradientStops,
+                panelColorMode: layer.panelColorMode,
+                panelColors: layer.panelColors,
+            panelColorMode: layer.panelColorMode,
+            panelColors: layer.panelColors,
+            gradientEnabled: layer.gradientEnabled,
+            gradientType: layer.gradientType,
+            gradientScope: layer.gradientScope,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientAngle: layer.gradientAngle,
+            gradientOpacity: layer.gradientOpacity,
+            gradientBlend: layer.gradientBlend,
+            gradientStops: layer.gradientStops,
+            panelColorMode: layer.panelColorMode,
+            panelColors: layer.panelColors,
                 powerVoltage: layer.powerVoltage,
                 powerVoltageCustom: layer.powerVoltageCustom,
                 powerAmperage: layer.powerAmperage,
@@ -3874,6 +3919,11 @@ class LEDRasterApp {
             window.canvasRenderer.render();
             if (isFinal) this.updateLayers(this.getSelectedLayers());
         });
+
+        // v0.8.7.8: gradient overlay editor (Photoshop-style multi-stop).
+        this.setupGradientEditor();
+        // v0.8.7.8: multi-color cabinet palette editor.
+        this.setupPaletteEditor();
         
         const rasterWidthInput = document.getElementById('toolbar-raster-width');
         const rasterHeightInput = document.getElementById('toolbar-raster-height');
@@ -5703,10 +5753,610 @@ class LEDRasterApp {
         layer.border_color_cabinet = layer.border_color || prefs.borderColor;
         layer.border_color_data = layer.border_color || prefs.borderColor;
         layer.border_color_power = layer.border_color || prefs.borderColor;
+        // v0.8.7.8: multi-color cabinet palette. 'checker' keeps the legacy
+        // 2-color checkerboard (color1/color2); palette modes distribute
+        // panelColors across cabinets by grid position.
+        if (!layer.panelColorMode) layer.panelColorMode = 'checker';
+        if (!Array.isArray(layer.panelColors)) layer.panelColors = [];
+
+        // v0.8.7.8: Photoshop-style gradient overlay. When enabled, a gradient
+        // is composited on top of the checkerboard test pattern (Pixel Map /
+        // Show Look / Cabinet ID) at gradientOpacity using gradientBlend.
+        // Stops are { pos: 0..1, color: '#rrggbb' }.
+        if (layer.gradientEnabled == null) layer.gradientEnabled = false;
+        if (!layer.gradientType) layer.gradientType = 'linear';
+        if (!layer.gradientScope) layer.gradientScope = 'screen';       // screen = whole screen, panel = per cabinet
+        if (layer.gradientPanelAlternate == null) layer.gradientPanelAlternate = false; // mirror every other cabinet
+        if (layer.gradientAngle == null) layer.gradientAngle = 0;       // 0 = left→right, 90 = top→bottom
+        if (layer.gradientOpacity == null) layer.gradientOpacity = 0.6;
+        if (!layer.gradientBlend) layer.gradientBlend = 'normal';       // normal|multiply|screen|overlay|...
+        if (!Array.isArray(layer.gradientStops) || layer.gradientStops.length < 2) {
+            layer.gradientStops = [
+                { pos: 0, color: '#1d9e75' },
+                { pos: 1, color: '#2145dc' },
+            ];
+        }
         // Only fall back to prefs if the server-created layer didn't already
         // carry these from the add request (e.g. from a preset or catalog panel).
         if (layer.panel_weight == null) layer.panel_weight = prefs.panelWeight;
         if (layer.weight_unit == null) layer.weight_unit = prefs.weightUnit || 'kg';
+    }
+
+    // ── v0.8.7.8: Gradient overlay editor ──────────────────────────────
+    // Photoshop-style multi-stop gradient editor in the Colors panel. Edits
+    // currentLayer.gradient* and mirrors the whole config onto every selected
+    // screen layer (so multi-select bulk-applies, like the color pickers).
+
+    _gradientLayer() {
+        const l = this.currentLayer;
+        return (l && (l.type || 'screen') === 'screen') ? l : null;
+    }
+
+    // Make sure a layer carries a complete gradient config before we edit it,
+    // so partial edits don't leave undefined fields that get dropped across the
+    // server round-trip (the layer may predate the gradient feature).
+    _ensureGradientDefaults(layer) {
+        if (!layer || (layer.type || 'screen') !== 'screen') return;
+        if (layer.gradientEnabled == null) layer.gradientEnabled = false;
+        if (!layer.gradientType) layer.gradientType = 'linear';
+        if (!layer.gradientScope) layer.gradientScope = 'screen';
+        if (layer.gradientPanelAlternate == null) layer.gradientPanelAlternate = false;
+        if (layer.gradientAngle == null) layer.gradientAngle = 0;
+        if (layer.gradientOpacity == null) layer.gradientOpacity = 0.6;
+        if (!layer.gradientBlend) layer.gradientBlend = 'normal';
+        if (!Array.isArray(layer.gradientStops) || layer.gradientStops.length < 2) {
+            layer.gradientStops = [{ pos: 0, color: '#1d9e75' }, { pos: 1, color: '#2145dc' }];
+        }
+    }
+
+    // Apply a partial patch to the gradient config of every selected screen
+    // layer (deep-cloning arrays so layers don't share references), re-render,
+    // and optionally persist. Keeps currentLayer authoritative for the editor.
+    _applyGradient(patch, isFinal) {
+        this.applyToSelectedLayers(layer => {
+            if ((layer.type || 'screen') !== 'screen') return;
+            this._ensureGradientDefaults(layer);
+            Object.keys(patch).forEach(k => {
+                const v = patch[k];
+                layer[k] = (k === 'gradientStops' && Array.isArray(v))
+                    ? v.map(s => ({ pos: s.pos, color: s.color }))
+                    : v;
+            });
+        });
+        if (window.canvasRenderer) window.canvasRenderer.render();
+        if (isFinal) this.updateLayers(this.getSelectedLayers());
+    }
+
+    _gradientStops() {
+        const l = this._gradientLayer();
+        const stops = l && Array.isArray(l.gradientStops) ? l.gradientStops : [];
+        return stops.length >= 2 ? stops : [{ pos: 0, color: '#1d9e75' }, { pos: 1, color: '#2145dc' }];
+    }
+
+    setupGradientEditor() {
+        this.gradientSelectedStop = 0;
+        const $ = (id) => document.getElementById(id);
+        const enabled = $('gradient-enabled');
+        const controls = $('gradient-controls');
+        const typeSel = $('gradient-type');
+        const angleRow = $('gradient-angle-row');
+        const angle = $('gradient-angle');
+        const angleNum = $('gradient-angle-num');
+        const opacity = $('gradient-opacity');
+        const opacityNum = $('gradient-opacity-num');
+        const blend = $('gradient-blend');
+        const bar = $('gradient-bar');
+        const stopColor = $('gradient-stop-color');
+        const stopHex = $('gradient-stop-hex');
+        const stopPos = $('gradient-stop-pos');
+        const stopRemove = $('gradient-stop-remove');
+        if (!enabled || !bar) return;
+
+        enabled.addEventListener('change', () => {
+            if (!this._gradientLayer()) { enabled.checked = false; return; }
+            this._applyGradient({ gradientEnabled: enabled.checked }, true);
+            if (controls) controls.style.display = enabled.checked ? 'block' : 'none';
+        });
+
+        if (typeSel) typeSel.addEventListener('change', () => {
+            this._applyGradient({ gradientType: typeSel.value }, true);
+            if (angleRow) angleRow.style.display = (typeSel.value === 'radial') ? 'none' : 'block';
+        });
+
+        const scopeSel = $('gradient-scope');
+        const altRow = $('gradient-alternate-row');
+        if (scopeSel) scopeSel.addEventListener('change', () => {
+            this._applyGradient({ gradientScope: scopeSel.value }, true);
+            if (altRow) altRow.style.display = (scopeSel.value === 'panel') ? 'flex' : 'none';
+        });
+        const alt = $('gradient-panel-alternate');
+        if (alt) alt.addEventListener('change', () => {
+            this._applyGradient({ gradientPanelAlternate: alt.checked }, true);
+        });
+
+        // Preset library (custom swatch menu).
+        const presetTrigger = $('gradient-preset-trigger');
+        const presetMenu = $('gradient-preset-menu');
+        if (presetTrigger && presetMenu) {
+            presetTrigger.addEventListener('click', (e) => {
+                e.stopPropagation();
+                presetMenu.style.display = (presetMenu.style.display === 'none') ? 'block' : 'none';
+            });
+            // Close on outside click.
+            document.addEventListener('click', (e) => {
+                if (presetMenu.style.display !== 'none'
+                    && !presetMenu.contains(e.target) && e.target !== presetTrigger
+                    && !presetTrigger.contains(e.target)) {
+                    presetMenu.style.display = 'none';
+                }
+            });
+        }
+        const presetSave = $('gradient-preset-save');
+        if (presetSave) presetSave.addEventListener('click', () => this.saveCurrentGradientPreset());
+        this.refreshGradientPresetDropdown();
+
+        // Angle: slider + typeable number field, kept in sync.
+        const applyAngle = (val, isFinal) => {
+            let v = Math.round(Number(val));
+            if (!Number.isFinite(v)) v = 0;
+            v = ((v % 360) + 360) % 360;   // wrap into 0–359
+            if (angle) angle.value = v;
+            if (angleNum) angleNum.value = v;
+            this._applyGradient({ gradientAngle: v }, isFinal);
+        };
+        if (angle) {
+            angle.addEventListener('input', () => applyAngle(angle.value, false));
+            angle.addEventListener('change', () => applyAngle(angle.value, true));
+        }
+        if (angleNum) {
+            angleNum.addEventListener('change', () => applyAngle(angleNum.value, true));
+        }
+        // Opacity: slider + typeable number field (0–100%).
+        const applyOpacity = (val, isFinal) => {
+            let v = Math.round(Number(val));
+            if (!Number.isFinite(v)) v = 0;
+            v = Math.min(100, Math.max(0, v));
+            if (opacity) opacity.value = v;
+            if (opacityNum) opacityNum.value = v;
+            this._applyGradient({ gradientOpacity: v / 100 }, isFinal);
+        };
+        if (opacity) {
+            opacity.addEventListener('input', () => applyOpacity(opacity.value, false));
+            opacity.addEventListener('change', () => applyOpacity(opacity.value, true));
+        }
+        if (opacityNum) {
+            opacityNum.addEventListener('change', () => applyOpacity(opacityNum.value, true));
+        }
+        if (blend) blend.addEventListener('change', () => {
+            this._applyGradient({ gradientBlend: blend.value }, true);
+        });
+
+        // Selected-stop color / hex / position editors.
+        const setStop = (mutate, isFinal) => {
+            const stops = this._gradientStops().map(s => ({ pos: s.pos, color: s.color }));
+            const i = Math.min(this.gradientSelectedStop, stops.length - 1);
+            if (i < 0 || !stops[i]) return;
+            mutate(stops[i]);
+            this._applyGradient({ gradientStops: stops }, isFinal);
+            this.renderGradientBar();
+        };
+        if (stopColor) {
+            stopColor.addEventListener('input', () => setStop(s => { s.color = stopColor.value; if (stopHex) stopHex.value = stopColor.value.toUpperCase(); }, false));
+            stopColor.addEventListener('change', () => setStop(s => { s.color = stopColor.value; }, true));
+        }
+        if (stopHex) stopHex.addEventListener('change', () => {
+            let v = stopHex.value.trim();
+            if (/^#?[0-9a-fA-F]{6}$/.test(v)) {
+                if (v[0] !== '#') v = '#' + v;
+                if (stopColor) stopColor.value = v;
+                setStop(s => { s.color = v; }, true);
+            }
+        });
+        if (stopPos) stopPos.addEventListener('change', () => {
+            const p = Math.min(100, Math.max(0, Number(stopPos.value) || 0)) / 100;
+            setStop(s => { s.pos = p; }, true);
+        });
+        if (stopRemove) stopRemove.addEventListener('click', () => {
+            const stops = this._gradientStops().map(s => ({ pos: s.pos, color: s.color }));
+            if (stops.length <= 2) return;
+            stops.splice(this.gradientSelectedStop, 1);
+            this.gradientSelectedStop = Math.max(0, this.gradientSelectedStop - 1);
+            this._applyGradient({ gradientStops: stops }, true);
+            this.loadGradientEditor();
+        });
+
+        // Click empty bar → add a stop at that position (interpolated color).
+        bar.addEventListener('mousedown', (e) => {
+            if (e.target !== bar) return;   // marker drags handled per-marker
+            const rect = bar.getBoundingClientRect();
+            const pos = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));
+            const stops = this._gradientStops().map(s => ({ pos: s.pos, color: s.color }));
+            stops.push({ pos, color: this._sampleGradient(stops, pos) });
+            stops.sort((a, b) => a.pos - b.pos);
+            this.gradientSelectedStop = stops.findIndex(s => s.pos === pos);
+            this._applyGradient({ gradientStops: stops }, true);
+            this.loadGradientEditor();
+        });
+
+        this._gradientBarEl = bar;
+    }
+
+    // Sample a hex color along the current stop list at position p (0..1).
+    _sampleGradient(stops, p) {
+        const sorted = stops.slice().sort((a, b) => a.pos - b.pos);
+        if (p <= sorted[0].pos) return sorted[0].color;
+        if (p >= sorted[sorted.length - 1].pos) return sorted[sorted.length - 1].color;
+        for (let i = 0; i < sorted.length - 1; i++) {
+            const a = sorted[i], b = sorted[i + 1];
+            if (p >= a.pos && p <= b.pos) {
+                const t = (b.pos - a.pos) ? (p - a.pos) / (b.pos - a.pos) : 0;
+                const ca = this.hexToRgb(a.color), cb = this.hexToRgb(b.color);
+                const mix = (x, y) => Math.round(x + (y - x) * t);
+                const toHex = (n) => n.toString(16).padStart(2, '0');
+                return `#${toHex(mix(ca.r, cb.r))}${toHex(mix(ca.g, cb.g))}${toHex(mix(ca.b, cb.b))}`;
+            }
+        }
+        return sorted[0].color;
+    }
+
+    // Paint the gradient bar background + stop markers, and wire marker drag.
+    renderGradientBar() {
+        const bar = this._gradientBarEl || document.getElementById('gradient-bar');
+        if (!bar) return;
+        const stops = this._gradientStops().slice().sort((a, b) => a.pos - b.pos);
+        const css = stops.map(s => `${s.color} ${Math.round(s.pos * 100)}%`).join(', ');
+        bar.style.background = `linear-gradient(to right, ${css})`;
+        bar.innerHTML = '';
+        const orig = this._gradientStops();
+        stops.forEach((s) => {
+            const idx = orig.indexOf(s);
+            const m = document.createElement('div');
+            const selected = idx === this.gradientSelectedStop;
+            m.style.cssText = `position:absolute; top:-3px; width:12px; height:32px; margin-left:-6px; left:${s.pos * 100}%; border-radius:3px; border:2px solid ${selected ? '#fff' : '#222'}; box-shadow:0 0 0 1px rgba(0,0,0,0.6); background:${s.color}; cursor:grab;`;
+            m.addEventListener('mousedown', (e) => {
+                e.stopPropagation();
+                this.gradientSelectedStop = idx;
+                this.loadGradientEditor();
+                const rect = bar.getBoundingClientRect();
+                const move = (ev) => {
+                    const pos = Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width));
+                    const cur = this._gradientStops().map(x => ({ pos: x.pos, color: x.color }));
+                    if (cur[idx]) { cur[idx].pos = pos; }
+                    this._applyGradient({ gradientStops: cur }, false);
+                    if (document.getElementById('gradient-stop-pos')) document.getElementById('gradient-stop-pos').value = Math.round(pos * 100);
+                    this.renderGradientBar();
+                };
+                const up = () => {
+                    document.removeEventListener('mousemove', move);
+                    document.removeEventListener('mouseup', up);
+                    this.updateLayers(this.getSelectedLayers());
+                };
+                document.addEventListener('mousemove', move);
+                document.addEventListener('mouseup', up);
+            });
+            bar.appendChild(m);
+        });
+        if (typeof this.updateGradientPresetPreview === 'function') this.updateGradientPresetPreview();
+    }
+
+    // Reflect currentLayer's gradient config into all editor controls.
+    loadGradientEditor() {
+        const l = this._gradientLayer();
+        const $ = (id) => document.getElementById(id);
+        const enabled = $('gradient-enabled');
+        const controls = $('gradient-controls');
+        if (!enabled) return;
+        if (!l) { enabled.checked = false; if (controls) controls.style.display = 'none'; return; }
+        enabled.checked = !!l.gradientEnabled;
+        if (controls) controls.style.display = l.gradientEnabled ? 'block' : 'none';
+        if ($('gradient-type')) $('gradient-type').value = l.gradientType || 'linear';
+        if ($('gradient-scope')) $('gradient-scope').value = l.gradientScope || 'screen';
+        if ($('gradient-alternate-row')) $('gradient-alternate-row').style.display = (l.gradientScope === 'panel') ? 'flex' : 'none';
+        if ($('gradient-panel-alternate')) $('gradient-panel-alternate').checked = !!l.gradientPanelAlternate;
+        if ($('gradient-angle-row')) $('gradient-angle-row').style.display = ((l.gradientType || 'linear') === 'radial') ? 'none' : 'block';
+        const ang = Number(l.gradientAngle) || 0;
+        if ($('gradient-angle')) $('gradient-angle').value = ang;
+        if ($('gradient-angle-num')) $('gradient-angle-num').value = ang;
+        const opPct = Math.round(((l.gradientOpacity != null) ? l.gradientOpacity : 0.6) * 100);
+        if ($('gradient-opacity')) $('gradient-opacity').value = opPct;
+        if ($('gradient-opacity-num')) $('gradient-opacity-num').value = opPct;
+        if ($('gradient-blend')) $('gradient-blend').value = l.gradientBlend || 'normal';
+        const stops = this._gradientStops();
+        if (this.gradientSelectedStop >= stops.length) this.gradientSelectedStop = 0;
+        const sel = stops[this.gradientSelectedStop] || stops[0];
+        if (sel) {
+            if ($('gradient-stop-color')) $('gradient-stop-color').value = sel.color;
+            if ($('gradient-stop-hex')) $('gradient-stop-hex').value = (sel.color || '').toUpperCase();
+            if ($('gradient-stop-pos')) $('gradient-stop-pos').value = Math.round((sel.pos || 0) * 100);
+        }
+        if ($('gradient-stop-remove')) $('gradient-stop-remove').disabled = stops.length <= 2;
+        this.renderGradientBar();
+        if (typeof this.updateGradientPresetPreview === 'function') this.updateGradientPresetPreview();
+    }
+
+    // ── v0.8.7.8: Gradient preset library ──────────────────────────────
+    // A preset stores the full gradient *look* (type/angle/scope/opacity/
+    // blend/alternate + stops). Built-ins ship with the app; user presets
+    // live in localStorage. Applying a preset turns the gradient on.
+
+    _builtinGradientPresets() {
+        const S = (...c) => c.map((color, i) => ({ pos: c.length === 1 ? 0 : i / (c.length - 1), color }));
+        return [
+            { name: 'Black, White', gradientType: 'linear', gradientStops: S('#000000', '#ffffff') },
+            { name: 'Spectrum', gradientType: 'linear', gradientStops: [
+                { pos: 0, color: '#ff0000' }, { pos: 0.17, color: '#ff9900' }, { pos: 0.34, color: '#ffff00' },
+                { pos: 0.5, color: '#33cc33' }, { pos: 0.67, color: '#0066ff' }, { pos: 0.84, color: '#6600cc' }, { pos: 1, color: '#cc00cc' } ] },
+            { name: 'Transparent Rainbow', gradientType: 'linear', gradientStops: [
+                { pos: 0, color: '#ff0040' }, { pos: 0.2, color: '#ff9900' }, { pos: 0.4, color: '#ffee00' },
+                { pos: 0.6, color: '#00cc66' }, { pos: 0.8, color: '#0099ff' }, { pos: 1, color: '#cc33ff' } ] },
+            { name: 'Red, Green', gradientType: 'linear', gradientStops: S('#e21f26', '#00a651') },
+            { name: 'Violet, Orange', gradientType: 'linear', gradientStops: S('#7b2ff7', '#f7971e') },
+            { name: 'Blue, Red, Yellow', gradientType: 'linear', gradientStops: S('#2145dc', '#e21f26', '#ffe400') },
+            { name: 'Blue, Yellow, Blue', gradientType: 'linear', gradientStops: S('#1f5fd0', '#ffe400', '#1f5fd0') },
+            { name: 'Orange, Yellow, Orange', gradientType: 'linear', gradientStops: S('#f7591f', '#ffe400', '#f7591f') },
+            { name: 'Violet, Green, Orange', gradientType: 'linear', gradientStops: S('#8e2de2', '#00a651', '#f7971e') },
+            { name: 'Yellow, Violet, Orange, Blue', gradientType: 'linear', gradientStops: S('#ffe400', '#8e2de2', '#f7971e', '#2145dc') },
+            { name: 'Copper', gradientType: 'linear', gradientStops: [
+                { pos: 0, color: '#3a1c0e' }, { pos: 0.4, color: '#b5683a' }, { pos: 0.6, color: '#e9a178' }, { pos: 1, color: '#7a3b1e' } ] },
+            { name: 'Chrome', gradientType: 'linear', gradientStops: [
+                { pos: 0, color: '#2b2f33' }, { pos: 0.35, color: '#c9d2d9' }, { pos: 0.5, color: '#7c8a96' }, { pos: 0.65, color: '#eef3f6' }, { pos: 1, color: '#3a4248' } ] },
+            { name: 'Gold', gradientType: 'linear', gradientStops: [
+                { pos: 0, color: '#7a5a10' }, { pos: 0.5, color: '#ffd75e' }, { pos: 1, color: '#a9791a' } ] },
+            { name: 'Fire', gradientType: 'linear', gradientAngle: 90, gradientStops: [
+                { pos: 0, color: '#000000' }, { pos: 0.45, color: '#cc1100' }, { pos: 0.8, color: '#ff7700' }, { pos: 1, color: '#ffdd00' } ] },
+            { name: 'Ocean', gradientType: 'linear', gradientStops: S('#001f3f', '#0074d9', '#7fdbff') },
+            { name: 'Sunset', gradientType: 'linear', gradientStops: S('#2c3e50', '#fd746c', '#ffc371') },
+            { name: 'Ice', gradientType: 'linear', gradientStops: S('#0b486b', '#3b8686', '#cfeff5') },
+            { name: 'Neon', gradientType: 'linear', gradientStops: S('#ff00cc', '#00ffff') },
+            { name: 'Pastels', gradientType: 'linear', gradientStops: S('#ffd1dc', '#c1f0c1', '#c9e4ff', '#fff2b2') },
+            { name: 'Blues', gradientType: 'linear', gradientStops: S('#cfe8ff', '#3a7bd5', '#0b2a5b') },
+            { name: 'Greens', gradientType: 'linear', gradientStops: S('#d6f5d6', '#3fae3f', '#0e3b13') },
+            { name: 'Purples', gradientType: 'linear', gradientStops: S('#efd6ff', '#8e44ad', '#2c0b3a') },
+        ];
+    }
+
+    _userGradientPresets() {
+        try { return JSON.parse(localStorage.getItem('ledRasterGradientPresets') || '[]') || []; }
+        catch { return []; }
+    }
+    _setUserGradientPresets(arr) {
+        try { localStorage.setItem('ledRasterGradientPresets', JSON.stringify(arr || [])); } catch (_) {}
+    }
+
+    // CSS left→right gradient string for previewing a stop list as a swatch.
+    _gradientCssBar(stops) {
+        const arr = (Array.isArray(stops) ? stops.slice() : [])
+            .filter(s => s && s.color)
+            .sort((a, b) => (Number(a.pos) || 0) - (Number(b.pos) || 0));
+        if (arr.length < 2) return arr[0] ? arr[0].color : '#444';
+        return `linear-gradient(to right, ${arr.map(s => `${s.color} ${Math.round((Number(s.pos) || 0) * 100)}%`).join(', ')})`;
+    }
+
+    // Build the custom preset menu with a gradient swatch per row.
+    refreshGradientPresetDropdown() {
+        const menu = document.getElementById('gradient-preset-menu');
+        if (!menu) return;
+        menu.innerHTML = '';
+        const groups = [
+            { label: 'Built-in', items: this._builtinGradientPresets(), prefix: 'builtin', canDelete: false },
+            { label: 'Saved', items: this._userGradientPresets(), prefix: 'user', canDelete: true },
+        ];
+        groups.forEach(g => {
+            if (!g.items.length) return;
+            const h = document.createElement('div');
+            h.textContent = g.label;
+            h.style.cssText = 'font-size:10px; color:#888; text-transform:uppercase; letter-spacing:0.5px; padding:4px 4px 2px;';
+            menu.appendChild(h);
+            g.items.forEach(p => {
+                const row = document.createElement('div');
+                row.style.cssText = 'display:flex; align-items:center; gap:6px; padding:3px 4px; border-radius:4px; cursor:pointer;';
+                row.addEventListener('mouseenter', () => { row.style.background = '#2a2a2a'; });
+                row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+                const sw = document.createElement('span');
+                sw.style.cssText = `flex:1; min-width:0; height:16px; border-radius:3px; border:1px solid rgba(0,0,0,0.5); background:${this._gradientCssBar(p.gradientStops)};`;
+                const nm = document.createElement('span');
+                nm.textContent = p.name;
+                nm.style.cssText = 'flex:1.4; font-size:11px; color:#ddd; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;';
+                row.appendChild(sw); row.appendChild(nm);
+                row.addEventListener('click', () => {
+                    this.applyGradientPreset(`${g.prefix}:${p.name}`);
+                    this._closeGradientPresetMenu();
+                });
+                if (g.canDelete) {
+                    const x = document.createElement('button');
+                    x.textContent = '×';
+                    x.title = 'Delete preset';
+                    x.style.cssText = 'background:transparent; border:none; color:#999; font-size:14px; cursor:pointer; padding:0 4px;';
+                    x.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        this._setUserGradientPresets(this._userGradientPresets().filter(u => u.name !== p.name));
+                        this.refreshGradientPresetDropdown();
+                    });
+                    row.appendChild(x);
+                }
+                menu.appendChild(row);
+            });
+        });
+    }
+
+    _closeGradientPresetMenu() {
+        const menu = document.getElementById('gradient-preset-menu');
+        if (menu) menu.style.display = 'none';
+    }
+
+    // Reflect the current layer's gradient as the trigger's preview swatch.
+    updateGradientPresetPreview() {
+        const prev = document.getElementById('gradient-preset-preview');
+        if (!prev) return;
+        prev.style.background = this._gradientCssBar(this._gradientStops());
+    }
+
+    applyGradientPreset(value) {
+        if (!value) return;
+        const [kind, ...rest] = value.split(':');
+        const name = rest.join(':');
+        const list = kind === 'user' ? this._userGradientPresets() : this._builtinGradientPresets();
+        const p = list.find(x => x.name === name);
+        if (!p) return;
+        // Apply only the fields the preset defines; default the rest sanely.
+        const patch = {
+            gradientEnabled: true,
+            gradientType: p.gradientType || 'linear',
+            gradientAngle: (p.gradientAngle != null) ? p.gradientAngle : 0,
+            gradientStops: (p.gradientStops || []).map(s => ({ pos: s.pos, color: s.color })),
+        };
+        if (p.gradientScope != null) patch.gradientScope = p.gradientScope;
+        if (p.gradientOpacity != null) patch.gradientOpacity = p.gradientOpacity;
+        if (p.gradientBlend != null) patch.gradientBlend = p.gradientBlend;
+        if (p.gradientPanelAlternate != null) patch.gradientPanelAlternate = p.gradientPanelAlternate;
+        this._applyGradient(patch, true);
+        this.loadGradientEditor();
+    }
+
+    saveCurrentGradientPreset() {
+        const l = this._gradientLayer();
+        if (!l) return;
+        const name = (window.prompt('Save gradient preset as:') || '').trim();
+        if (!name) return;
+        const preset = {
+            name,
+            gradientType: l.gradientType || 'linear',
+            gradientAngle: Number(l.gradientAngle) || 0,
+            gradientScope: l.gradientScope || 'screen',
+            gradientOpacity: (l.gradientOpacity != null) ? l.gradientOpacity : 0.6,
+            gradientBlend: l.gradientBlend || 'normal',
+            gradientPanelAlternate: !!l.gradientPanelAlternate,
+            gradientStops: this._gradientStops().map(s => ({ pos: s.pos, color: s.color })),
+        };
+        const users = this._userGradientPresets().filter(p => p.name !== name);
+        users.push(preset);
+        this._setUserGradientPresets(users);
+        this.refreshGradientPresetDropdown();
+    }
+
+    // ── v0.8.7.8: Multi-color cabinet palette editor ───────────────────
+
+    _defaultPalette() {
+        return ['#BC382F', '#BA7517', '#D2E94D', '#1D9E75', '#2145DC', '#7414F5'];
+    }
+
+    _paletteColors() {
+        const l = this._gradientLayer();
+        const pal = l && Array.isArray(l.panelColors) ? l.panelColors : [];
+        return pal.length ? pal.slice() : this._defaultPalette();
+    }
+
+    // Apply panelColorMode / panelColors to every selected screen layer.
+    _applyPanelColors(patch, isFinal) {
+        this.applyToSelectedLayers(layer => {
+            if ((layer.type || 'screen') !== 'screen') return;
+            if (patch.panelColors && (!Array.isArray(layer.panelColors) || layer.panelColors.length === 0)) {
+                // seed handled by caller; ensure array exists
+            }
+            Object.keys(patch).forEach(k => {
+                const v = patch[k];
+                layer[k] = (k === 'panelColors' && Array.isArray(v)) ? v.slice() : v;
+            });
+        });
+        if (window.canvasRenderer) window.canvasRenderer.render();
+        if (isFinal) this.updateLayers(this.getSelectedLayers());
+    }
+
+    setupPaletteEditor() {
+        this.paletteSelectedIndex = 0;
+        const $ = (id) => document.getElementById(id);
+        const modeSel = $('panel-color-mode');
+        const editor = $('panel-palette-editor');
+        const color = $('palette-color');
+        const hex = $('palette-hex');
+        const addBtn = $('palette-add');
+        const removeBtn = $('palette-remove');
+        if (!modeSel) return;
+
+        modeSel.addEventListener('change', () => {
+            const l = this._gradientLayer();
+            if (!l) { modeSel.value = 'checker'; return; }
+            const patch = { panelColorMode: modeSel.value };
+            // Seed a starter palette the first time a palette mode is chosen.
+            if (modeSel.value !== 'checker' && (!Array.isArray(l.panelColors) || l.panelColors.length === 0)) {
+                patch.panelColors = this._defaultPalette();
+            }
+            this._applyPanelColors(patch, true);
+            if (editor) editor.style.display = (modeSel.value === 'checker') ? 'none' : 'block';
+            this.loadPaletteEditor();
+        });
+
+        const setSwatch = (mutate, isFinal) => {
+            const pal = this._paletteColors();
+            const i = Math.min(this.paletteSelectedIndex, pal.length - 1);
+            if (i < 0 || !pal[i]) return;
+            mutate(pal, i);
+            this._applyPanelColors({ panelColors: pal }, isFinal);
+            this.renderPaletteSwatches();
+        };
+        if (color) {
+            color.addEventListener('input', () => setSwatch((pal, i) => { pal[i] = color.value; if (hex) hex.value = color.value.toUpperCase(); }, false));
+            color.addEventListener('change', () => setSwatch((pal, i) => { pal[i] = color.value; }, true));
+        }
+        if (hex) hex.addEventListener('change', () => {
+            let v = hex.value.trim();
+            if (/^#?[0-9a-fA-F]{6}$/.test(v)) {
+                if (v[0] !== '#') v = '#' + v;
+                if (color) color.value = v;
+                setSwatch((pal, i) => { pal[i] = v; }, true);
+            }
+        });
+        if (addBtn) addBtn.addEventListener('click', () => {
+            const pal = this._paletteColors();
+            pal.push(color ? color.value : '#ffffff');
+            this.paletteSelectedIndex = pal.length - 1;
+            this._applyPanelColors({ panelColors: pal }, true);
+            this.loadPaletteEditor();
+        });
+        if (removeBtn) removeBtn.addEventListener('click', () => {
+            const pal = this._paletteColors();
+            if (pal.length <= 1) return;
+            pal.splice(this.paletteSelectedIndex, 1);
+            this.paletteSelectedIndex = Math.max(0, this.paletteSelectedIndex - 1);
+            this._applyPanelColors({ panelColors: pal }, true);
+            this.loadPaletteEditor();
+        });
+    }
+
+    renderPaletteSwatches() {
+        const host = document.getElementById('panel-palette-swatches');
+        if (!host) return;
+        const pal = this._paletteColors();
+        host.innerHTML = '';
+        pal.forEach((c, i) => {
+            const sw = document.createElement('button');
+            const selected = i === this.paletteSelectedIndex;
+            sw.style.cssText = `width:24px; height:24px; padding:0; border-radius:4px; cursor:pointer; background:${c}; border:2px solid ${selected ? '#fff' : '#333'}; box-shadow:0 0 0 1px rgba(0,0,0,0.5);`;
+            sw.title = c;
+            sw.addEventListener('click', () => { this.paletteSelectedIndex = i; this.loadPaletteEditor(); });
+            host.appendChild(sw);
+        });
+    }
+
+    loadPaletteEditor() {
+        const l = this._gradientLayer();
+        const $ = (id) => document.getElementById(id);
+        const modeSel = $('panel-color-mode');
+        const editor = $('panel-palette-editor');
+        if (!modeSel) return;
+        if (!l) { modeSel.value = 'checker'; if (editor) editor.style.display = 'none'; return; }
+        const mode = l.panelColorMode || 'checker';
+        modeSel.value = mode;
+        if (editor) editor.style.display = (mode === 'checker') ? 'none' : 'block';
+        const pal = this._paletteColors();
+        if (this.paletteSelectedIndex >= pal.length) this.paletteSelectedIndex = 0;
+        const sel = pal[this.paletteSelectedIndex] || pal[0];
+        if (sel) {
+            if ($('palette-color')) $('palette-color').value = sel;
+            if ($('palette-hex')) $('palette-hex').value = sel.toUpperCase();
+        }
+        if ($('palette-remove')) $('palette-remove').disabled = pal.length <= 1;
+        this.renderPaletteSwatches();
     }
 
     getSelectedLayers() {
@@ -6498,6 +7148,16 @@ class LEDRasterApp {
                     screenNameOffsetYPower: this.currentLayer.screenNameOffsetYPower,
                     screenNameOffsetXShowLook: this.currentLayer.screenNameOffsetXShowLook,
                     screenNameOffsetYShowLook: this.currentLayer.screenNameOffsetYShowLook,
+                    gradientEnabled: this.currentLayer.gradientEnabled,
+                    gradientType: this.currentLayer.gradientType,
+                    gradientScope: this.currentLayer.gradientScope,
+                    gradientPanelAlternate: this.currentLayer.gradientPanelAlternate,
+                    gradientAngle: this.currentLayer.gradientAngle,
+                    gradientOpacity: this.currentLayer.gradientOpacity,
+                    gradientBlend: this.currentLayer.gradientBlend,
+                    gradientStops: this.currentLayer.gradientStops,
+                    panelColorMode: this.currentLayer.panelColorMode,
+                    panelColors: this.currentLayer.panelColors,
                     screenNameSize: this.currentLayer.screenNameSize,
                     screenNameSizeCabinet: this.currentLayer.screenNameSizeCabinet,
                     screenNameSizeDataFlow: this.currentLayer.screenNameSizeDataFlow,
@@ -6623,6 +7283,31 @@ class LEDRasterApp {
                 screenNameOffsetYPower: layer.screenNameOffsetYPower,
                 screenNameOffsetXShowLook: layer.screenNameOffsetXShowLook,
                 screenNameOffsetYShowLook: layer.screenNameOffsetYShowLook,
+                gradientEnabled: layer.gradientEnabled,
+                gradientType: layer.gradientType,
+                gradientScope: layer.gradientScope,
+                gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientScope: layer.gradientScope,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+                gradientAngle: layer.gradientAngle,
+                gradientOpacity: layer.gradientOpacity,
+                gradientBlend: layer.gradientBlend,
+                gradientStops: layer.gradientStops,
+                panelColorMode: layer.panelColorMode,
+                panelColors: layer.panelColors,
+            panelColorMode: layer.panelColorMode,
+            panelColors: layer.panelColors,
+            gradientEnabled: layer.gradientEnabled,
+            gradientType: layer.gradientType,
+            gradientScope: layer.gradientScope,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientAngle: layer.gradientAngle,
+            gradientOpacity: layer.gradientOpacity,
+            gradientBlend: layer.gradientBlend,
+            gradientStops: layer.gradientStops,
+            panelColorMode: layer.panelColorMode,
+            panelColors: layer.panelColors,
                 screenNameSize: layer.screenNameSize,
                 screenNameSizeCabinet: layer.screenNameSizeCabinet,
                 screenNameSizeDataFlow: layer.screenNameSizeDataFlow,
@@ -7447,6 +8132,9 @@ class LEDRasterApp {
         if (document.getElementById('color2-hex')) {
             document.getElementById('color2-hex').value = hex2.toUpperCase();
         }
+        // v0.8.7.8: sync the gradient editor to the (now current) layer.
+        if (typeof this.loadGradientEditor === 'function') this.loadGradientEditor();
+        if (typeof this.loadPaletteEditor === 'function') this.loadPaletteEditor();
     }
 
     updateLayerPanelVisibility(allImages, allText) {
@@ -13146,6 +13834,16 @@ class LEDRasterApp {
             screenNameOffsetYPower: layer.screenNameOffsetYPower,
             screenNameOffsetXShowLook: layer.screenNameOffsetXShowLook,
             screenNameOffsetYShowLook: layer.screenNameOffsetYShowLook,
+            gradientEnabled: layer.gradientEnabled,
+            gradientType: layer.gradientType,
+            gradientScope: layer.gradientScope,
+            gradientPanelAlternate: layer.gradientPanelAlternate,
+            gradientAngle: layer.gradientAngle,
+            gradientOpacity: layer.gradientOpacity,
+            gradientBlend: layer.gradientBlend,
+            gradientStops: layer.gradientStops,
+            panelColorMode: layer.panelColorMode,
+            panelColors: layer.panelColors,
             border_color_pixel: layer.border_color_pixel,
             border_color_cabinet: layer.border_color_cabinet,
             border_color_data: layer.border_color_data,

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -2271,6 +2271,9 @@ class CanvasRenderer {
     }
 
     render() {
+        // v0.8.7.8: bump a per-render token so screen-fill gradients are built
+        // at most once per layer per frame (cached on the layer keyed by this).
+        this._renderPass = (this._renderPass || 0) + 1;
         if (this.layerSelectionRect && !this.isSelectingLayers && !this.isSelectingPanels && !this.isDraggingLayer) {
             this.layerSelectionRect = null;
         }
@@ -3062,6 +3065,114 @@ class CanvasRenderer {
         this.ctx.restore();
     }
     
+    // v0.8.7.8: build a CanvasGradient spanning the layer's bounding box in
+    // the current ctx coordinate space. Because canvas gradients live in user
+    // space, the SAME gradient used as the fill for each panel rect renders as
+    // one continuous gradient across the whole screen (and naturally skips
+    // blank/half/hidden panels, which never fill).
+    // v0.8.7.8: base cabinet fill. Default is the legacy 2-color checkerboard
+    // (color1/color2 via panel.is_color1). When panelColorMode selects a
+    // palette distribution and panelColors has entries, each cabinet samples a
+    // color from the palette by its grid position.
+    _panelBaseFill(panel, layer) {
+        const mode = layer.panelColorMode || 'checker';
+        const pal = Array.isArray(layer.panelColors) ? layer.panelColors : [];
+        if (mode !== 'checker' && pal.length >= 1) {
+            const cols = Math.max(1, Number(layer.columns) || 1);
+            const r = Number(panel.row) || 0;
+            const c = Number(panel.col) || 0;
+            let idx;
+            switch (mode) {
+                case 'diagonal': idx = (r + c) % pal.length; break;        // ORACLE wave
+                case 'cycle': idx = (r * cols + c) % pal.length; break;
+                case 'row': idx = r % pal.length; break;
+                case 'column': idx = c % pal.length; break;
+                default: idx = 0;
+            }
+            return pal[((idx % pal.length) + pal.length) % pal.length] || '#000000';
+        }
+        const color = panel.is_color1 ? layer.color1 : layer.color2;
+        return `rgb(${color.r}, ${color.g}, ${color.b})`;
+    }
+
+    _buildGradientForRect(layer, x, y, w, h, invert) {
+        const ctx = this.ctx;
+        let stops = Array.isArray(layer.gradientStops) ? layer.gradientStops.slice() : [];
+        if (stops.length < 2) {
+            stops = [{ pos: 0, color: '#000000' }, { pos: 1, color: '#ffffff' }];
+        }
+        // invert = mirror the gradient (pos → 1-pos); used to flip alternating
+        // cabinets in per-panel mode so adjacent panels mirror each other.
+        if (invert) stops = stops.map(s => ({ pos: 1 - (Number(s.pos) || 0), color: s.color }));
+        stops.sort((a, b) => (Number(a.pos) || 0) - (Number(b.pos) || 0));
+        let grad;
+        if ((layer.gradientType || 'linear') === 'radial') {
+            const cx = x + w / 2;
+            const cy = y + h / 2;
+            const r = Math.max(w, h) / 2 || 1;
+            grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+        } else {
+            // angle: 0 = left→right, 90 = top→bottom (canvas +y is down).
+            const angle = ((Number(layer.gradientAngle) || 0) * Math.PI) / 180;
+            const dx = Math.cos(angle);
+            const dy = Math.sin(angle);
+            const cx = x + w / 2;
+            const cy = y + h / 2;
+            // Project the box half-extent onto the gradient direction so the
+            // 0 and 1 stops land on the bounding edges along that angle.
+            const half = (Math.abs(dx) * w + Math.abs(dy) * h) / 2 || 1;
+            grad = ctx.createLinearGradient(cx - dx * half, cy - dy * half, cx + dx * half, cy + dy * half);
+        }
+        stops.forEach(s => {
+            const p = Math.min(1, Math.max(0, Number(s.pos) || 0));
+            try { grad.addColorStop(p, s.color || '#000000'); } catch (_) {}
+        });
+        return grad;
+    }
+
+    // Memoized per-layer-per-render gradient spanning the whole screen. Safe to
+    // call once per panel. (Per-panel spread builds its own gradient per rect.)
+    _screenGradientFor(layer) {
+        if (layer._gradPass !== this._renderPass) {
+            const b = this.getLayerBounds(layer);
+            layer._gradObj = this._buildGradientForRect(layer, b.x, b.y, b.width, b.height);
+            layer._gradPass = this._renderPass;
+        }
+        return layer._gradObj;
+    }
+
+    // Map a friendly gradient blend name to a canvas globalCompositeOperation.
+    _gradientCompositeOp(name) {
+        if (!name || name === 'normal') return 'source-over';
+        // The remaining names match canvas composite operations 1:1.
+        return name;
+    }
+
+    // Composite the gradient over a single panel rect (called after the
+    // checkerboard fill, before borders). No-op unless the layer opts in.
+    // gradientScope 'screen' = one continuous gradient across the whole screen;
+    // 'panel' = the gradient is mapped to each cabinet individually.
+    _applyGradientOverlay(panel, layer) {
+        if (!layer || !layer.gradientEnabled) return;
+        let grad;
+        if (layer.gradientScope === 'panel') {
+            // Mirror the gradient on alternating COLUMNS (a whole column shares
+            // one orientation; every other column flips) — the SUPERTASK wave.
+            const invert = !!layer.gradientPanelAlternate
+                && ((Number(panel.col) || 0) % 2 === 1);
+            grad = this._buildGradientForRect(layer, panel.x, panel.y, panel.width, panel.height, invert);
+        } else {
+            grad = this._screenGradientFor(layer);
+        }
+        if (!grad) return;
+        this.ctx.save();
+        this.ctx.globalAlpha = (layer.gradientOpacity != null) ? layer.gradientOpacity : 0.6;
+        this.ctx.globalCompositeOperation = this._gradientCompositeOp(layer.gradientBlend);
+        this.ctx.fillStyle = grad;
+        this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+        this.ctx.restore();
+    }
+
     renderPixelMap(panel, layer) {
         // If panel is hidden, render as ghost outline only - scales with zoom like text
         if (panel.hidden) {
@@ -3073,12 +3184,14 @@ class CanvasRenderer {
             return; // Don't fill, just outline
         }
         
-        // Use normal checkerboard colors (removed blank mode)
-        const color = panel.is_color1 ? layer.color1 : layer.color2;
-        this.ctx.fillStyle = `rgb(${color.r}, ${color.g}, ${color.b})`;
-        
+        // Base cabinet fill: 2-color checkerboard or multi-color palette.
+        this.ctx.fillStyle = this._panelBaseFill(panel, layer);
+
         this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-        
+
+        // v0.8.7.8: gradient overlay on top of the checkerboard, below borders.
+        this._applyGradientOverlay(panel, layer);
+
         // Panel borders - 2 pixels wide per panel, drawn INSIDE the panel
         // Where two panels meet, you get 2+2 = 4 pixels total
         if (layer.show_panel_borders) {
@@ -3171,11 +3284,13 @@ class CanvasRenderer {
             return;
         }
         
-        // Use normal checkerboard colors (removed blank mode)
-        const color = panel.is_color1 ? layer.color1 : layer.color2;
-        this.ctx.fillStyle = `rgb(${color.r}, ${color.g}, ${color.b})`;
+        // Base cabinet fill: 2-color checkerboard or multi-color palette.
+        this.ctx.fillStyle = this._panelBaseFill(panel, layer);
         this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-        
+
+        // v0.8.7.8: gradient overlay on top of the checkerboard, below borders.
+        this._applyGradientOverlay(panel, layer);
+
         // Panel borders - 2 pixels wide per panel, drawn INSIDE the panel
         if (layer.show_panel_borders) {
             this.ctx.strokeStyle = this.getLayerBorderColor(layer, 'cabinet-id');

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3107,9 +3107,14 @@ class CanvasRenderer {
         stops.sort((a, b) => (Number(a.pos) || 0) - (Number(b.pos) || 0));
         let grad;
         if ((layer.gradientType || 'linear') === 'radial') {
-            const cx = x + w / 2;
-            const cy = y + h / 2;
-            const r = Math.max(w, h) / 2 || 1;
+            // Center is a fraction of the rect (0.5 = middle); radius is a
+            // multiplier of the rect's base radius (max(w,h)/2).
+            const fx = (layer.gradientRadialCenterX != null) ? layer.gradientRadialCenterX : 0.5;
+            const fy = (layer.gradientRadialCenterY != null) ? layer.gradientRadialCenterY : 0.5;
+            const rs = (layer.gradientRadialRadius != null) ? layer.gradientRadialRadius : 1;
+            const cx = x + w * fx;
+            const cy = y + h * fy;
+            const r = Math.max(1, (Math.max(w, h) / 2) * rs);
             grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
         } else {
             // angle: 0 = left→right, 90 = top→bottom (canvas +y is down).

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.8</title>
+    <title>LED Raster Designer v0.8.8.0</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.8</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.8.0</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1215,6 +1215,29 @@
                                     <input type="number" id="gradient-angle-num" min="0" max="360" step="1" value="0" style="width: 52px;" aria-label="Gradient angle in degrees">
                                 </div>
                             </div>
+                            <div id="gradient-radial-rows" style="display: none;">
+                                <div class="info-row">
+                                    <label>Center X</label>
+                                    <div style="display: flex; gap: 6px; align-items: center; flex: 1;">
+                                        <input type="range" id="gradient-rcx" min="-50" max="150" step="1" value="50" style="flex: 1;">
+                                        <input type="number" id="gradient-rcx-num" min="-50" max="150" step="1" value="50" style="width: 52px;" aria-label="Radial center X percent">
+                                    </div>
+                                </div>
+                                <div class="info-row">
+                                    <label>Center Y</label>
+                                    <div style="display: flex; gap: 6px; align-items: center; flex: 1;">
+                                        <input type="range" id="gradient-rcy" min="-50" max="150" step="1" value="50" style="flex: 1;">
+                                        <input type="number" id="gradient-rcy-num" min="-50" max="150" step="1" value="50" style="width: 52px;" aria-label="Radial center Y percent">
+                                    </div>
+                                </div>
+                                <div class="info-row">
+                                    <label>Size</label>
+                                    <div style="display: flex; gap: 6px; align-items: center; flex: 1;">
+                                        <input type="range" id="gradient-rsize" min="10" max="400" step="1" value="100" style="flex: 1;">
+                                        <input type="number" id="gradient-rsize-num" min="10" max="400" step="1" value="100" style="width: 52px;" aria-label="Radial size percent">
+                                    </div>
+                                </div>
+                            </div>
                             <div class="info-row">
                                 <label>Opacity</label>
                                 <div style="display: flex; gap: 6px; align-items: center; flex: 1;">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.8.7.7.4</title>
+    <title>LED Raster Designer v0.8.7.8</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -84,7 +84,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.7.4</span></h1>
+                <h1>LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.8.7.8</span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1141,6 +1141,108 @@
                                 <input type="color" id="color2-picker" value="#959CB8">
                                 <button class="color-swatch" id="color2-picker-swatch" aria-label="Checkerboard Color 2"></button>
                                 <input type="text" id="color2-hex" value="#959CB8" maxlength="7" style="width: 70px; font-family: monospace;">
+                            </div>
+                        </div>
+
+                        <!-- v0.8.7.8: multi-color cabinet palette. -->
+                        <div class="info-row" style="margin-top: 10px;" data-tooltip="Checkerboard uses Color 1 / Color 2. Palette modes distribute the colors below across cabinets.">
+                            <label>Pattern</label>
+                            <select id="panel-color-mode" class="info-select" style="max-width: 130px;">
+                                <option value="checker">Checkerboard</option>
+                                <option value="diagonal">Diagonal wave</option>
+                                <option value="cycle">Cycle / sweep</option>
+                                <option value="row">By row</option>
+                                <option value="column">By column</option>
+                            </select>
+                        </div>
+                        <div id="panel-palette-editor" style="display: none; margin-top: 4px;">
+                            <div id="panel-palette-swatches" style="display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 6px;"></div>
+                            <div style="display: flex; gap: 5px; align-items: center;">
+                                <input type="color" id="palette-color" value="#bc382f" aria-label="Selected palette color">
+                                <input type="text" id="palette-hex" value="#BC382F" maxlength="7" style="width: 70px; font-family: monospace;">
+                                <button class="btn" id="palette-add" style="padding: 4px 8px; font-size: 11px;" title="Add a color">+ Add</button>
+                                <button class="btn" id="palette-remove" style="padding: 4px 8px; font-size: 11px;" title="Remove selected color">Remove</button>
+                            </div>
+                        </div>
+
+                        <!-- v0.8.7.8: Photoshop-style gradient overlay. -->
+                        <div class="checkbox-row" style="margin-top: 10px;" data-tooltip="Overlay a gradient on top of the checkerboard test pattern (Pixel Map, Show Look, Cabinet ID).">
+                            <input type="checkbox" id="gradient-enabled">
+                            <label for="gradient-enabled">Gradient overlay</label>
+                        </div>
+                        <div id="gradient-controls" style="display: none; margin-top: 6px;">
+                            <!-- Preset gradient library (custom picker with color swatches). -->
+                            <div data-tooltip="Apply a gradient preset, or save the current gradient as one.">
+                                <button id="gradient-preset-trigger" style="width: 100%; display: flex; align-items: center; gap: 6px; background: #1a1a1a; border: 1px solid #3a3a3a; border-radius: 4px; padding: 5px 8px; cursor: pointer;">
+                                    <span id="gradient-preset-preview" style="flex: 1; min-width: 0; height: 14px; border-radius: 3px; background: #444;"></span>
+                                    <span style="font-size: 10px; color: #aaa;">▾</span>
+                                </button>
+                                <div id="gradient-preset-menu" style="display: none; margin-top: 4px; max-height: 240px; overflow-y: auto; background: #1a1a1a; border: 1px solid #4a4a4a; border-radius: 6px; padding: 4px;"></div>
+                            </div>
+                            <div style="display: flex; gap: 5px; margin: 6px 0 8px;">
+                                <button class="btn" id="gradient-preset-save" style="padding: 4px 8px; font-size: 11px;" title="Save the current gradient as a preset">Save current…</button>
+                            </div>
+                            <!-- Stop bar: click to add a stop, drag markers to move. -->
+                            <div id="gradient-bar" style="position: relative; height: 26px; border-radius: 4px; border: 1px solid #4a4a4a; cursor: copy; margin-bottom: 6px;" title="Click to add a color stop; drag a marker to move it"></div>
+                            <div style="display: flex; gap: 5px; align-items: center; margin-bottom: 8px;">
+                                <input type="color" id="gradient-stop-color" value="#1d9e75" aria-label="Selected stop color">
+                                <input type="text" id="gradient-stop-hex" value="#1D9E75" maxlength="7" style="width: 70px; font-family: monospace;">
+                                <input type="number" id="gradient-stop-pos" min="0" max="100" value="0" style="width: 52px;" aria-label="Selected stop position percent" title="Stop position (%)">
+                                <button class="btn" id="gradient-stop-remove" style="padding: 4px 8px; font-size: 11px;" title="Remove selected stop">Remove</button>
+                            </div>
+                            <div class="info-row">
+                                <label>Type</label>
+                                <select id="gradient-type" class="info-select" style="max-width: 120px;">
+                                    <option value="linear">Linear</option>
+                                    <option value="radial">Radial</option>
+                                </select>
+                            </div>
+                            <div class="info-row" data-tooltip="Spread the gradient across the whole screen, or repeat it on each cabinet panel.">
+                                <label>Spread</label>
+                                <select id="gradient-scope" class="info-select" style="max-width: 120px;">
+                                    <option value="screen">Whole screen</option>
+                                    <option value="panel">Each panel</option>
+                                </select>
+                            </div>
+                            <div class="checkbox-row" id="gradient-alternate-row" style="display: none;" data-tooltip="Mirror the gradient on every other cabinet so adjacent panels flip (wave look).">
+                                <input type="checkbox" id="gradient-panel-alternate">
+                                <label for="gradient-panel-alternate">Alternate panels</label>
+                            </div>
+                            <div class="info-row" id="gradient-angle-row">
+                                <label>Angle</label>
+                                <div style="display: flex; gap: 6px; align-items: center; flex: 1;">
+                                    <input type="range" id="gradient-angle" min="0" max="360" step="1" value="0" style="flex: 1;">
+                                    <input type="number" id="gradient-angle-num" min="0" max="360" step="1" value="0" style="width: 52px;" aria-label="Gradient angle in degrees">
+                                </div>
+                            </div>
+                            <div class="info-row">
+                                <label>Opacity</label>
+                                <div style="display: flex; gap: 6px; align-items: center; flex: 1;">
+                                    <input type="range" id="gradient-opacity" min="0" max="100" step="1" value="60" style="flex: 1;">
+                                    <input type="number" id="gradient-opacity-num" min="0" max="100" step="1" value="60" style="width: 52px;" aria-label="Gradient opacity percent">
+                                    <span style="font-size: 12px; color: #888;">%</span>
+                                </div>
+                            </div>
+                            <div class="info-row">
+                                <label>Blend</label>
+                                <select id="gradient-blend" class="info-select" style="max-width: 120px;">
+                                    <option value="normal">Normal</option>
+                                    <option value="multiply">Multiply</option>
+                                    <option value="screen">Screen</option>
+                                    <option value="overlay">Overlay</option>
+                                    <option value="darken">Darken</option>
+                                    <option value="lighten">Lighten</option>
+                                    <option value="color-dodge">Color Dodge</option>
+                                    <option value="color-burn">Color Burn</option>
+                                    <option value="hard-light">Hard Light</option>
+                                    <option value="soft-light">Soft Light</option>
+                                    <option value="difference">Difference</option>
+                                    <option value="exclusion">Exclusion</option>
+                                    <option value="hue">Hue</option>
+                                    <option value="saturation">Saturation</option>
+                                    <option value="color">Color</option>
+                                    <option value="luminosity">Luminosity</option>
+                                </select>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
Adds Photoshop-style **gradient overlays** and **multi-color cabinet palettes** to screens (Pixel Map / Show Look / Cabinet ID).

### Gradient overlay
- Composited over the checkerboard test pattern at adjustable opacity/blend.
- Multi-stop editor (click-add, drag, typeable hex + position).
- **Linear** (typeable angle) and **Radial** with a movable center (Center X/Y) and adjustable Size.
- Spread: **Whole screen** or **Each panel**; "Alternate panels" mirrors every other column (woven wave).
- Typeable opacity + the full blend-mode set.
- Preset library with live color swatches: 22 built-ins + **Save current…** (per-browser). Built-in presets re-color the current gradient only (keep your type/radial/opacity/blend); your own saved presets restore their full settings.

### Multi-color cabinet palette
- Pattern modes: **Checkerboard** (default, unchanged), **Diagonal wave**, Cycle, By row, By column — distribute an N-color palette across cabinets.
- Existing screens stay on the 2-color checkerboard until changed.

All new settings persist with the project + the live server round-trip and bulk-apply across a multi-selection.

## Test plan
- [x] Verified extensively in preview: linear/radial, movable+resizable radial, per-panel spread + alternate columns, blend modes, presets (built-in re-color vs user full-restore), multi-color diagonal wave, round-trip persistence, multi-select bulk apply.
- [x] `pytest tests/test_version.py` green; `node --check` on app.js/canvas.js.
- [x] Validated as a private v0.8.8.0 build on a real system.