### PR TITLE
Fix: PSD Export Transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.9.1
+# LED Raster Designer v0.9.1.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,14 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.9.1.1 - July 6, 2026
+----------------------------
+- FIX: PSD export now preserves Transparent (no fill) screen interiors as
+  real layer transparency. Exports keep the PSD document RGB, write the
+  rendered alpha channel into each layer's transparency channel, and avoid
+  phantom layer-mask metadata that caused Affinity Photo mask warnings.
+
+
 v0.9.1 - July 2, 2026
 ----------------------------
 - FEATURE: Transparent fill. A "Transparent (no fill)" checkbox in the

--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,22 @@ import numpy as np
 # decompression bomb DOS attack".
 Image.MAX_IMAGE_PIXELS = None
 
+
+def _empty_psd_layer_mask(psd_layers):
+    """Create a no-op layer mask that serializes as absent mask data."""
+    class EmptyLayerMask(psd_layers.LayerMask):
+        def length(self, header):
+            return 0
+
+        def total_length(self, header):
+            return 4
+
+        def write(self, fd, header):
+            fd.write(b'\x00\x00\x00\x00')
+
+    return EmptyLayerMask()
+
+
 # Support PyInstaller --onedir bundle: resolve templates/static from _MEIPASS
 if getattr(sys, 'frozen', False):
     BASE_DIR = sys._MEIPASS
@@ -2876,8 +2892,10 @@ def export_psd_from_image():
         full_img = decode_base64_image(image_data)
         full_img = full_img.convert('RGBA')  # Convert to RGBA for alpha support
         
-        # Create PSD with alpha channel (4 channels: RGB + Alpha)
-        psd = PsdFile(num_channels=4, height=height, width=width, color_mode=ColorMode.rgb)
+        # Keep the merged document RGB; layer transparency is stored in each
+        # layer's -1 channel. Advertising a document alpha channel without
+        # merged alpha data triggers warnings in some PSD readers.
+        psd = PsdFile(num_channels=3, height=height, width=width, color_mode=ColorMode.rgb)
         
         layer_records = []
         
@@ -2915,7 +2933,7 @@ def export_psd_from_image():
             # Create ChannelImageData for RGB + Alpha
             # Channel -1 is the alpha/transparency mask
             channels = {
-                -1: psd_layers.ChannelImageData(image=np.full((actual_height, actual_width), 255, dtype=np.uint8), compression=Compression.raw),  # Full opacity
+                -1: psd_layers.ChannelImageData(image=img_array[:, :, 3].copy(), compression=Compression.raw),
                 0: psd_layers.ChannelImageData(image=img_array[:, :, 0].copy(), compression=Compression.raw),
                 1: psd_layers.ChannelImageData(image=img_array[:, :, 1].copy(), compression=Compression.raw),
                 2: psd_layers.ChannelImageData(image=img_array[:, :, 2].copy(), compression=Compression.raw),
@@ -2931,6 +2949,7 @@ def export_psd_from_image():
                 opacity=255,
                 channels=channels
             )
+            layer_record.mask = _empty_psd_layer_mask(psd_layers)
             layer_records.append(layer_record)
         
         psd.layer_and_mask_info.layer_info.layer_records = layer_records
@@ -2981,8 +3000,9 @@ def export_psd_zip_from_images():
                 view_name = img_info['name']
                 full_img = decode_base64_image(img_info['data']).convert('RGBA')
                 
-                # Create PSD with alpha channel
-                psd = PsdFile(num_channels=4, height=height, width=width, color_mode=ColorMode.rgb)
+                # Keep the merged document RGB; layer transparency is stored in
+                # each layer's -1 channel.
+                psd = PsdFile(num_channels=3, height=height, width=width, color_mode=ColorMode.rgb)
                 layer_records = []
                 
                 # Create a layer for each screen
