### PR TITLE
v0.10.2: Size by Wall Dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.1
+# LED Raster Designer v0.11.0
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.11.0
+# LED Raster Designer v0.10.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,18 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.11.0 - July 15, 2026
+----------------------------
+- FEATURE: Size by Wall Dimensions. A new checkbox in Screen Info lets you
+  enter the wall size you want (in ft, m, or px) and the app works out the
+  number of tiles for you - handy for quoting when you know the wall, not
+  the panel math. Pick a panel preset for the pitch, tick the box, type the
+  target width/height, and columns/rows fill in automatically (rounded up
+  so the wall is always covered). A readout shows the tile count and the
+  actual built size in m, ft, and px. Columns/Rows lock while the mode is
+  on; untick to edit them by hand again. The mode and targets are saved
+  per screen.
+
 v0.10.1 - July 15, 2026
 ----------------------------
 - FIX: Magnetic snap could land a dragged screen at the wrong position

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,16 +1,17 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
-v0.11.0 - July 15, 2026
+v0.10.2 - July 15, 2026
 ----------------------------
 - FEATURE: Size by Wall Dimensions. A new checkbox in Screen Info lets you
   enter the wall size you want (in ft, m, or px) and the app works out the
   number of tiles for you - handy for quoting when you know the wall, not
   the panel math. Pick a panel preset for the pitch, tick the box, type the
