### PR TITLE
v0.10.1: magnetic snap fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.0
+# LED Raster Designer v0.10.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -10,6 +10,10 @@ v0.10.1 - July 15, 2026
   ties, and a screen only snaps to other screens that overlap (or nearly
   touch) it on the other axis - a screen in a different row/column no
   longer grabs the drag.
+- TWEAK: Magnetic snap engages from a shorter distance (~14 screen px,
+  down from ~34, matching the canvas snap feel). It still scales with
+  zoom, but is now capped at 60 raster px so a zoomed-out view can't
+  snap a screen from a whole cabinet-width away.
 
 v0.10.0 - July 13, 2026
 ----------------------------

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,16 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.1 - July 15, 2026
+----------------------------
+- FIX: Magnetic snap could land a dragged screen at the wrong position
+  (e.g. X = -40 instead of 0) when a far-away screen's edge happened to
+  line up with the dragged screen's opposite edge. Snapping now picks the
+  NEAREST snap target instead of the last one checked, raster edges win
+  ties, and a screen only snaps to other screens that overlap (or nearly
+  touch) it on the other axis - a screen in a different row/column no
+  longer grabs the drag.
+
 v0.10.0 - July 13, 2026
 ----------------------------
 - FEATURE: New launcher window. Opening the app now shows a control window

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.0',
-            'CFBundleVersion': '0.10.0',
+            'CFBundleShortVersionString': '0.10.1',
+            'CFBundleVersion': '0.10.1',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3059,8 +3059,6 @@ class CanvasRenderer {
     calculateMagneticSnap(offsetX, offsetY, currentLayer) {
         // Stronger, zoom-consistent snap zone (~34 screen px regardless of zoom).
         const snapDistance = 34 / (this.zoom || 1);
-        let snappedX = offsetX;
-        let snappedY = offsetY;
 
         // v0.9.3: snap by the rotated FOOTPRINT. It's centered on the screen, so
         // its top-left sits at offset + fpD (fpD = 0 when unrotated). We snap the
@@ -3077,13 +3075,33 @@ class CanvasRenderer {
         const currentTop = offsetY + fpDy;
         const currentBottom = currentTop + layerHeight;
 
-        // Snap to raster boundaries, HARD EDGES ONLY
-        if (Math.abs(currentLeft - 0) <= snapDistance) snappedX = 0 - fpDx;
-        if (Math.abs(currentRight - this.rasterWidth) <= snapDistance) snappedX = this.rasterWidth - layerWidth - fpDx;
-        if (Math.abs(currentTop - 0) <= snapDistance) snappedY = 0 - fpDy;
-        if (Math.abs(currentBottom - this.rasterHeight) <= snapDistance) snappedY = this.rasterHeight - layerHeight - fpDy;
+        // v0.10.1: the NEAREST candidate wins on each axis. The old code let
+        // whichever candidate was checked last overwrite the rest, so dragging
+        // toward the raster's left edge could land at a far layer's edge
+        // instead (e.g. -40 rather than 0). Raster edges are seeded first so
+        // they win exact ties (strict < keeps the earlier candidate).
+        let bestX = null;
+        let bestY = null;
+        const considerX = (edgePos, target, resultOffset) => {
+            const dist = Math.abs(edgePos - target);
+            if (dist <= snapDistance && (!bestX || dist < bestX.dist)) bestX = { value: resultOffset, dist };
+        };
+        const considerY = (edgePos, target, resultOffset) => {
+            const dist = Math.abs(edgePos - target);
+            if (dist <= snapDistance && (!bestY || dist < bestY.dist)) bestY = { value: resultOffset, dist };
+        };
 
-        // Snap to other layers' footprints, HARD EDGES ONLY
+        // Snap to raster boundaries, HARD EDGES ONLY
+        considerX(currentLeft, 0, 0 - fpDx);
+        considerX(currentRight, this.rasterWidth, this.rasterWidth - layerWidth - fpDx);
+        considerY(currentTop, 0, 0 - fpDy);
+        considerY(currentBottom, this.rasterHeight, this.rasterHeight - layerHeight - fpDy);
+
+        // Snap to other layers' footprints, HARD EDGES ONLY.
+        // v0.10.1: only layers that are neighbors on the perpendicular axis
+        // (ranges overlap, or nearly touch within the snap zone) attract a
+        // snap. A screen far above shouldn't grab a screen dragged along the
+        // raster's bottom just because their widths line up.
         if (window.app && window.app.project) {
             window.app.project.layers.forEach(layer => {
                 if (layer.id === currentLayer.id || !layer.visible) return;
@@ -3094,22 +3112,34 @@ class CanvasRenderer {
                 const otherTop = otherBounds.y;
                 const otherBottom = otherBounds.y + otherBounds.height;
 
-                // Left edge snaps
-                if (Math.abs(currentLeft - otherLeft) <= snapDistance) snappedX = otherLeft - fpDx;
-                if (Math.abs(currentLeft - otherRight) <= snapDistance) snappedX = otherRight - fpDx;
-                // Right edge snaps
-                if (Math.abs(currentRight - otherLeft) <= snapDistance) snappedX = otherLeft - layerWidth - fpDx;
-                if (Math.abs(currentRight - otherRight) <= snapDistance) snappedX = otherRight - layerWidth - fpDx;
-                // Top edge snaps
-                if (Math.abs(currentTop - otherTop) <= snapDistance) snappedY = otherTop - fpDy;
-                if (Math.abs(currentTop - otherBottom) <= snapDistance) snappedY = otherBottom - fpDy;
-                // Bottom edge snaps
-                if (Math.abs(currentBottom - otherTop) <= snapDistance) snappedY = otherTop - layerHeight - fpDy;
-                if (Math.abs(currentBottom - otherBottom) <= snapDistance) snappedY = otherBottom - layerHeight - fpDy;
+                const nearVertically = currentTop <= otherBottom + snapDistance &&
+                    currentBottom >= otherTop - snapDistance;
+                const nearHorizontally = currentLeft <= otherRight + snapDistance &&
+                    currentRight >= otherLeft - snapDistance;
+
+                if (nearVertically) {
+                    // Left edge snaps
+                    considerX(currentLeft, otherLeft, otherLeft - fpDx);
+                    considerX(currentLeft, otherRight, otherRight - fpDx);
+                    // Right edge snaps
+                    considerX(currentRight, otherLeft, otherLeft - layerWidth - fpDx);
+                    considerX(currentRight, otherRight, otherRight - layerWidth - fpDx);
+                }
+                if (nearHorizontally) {
+                    // Top edge snaps
+                    considerY(currentTop, otherTop, otherTop - fpDy);
+                    considerY(currentTop, otherBottom, otherBottom - fpDy);
+                    // Bottom edge snaps
+                    considerY(currentBottom, otherTop, otherTop - layerHeight - fpDy);
+                    considerY(currentBottom, otherBottom, otherBottom - layerHeight - fpDy);
+                }
             });
         }
 
-        return { x: Math.round(snappedX), y: Math.round(snappedY) };
+        return {
+            x: Math.round(bestX ? bestX.value : offsetX),
+            y: Math.round(bestY ? bestY.value : offsetY)
+        };
     }
     
     setViewMode(mode) {

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3057,8 +3057,10 @@ class CanvasRenderer {
     }
 
     calculateMagneticSnap(offsetX, offsetY, currentLayer) {
-        // Stronger, zoom-consistent snap zone (~34 screen px regardless of zoom).
-        const snapDistance = 34 / (this.zoom || 1);
+        // Zoom-consistent snap zone (~14 screen px, same feel as the canvas
+        // snap), capped at 60 raster px so a zoomed-out view can't grab the
+        // screen from a whole cabinet-width away.
+        const snapDistance = Math.min(14 / (this.zoom || 1), 60);
 
         // v0.9.3: snap by the rotated FOOTPRINT. It's centered on the screen, so
         // its top-left sits at offset + fpD (fpD = 0 when unrotated). We snap the

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.0</title>
+    <title>LED Raster Designer v0.10.1</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -92,7 +92,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.0</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.1</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## v0.10.1

- FIX: Magnetic snap could land a dragged screen at the wrong position (e.g. X = -40 instead of 0) when a far-away screen's edge happened to line up with the dragged screen's opposite edge. Snapping now picks the nearest snap target (raster edges win ties), and a screen only snaps to other screens that overlap or nearly touch it on the other axis.
- TWEAK: Magnetic snap engages from a shorter distance (~14 screen px, down from ~34, matching the canvas snap feel), still zoom-scaled but capped at 60 raster px so zoomed-out views can't snap from a cabinet-width away.