@@ -3013,7 +3033,7 @@ def export_psd_zip_from_images():
                     
                     # Create ChannelImageData for RGB + Alpha
                     channels = {
-                        -1: psd_layers.ChannelImageData(image=np.full((actual_height, actual_width), 255, dtype=np.uint8), compression=Compression.raw),
+                        -1: psd_layers.ChannelImageData(image=img_array[:, :, 3].copy(), compression=Compression.raw),
                         0: psd_layers.ChannelImageData(image=img_array[:, :, 0].copy(), compression=Compression.raw),
                         1: psd_layers.ChannelImageData(image=img_array[:, :, 1].copy(), compression=Compression.raw),
                         2: psd_layers.ChannelImageData(image=img_array[:, :, 2].copy(), compression=Compression.raw),
@@ -3028,6 +3048,7 @@ def export_psd_zip_from_images():
                         opacity=255,
                         channels=channels
                     )
+                    layer_record.mask = _empty_psd_layer_mask(psd_layers)
                     layer_records.append(layer_record)
                 
                 psd.layer_and_mask_info.layer_info.layer_records = layer_records

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -96,8 +96,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.9.1',
-            'CFBundleVersion': '0.9.1',
+            'CFBundleShortVersionString': '0.9.1.1',
+            'CFBundleVersion': '0.9.1.1',
             'NSHighResolutionCapable': True,
             'LSUIElement': True,  # Menu bar only — no Dock icon
         },

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.9.1</title>
+    <title>LED Raster Designer v0.9.1.1</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -89,7 +89,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                <h1><svg class="lrd-logo-mark" width="26" height="26" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:9px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.9.1</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="26" height="26" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:9px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.9.1.1</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
Fixes PSD export for screen layers using the Transparent / no-fill option.

Previously, PSD export preserved the layer rectangles but forced every layer alpha channel to full opacity. In Photoshop and Affinity Photo this caused transparent screen interiors to render as black `rgb(0, 0, 0)` backgrounds.

This change:
- writes the rendered PNG alpha channel into each PSD layer's `-1` transparency channel
- keeps the PSD document as a normal RGB document instead of advertising document-level RGBA
- suppresses phantom layer-mask metadata so readers do not see missing user-mask data
- bumps the app version to `v0.9.1.1` for this patch release

## Root Cause

This was introduced in v0.9.1 with the new Transparent / no-fill feature introduced in `5a0bf75118ee1d147a4b1d202595508cbad4f08f`. The on-canvas transparent rendering worked, but the PSD writer still converted the cropped RGBA screen image into an opaque layer mask, so transparent interiors became black when opened in PSD readers.

The client-rendered PSD export path cropped each screen region from an RGBA PNG, but then wrote a synthetic full-opacity PSD alpha channel:

```text
layer alpha: 255 everywhere
```

That made transparent pixels opaque in downstream PSD readers.

After preserving real layer alpha, Affinity Photo still warned about missing mask data because the PSD also contained empty layer-mask metadata (`mask_len = 36`) without a corresponding user-mask channel. The final fix keeps transparency in the layer transparency channel and serializes absent user-mask metadata as `mask_len = 0`.

## Validation

Test project:
[Test Project.json](https://github.com/user-attachments/files/29711481/Test.Project.json)

Affected PSD:
[Test Project_Pixel Map_affected.psd.zip](https://github.com/user-attachments/files/29711490/Test.Project_Pixel.Map_affected.psd.zip)
- Structure:
  - document channels: `4`
  - layer alpha min/max: `255 / 255`
  - first layer mask length: `36`
- Result:
  - Photoshop 2026 / 27.8.0: screen interiors render black
  - Affinity Photo 3.0.1.3808: Missing mask data warning, then screen interiors render black

Fixed PSD:
[Test Project_Pixel Map_fixed.psd.zip](https://github.com/user-attachments/files/29711506/Test.Project_Pixel.Map_fixed.psd.zip)
- Structure:
  - document channels: `3`
  - layer channels: `[-1, 0, 1, 2]`
  - layer alpha min/max: `0 / 255`
  - first layer mask length: `0`
- Result:
  - Photoshop 2026 / 27.8.0: transparent screen interiors render correctly
  - Affinity Photo 3.0.1.3808: transparent screen interiors render correctly

Additional PSD validation:
- `file`: `Adobe Photoshop Image, 1920 x 1080, RGB, 3x 8-bit channels`
- `exiftool`: `File Type: PSD`, `Color Mode: RGB`, `Layer Count: 2`
- `pytoshop`: layer transparency channel exists and contains real `0..255` alpha