-  target width/height, and columns/rows fill in automatically (rounded up
-  so the wall is always covered). A readout shows the tile count and the
-  actual built size in m, ft, and px. Columns/Rows lock while the mode is
-  on; untick to edit them by hand again. The mode and targets are saved
+  target width/height, and columns/rows fill in automatically (rounded to
+  the nearest whole tile - 17 ft on 500 mm tiles gives 10 tiles because
+  16.40 ft is closer than 18.04 ft). A readout shows the tile count and
+  the actual built size in m, ft, and px. Columns/Rows lock while the mode
+  is on; untick to edit them by hand again. The mode and targets are saved
   per screen.
 
 v0.10.1 - July 15, 2026

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.11.0',
-            'CFBundleVersion': '0.11.0',
+            'CFBundleShortVersionString': '0.10.2',
+            'CFBundleVersion': '0.10.2',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.1',
-            'CFBundleVersion': '0.10.1',
+            'CFBundleShortVersionString': '0.11.0',
+            'CFBundleVersion': '0.11.0',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/static/js/app-core.js
+++ b/src/static/js/app-core.js
@@ -1654,7 +1654,8 @@ export class LEDRasterApp {
         
         ['offset-x', 'offset-y', 'cabinet-width', 'cabinet-height',
          'screen-columns', 'screen-rows', 'number-size', 'panel-width-mm', 'panel-height-mm', 'panel-weight-kg', 'image-scale', 'image-scale-range',
-         'show-offset-x', 'show-offset-y'].forEach(id => {
+         'show-offset-x', 'show-offset-y',
+         'size-by-dimensions', 'target-width', 'target-height', 'target-unit'].forEach(id => {
             const input = document.getElementById(id);
             if (input) {
                 input.addEventListener('change', () => {

--- a/src/static/js/app-screen-info.js
+++ b/src/static/js/app-screen-info.js
@@ -977,6 +977,15 @@ class _ScreenInfo {
         const cabinetHeightVal = readNumber('cabinet-height').value;
         const columnsVal = readNumber('screen-columns').value;
         const rowsVal = readNumber('screen-rows').value;
+        // v0.11.0: Size by Wall Dimensions mode - the user enters the wall
+        // size they want and columns/rows are derived per layer (rounded UP
+        // so the wall is always covered).
+        const sizeByDimEl = document.getElementById('size-by-dimensions');
+        const sizeByDimVal = sizeByDimEl && !sizeByDimEl.indeterminate ? sizeByDimEl.checked : null;
+        const targetUnitEl = document.getElementById('target-unit');
+        const targetUnitVal = targetUnitEl ? targetUnitEl.value : null;
+        const targetWidthVal = readNumber('target-width').value;
+        const targetHeightVal = readNumber('target-height').value;
         const numberSizeVal = readNumber('number-size').value;
         // The four screen-level half-tile flags were replaced by per-panel
         // halfTile state. The variables below remain (always null) so the
@@ -1096,6 +1105,18 @@ class _ScreenInfo {
                 if (cabinetHeightVal !== null) layer.cabinet_height = cabinetHeightVal;
                 if (columnsVal !== null) layer.columns = Math.round(columnsVal);
                 if (rowsVal !== null) layer.rows = Math.round(rowsVal);
+                if (sizeByDimVal !== null) layer.sizeByDimensions = sizeByDimVal;
+                if (layer.sizeByDimensions) {
+                    if (targetWidthVal !== null) layer.targetWidth = targetWidthVal;
+                    if (targetHeightVal !== null) layer.targetHeight = targetHeightVal;
+                    if (targetUnitVal !== null) layer.targetUnit = targetUnitVal;
+                    // Derive columns/rows from the targets using THIS layer's
+                    // panel dimensions (multi-select safe). Overrides any
+                    // manual columns/rows while the mode is on.
+                    const fit = this.computeTilesForWall(layer);
+                    if (fit.columns !== null) layer.columns = fit.columns;
+                    if (fit.rows !== null) layer.rows = fit.rows;
+                }
                 if (halfFirstColumnVal !== null) layer.halfFirstColumn = halfFirstColumnVal;
                 if (halfLastColumnVal !== null) layer.halfLastColumn = halfLastColumnVal;
                 if (halfFirstRowVal !== null) layer.halfFirstRow = halfFirstRowVal;
@@ -1145,6 +1166,13 @@ class _ScreenInfo {
         if (cabinetHeightVal !== null && document.getElementById('cabinet-height')) document.getElementById('cabinet-height').value = cabinetHeightVal;
         if (columnsVal !== null && document.getElementById('screen-columns')) document.getElementById('screen-columns').value = Math.round(columnsVal);
         if (rowsVal !== null && document.getElementById('screen-rows')) document.getElementById('screen-rows').value = Math.round(rowsVal);
+        // In Size by Wall Dimensions mode the columns/rows just derived from
+        // the targets win - reflect the primary layer's computed values.
+        if (this.currentLayer && this.currentLayer.sizeByDimensions) {
+            if (document.getElementById('screen-columns')) document.getElementById('screen-columns').value = this.currentLayer.columns;
+            if (document.getElementById('screen-rows')) document.getElementById('screen-rows').value = this.currentLayer.rows;
+        }
+        this.refreshSizeByDimensionsUI();
         if (numberSizeVal !== null && document.getElementById('number-size')) document.getElementById('number-size').value = Math.round(numberSizeVal);
         if (panelWidthMMVal !== null && document.getElementById('panel-width-mm')) document.getElementById('panel-width-mm').value = panelWidthMMVal;
         if (panelHeightMMVal !== null && document.getElementById('panel-height-mm')) document.getElementById('panel-height-mm').value = panelHeightMMVal;
@@ -1157,6 +1185,66 @@ class _ScreenInfo {
         
         this.updateLayers(targetLayers);
         this.debouncedSaveState('Update Properties');
+    }
+
+    // v0.11.0: Size by Wall Dimensions - how many tiles cover the target
+    // wall size. ft/m use the panel's physical size; px uses the cabinet
+    // pixel size. Rounds UP (a quote needs the wall fully covered); the
+    // tiny epsilon keeps exact fits (e.g. 5 m / 0.5 m) from rounding to 11.
+    computeTilesForWall(layer) {
+        const eps = 1e-6;
+        const unit = layer.targetUnit || 'ft';
+        const tw = Number(layer.targetWidth);
+        const th = Number(layer.targetHeight);
+        let columns = null;
+        let rows = null;
+        if (unit === 'px') {
+            const cw = Number(layer.cabinet_width) || 0;
+            const ch = Number(layer.cabinet_height) || 0;
+            if (Number.isFinite(tw) && tw > 0 && cw > 0) columns = Math.max(1, Math.ceil(tw / cw - eps));
+            if (Number.isFinite(th) && th > 0 && ch > 0) rows = Math.max(1, Math.ceil(th / ch - eps));
+        } else {
+            const factor = unit === 'm' ? 1000 : 304.8; // target -> mm
+            const pw = Number(layer.panel_width_mm) || 0;
+            const ph = Number(layer.panel_height_mm) || 0;
+            if (Number.isFinite(tw) && tw > 0 && pw > 0) columns = Math.max(1, Math.ceil((tw * factor) / pw - eps));
+            if (Number.isFinite(th) && th > 0 && ph > 0) rows = Math.max(1, Math.ceil((th * factor) / ph - eps));
+        }
+        return { columns, rows };
+    }
+
+    // Show/hide the target fields, lock Columns/Rows while the mode drives
+    // them, and render the tiles + actual-size readout for the primary layer.
+    refreshSizeByDimensionsUI() {
+        const checkbox = document.getElementById('size-by-dimensions');
+        const fields = document.getElementById('size-by-dimensions-fields');
+        const result = document.getElementById('size-by-dimensions-result');
+        if (!checkbox || !fields) return;
+        const on = checkbox.checked && !checkbox.indeterminate;
+        fields.style.display = on ? '' : 'none';
+        ['screen-columns', 'screen-rows'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.readOnly = on;
+                el.style.opacity = on ? '0.55' : '';
+            }
+        });
+        if (!result) return;
+        const primary = this.currentLayer && (this.currentLayer.type || 'screen') === 'screen' ? this.currentLayer : null;
+        if (!on || !primary) {
+            result.innerHTML = '';
+            return;
+        }
+        const cols = Number(primary.columns) || 0;
+        const rows = Number(primary.rows) || 0;
+        const wM = cols * (Number(primary.panel_width_mm) || 0) / 1000;
+        const hM = rows * (Number(primary.panel_height_mm) || 0) / 1000;
+        const wPx = cols * (Number(primary.cabinet_width) || 0);
+        const hPx = rows * (Number(primary.cabinet_height) || 0);
+        const ft = (m) => (m / 0.3048).toFixed(2);
+        result.innerHTML = `${cols} &times; ${rows} = <b>${cols * rows} tiles</b><br>` +
+            `Actual: ${wM.toFixed(2)} &times; ${hM.toFixed(2)} m &nbsp;&middot;&nbsp; ` +
+            `${ft(wM)} &times; ${ft(hM)} ft &nbsp;&middot;&nbsp; ${wPx} &times; ${hPx} px`;
     }
 
     loadLayerToInputs() {
@@ -1258,6 +1346,16 @@ class _ScreenInfo {
         setTextInput('cabinet-height', getCommon(l => l.cabinet_height));
         setTextInput('screen-columns', getCommon(l => l.columns));
         setTextInput('screen-rows', getCommon(l => l.rows));
+        // v0.11.0: restore Size by Wall Dimensions state for the selection
+        setCheckbox('size-by-dimensions', getCommon(l => !!l.sizeByDimensions));
+        setTextInput('target-width', getCommon(l => l.targetWidth ?? ''));
+        setTextInput('target-height', getCommon(l => l.targetHeight ?? ''));
+        const targetUnitSel = document.getElementById('target-unit');
+        if (targetUnitSel) {
+            const unitCommon2 = getCommon(l => l.targetUnit || 'ft');
+            if (!unitCommon2.mixed) targetUnitSel.value = unitCommon2.value;
+        }
+        this.refreshSizeByDimensionsUI();
         // (legacy half-* checkboxes were removed when half-tile state moved
         // to per-panel; the four screen-level flags are migrated to per-panel
         // halfTile values on first load.)

--- a/src/static/js/app-screen-info.js
+++ b/src/static/js/app-screen-info.js
@@ -977,9 +977,9 @@ class _ScreenInfo {
         const cabinetHeightVal = readNumber('cabinet-height').value;
         const columnsVal = readNumber('screen-columns').value;
         const rowsVal = readNumber('screen-rows').value;
-        // v0.11.0: Size by Wall Dimensions mode - the user enters the wall
-        // size they want and columns/rows are derived per layer (rounded UP
-        // so the wall is always covered).
+        // v0.10.2: Size by Wall Dimensions mode - the user enters the wall
+        // size they want and columns/rows are derived per layer (rounded to
+        // the nearest whole tile).
         const sizeByDimEl = document.getElementById('size-by-dimensions');
         const sizeByDimVal = sizeByDimEl && !sizeByDimEl.indeterminate ? sizeByDimEl.checked : null;
         const targetUnitEl = document.getElementById('target-unit');
@@ -1187,12 +1187,12 @@ class _ScreenInfo {
         this.debouncedSaveState('Update Properties');
     }
 
-    // v0.11.0: Size by Wall Dimensions - how many tiles cover the target
-    // wall size. ft/m use the panel's physical size; px uses the cabinet
-    // pixel size. Rounds UP (a quote needs the wall fully covered); the
-    // tiny epsilon keeps exact fits (e.g. 5 m / 0.5 m) from rounding to 11.
+    // v0.10.2: Size by Wall Dimensions - how many tiles for the target wall
+    // size. ft/m use the panel's physical size; px uses the cabinet pixel
+    // size. Rounds to the NEAREST whole tile (17 ft on 1.64 ft tiles is 10
+    // tiles, because 16.4 ft is closer than 18.04 ft); the readout shows the
+    // actual built size so a quote can state it.
     computeTilesForWall(layer) {
-        const eps = 1e-6;
         const unit = layer.targetUnit || 'ft';
         const tw = Number(layer.targetWidth);
         const th = Number(layer.targetHeight);
@@ -1201,14 +1201,14 @@ class _ScreenInfo {
         if (unit === 'px') {
             const cw = Number(layer.cabinet_width) || 0;
             const ch = Number(layer.cabinet_height) || 0;
-            if (Number.isFinite(tw) && tw > 0 && cw > 0) columns = Math.max(1, Math.ceil(tw / cw - eps));
-            if (Number.isFinite(th) && th > 0 && ch > 0) rows = Math.max(1, Math.ceil(th / ch - eps));
+            if (Number.isFinite(tw) && tw > 0 && cw > 0) columns = Math.max(1, Math.round(tw / cw));
+            if (Number.isFinite(th) && th > 0 && ch > 0) rows = Math.max(1, Math.round(th / ch));
         } else {
             const factor = unit === 'm' ? 1000 : 304.8; // target -> mm
             const pw = Number(layer.panel_width_mm) || 0;
             const ph = Number(layer.panel_height_mm) || 0;
-            if (Number.isFinite(tw) && tw > 0 && pw > 0) columns = Math.max(1, Math.ceil((tw * factor) / pw - eps));
-            if (Number.isFinite(th) && th > 0 && ph > 0) rows = Math.max(1, Math.ceil((th * factor) / ph - eps));
+            if (Number.isFinite(tw) && tw > 0 && pw > 0) columns = Math.max(1, Math.round((tw * factor) / pw));
+            if (Number.isFinite(th) && th > 0 && ph > 0) rows = Math.max(1, Math.round((th * factor) / ph));
         }
         return { columns, rows };
     }
@@ -1346,7 +1346,7 @@ class _ScreenInfo {
         setTextInput('cabinet-height', getCommon(l => l.cabinet_height));
         setTextInput('screen-columns', getCommon(l => l.columns));
         setTextInput('screen-rows', getCommon(l => l.rows));
-        // v0.11.0: restore Size by Wall Dimensions state for the selection
+        // v0.10.2: restore Size by Wall Dimensions state for the selection
         setCheckbox('size-by-dimensions', getCommon(l => !!l.sizeByDimensions));
         setTextInput('target-width', getCommon(l => l.targetWidth ?? ''));
         setTextInput('target-height', getCommon(l => l.targetHeight ?? ''));

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.11.0</title>
+    <title>LED Raster Designer v0.10.2</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -92,7 +92,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.11.0</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.2</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -150,12 +150,12 @@
                                 <label>Cabinet Height (px)</label>
                                 <input type="text" id="cabinet-height" value="128">
                             </div>
-                            <div class="info-row" data-tooltip="Size by Wall Dimensions, Enter the wall size you want and the number of tiles is worked out for you. Uses the panel's physical size for ft/m, or the cabinet pixel size for px. Tiles round UP so the wall is always covered.">
+                            <div class="info-row" data-tooltip="Size by Wall Dimensions, Enter the wall size you want and the number of tiles is worked out for you. Uses the panel's physical size for ft/m, or the cabinet pixel size for px. Tiles round to the NEAREST fit, and the readout shows the actual built size.">
                                 <label>Size by Wall Dimensions</label>
                                 <input type="checkbox" id="size-by-dimensions">
                             </div>
                             <div id="size-by-dimensions-fields" style="display:none;">
-                                <div class="info-row" data-tooltip="Target Width, Desired wall width. The number of columns is rounded up to cover it.">
+                                <div class="info-row" data-tooltip="Target Width, Desired wall width. The number of columns is rounded to the nearest whole tile.">
                                     <label>Target Width</label>
                                     <div style="display: flex; gap: 6px; align-items: center;">
                                         <input type="text" id="target-width" value="" autocomplete="off" style="width: 70px;">
@@ -166,7 +166,7 @@
                                         </select>
                                     </div>
                                 </div>
-                                <div class="info-row" data-tooltip="Target Height, Desired wall height. The number of rows is rounded up to cover it.">
+                                <div class="info-row" data-tooltip="Target Height, Desired wall height. The number of rows is rounded to the nearest whole tile.">
                                     <label>Target Height</label>
                                     <input type="text" id="target-height" value="" autocomplete="off" style="width: 70px;">
                                 </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.1</title>
+    <title>LED Raster Designer v0.11.0</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -92,7 +92,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.1</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.11.0</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -149,6 +149,28 @@
                             <div class="info-row" data-tooltip="Cabinet Height, Height of a single LED cabinet/panel in pixels.">
                                 <label>Cabinet Height (px)</label>
                                 <input type="text" id="cabinet-height" value="128">
+                            </div>
+                            <div class="info-row" data-tooltip="Size by Wall Dimensions, Enter the wall size you want and the number of tiles is worked out for you. Uses the panel's physical size for ft/m, or the cabinet pixel size for px. Tiles round UP so the wall is always covered.">
+                                <label>Size by Wall Dimensions</label>
+                                <input type="checkbox" id="size-by-dimensions">
+                            </div>
+                            <div id="size-by-dimensions-fields" style="display:none;">
+                                <div class="info-row" data-tooltip="Target Width, Desired wall width. The number of columns is rounded up to cover it.">
+                                    <label>Target Width</label>
+                                    <div style="display: flex; gap: 6px; align-items: center;">
+                                        <input type="text" id="target-width" value="" autocomplete="off" style="width: 70px;">
+                                        <select id="target-unit" class="info-select" style="width: 64px;" data-tooltip="Units, Feet and meters use the panel's physical size; px uses the cabinet pixel size.">
+                                            <option value="ft">ft</option>
+                                            <option value="m">m</option>
+                                            <option value="px">px</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="info-row" data-tooltip="Target Height, Desired wall height. The number of rows is rounded up to cover it.">
+                                    <label>Target Height</label>
+                                    <input type="text" id="target-height" value="" autocomplete="off" style="width: 70px;">
+                                </div>
+                                <div id="size-by-dimensions-result" style="margin: 4px 0 8px; font-size: 11px; color: #aac4ee; line-height: 1.5;"></div>
                             </div>
                             <div class="info-row" data-tooltip="Columns, Number of cabinets across the screen horizontally.">
                                 <label>Columns</label>


### PR DESCRIPTION
## v0.10.2

- FEATURE: Size by Wall Dimensions. A checkbox in Screen Info lets you enter the wall size you want (ft, m, or px) and the app works out the number of tiles (columns x rows round to the nearest whole tile). A readout shows the tile count and the actual built size in m, ft, and px. Columns/Rows lock while the mode is on; the mode and targets are saved per screen.