### PR TITLE
v0.10.5: gradients on Data/Power, Center on Canvas, undo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.4
+# LED Raster Designer v0.10.5
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.2
+# LED Raster Designer v0.10.3
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.3
+# LED Raster Designer v0.10.4
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,19 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.4 - July 16, 2026
+----------------------------
+- FEATURE: Center a screen on the canvas. Right-click a screen in Pixel Map
+  or Show Look and choose Center on Canvas X, Center on Canvas Y, or Center
+  on Canvas to snap it to the middle of its canvas's raster on that axis.
+  Works on a multi-selection (each screen centers on its own canvas), skips
+  locked screens, and centers rotated screens by their visible footprint.
+  In Pixel Map, a screen whose Show Look position still matches its Pixel
+  Map position keeps following, same as dragging. The items only appear in
+  Pixel Map and Show Look, the two views where screens can be positioned.
+- Right-clicking a screen that isn't selected now selects it first in those
+  two views, so the menu acts on the screen you pointed at.
+
 v0.10.3 - July 16, 2026
 ----------------------------
 - FIX: Screen gradients (and multi-color palette fills) now render on the

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,15 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.3 - July 16, 2026
+----------------------------
+- FIX: Screen gradients (and multi-color palette fills) now render on the
+  Data and Power views. Those views drew the plain two-color checkerboard
+  only, so an enabled gradient silently disappeared when switching from
+  Pixel Map to Data or Power. The gradient draws under the borders, flow
+  lines, and labels; the circuit color-coded Power view keeps its flat
+  circuit colors for readability.
+
 v0.10.2 - July 15, 2026
 ----------------------------
 - FEATURE: Size by Wall Dimensions. A new checkbox in Screen Info lets you

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -14,6 +14,19 @@ v0.10.5 - July 23, 2026
 - FIX: An edit made right before Undo/Redo (or right before a drag, delete,
   or duplicate) is now recorded first, so history stays in order and the
   edit can't be silently dropped or re-applied over the restored state.
+- FIX: Redo no longer loses a layer reorder, a "Reset to Pixel Map Position",
+  or a "Reset Entire Show Look". All three recorded their history entry just
+  before making the change instead of just after, so Undo followed by Redo
+  quietly dropped the change (the same mistake fixed for Add Layer in
+  v0.10.0).
+- FIX: Showing/hiding a layer and locking/unlocking a layer are now undoable
+  steps of their own. They previously left no history entry, so they rode
+  along on whatever you did next and a single Undo reverted both.
+- FIX: "Transparent (no fill)" now applies on the Data and Power views. Like
+  gradients, it was only honored on Pixel Map and Cabinet ID, so a
+  transparent screen still drew a full checkerboard on those two views.
+  Power's circuit color-coding is data rather than decoration, so it still
+  draws on a transparent screen.
 
 v0.10.4 - July 16, 2026
 ----------------------------

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,20 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.5 - July 23, 2026
+----------------------------
+- FIX: Undo now steps back one edit at a time. Screen Info changes (columns,
+  rows, cabinet size, checkboxes, dropdowns, colors - anything you type or
+  toggle) were folded together whenever you made them within half a second
+  of each other, so a single Cmd/Ctrl+Z could wipe out several edits at
+  once. Each committed change is now its own undo step.
+- Continuous edits still collapse sensibly: dragging the image scale slider
+  or typing into a text layer stays one undo step, but switching to a
+  different control now closes the previous step instead of merging both.
+- FIX: An edit made right before Undo/Redo (or right before a drag, delete,
+  or duplicate) is now recorded first, so history stays in order and the
+  edit can't be silently dropped or re-applied over the restored state.
+
 v0.10.4 - July 16, 2026
 ----------------------------
 - FEATURE: Center a screen on the canvas. Right-click a screen in Pixel Map

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.2',
-            'CFBundleVersion': '0.10.2',
+            'CFBundleShortVersionString': '0.10.3',
+            'CFBundleVersion': '0.10.3',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.3',
-            'CFBundleVersion': '0.10.3',
+            'CFBundleShortVersionString': '0.10.4',
+            'CFBundleVersion': '0.10.4',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.4',
-            'CFBundleVersion': '0.10.4',
+            'CFBundleShortVersionString': '0.10.5',
+            'CFBundleVersion': '0.10.5',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/static/js/app-canvas-ui.js
+++ b/src/static/js/app-canvas-ui.js
@@ -935,8 +935,11 @@ class _CanvasUi {
             action: historyAction,
             newOrder: newOrder.map(l => ({ id: l.id, name: l.name }))
         });
-        this.saveState(historyAction);
+        // v0.10.5: snapshot AFTER the reorder. Taken before, the entry held
+        // the pre-reorder order, so Undo-then-Redo silently lost the reorder
+        // (same bug class as the v0.10.0 "Add Layer" fix).
         this.project.layers = newOrder;
+        this.saveState(historyAction);
         this.updateUI();
         this.saveProject();
     }

--- a/src/static/js/app-core.js
+++ b/src/static/js/app-core.js
@@ -1674,7 +1674,8 @@ export class LEDRasterApp {
             showResetBtn.addEventListener('click', () => {
                 const layers = this.getSelectedLayers ? this.getSelectedLayers() : (this.currentLayer ? [this.currentLayer] : []);
                 if (layers.length === 0) return;
-                this.saveState('Reset Show Look Position');
+                // v0.10.5: snapshot AFTER the reset (see applyDisplayOrder);
+                // taken before, Undo-then-Redo lost the reset.
                 layers.forEach(l => {
                     l.showOffsetX = l.offset_x;
                     l.showOffsetY = l.offset_y;
@@ -1718,6 +1719,7 @@ export class LEDRasterApp {
                         this.updateCanvas(cid, patch);
                     });
                 }
+                this.saveState('Reset Show Look Position');
                 this.loadLayerToInputs();
                 if (window.canvasRenderer) window.canvasRenderer.render();
             });
@@ -1731,7 +1733,8 @@ export class LEDRasterApp {
         if (showResetAllBtn) {
             showResetAllBtn.addEventListener('click', () => {
                 if (!this.project) return;
-                this.saveState('Reset Entire Show Look');
+                // v0.10.5: snapshot AFTER the reset (see applyDisplayOrder);
+                // taken before, Undo-then-Redo lost the reset.
                 const allLayers = (this.project.layers || []).filter(
                     l => (l.type || 'screen') === 'screen'
                 );
@@ -1768,6 +1771,7 @@ export class LEDRasterApp {
                         this.updateCanvas(c.id, patch);
                     });
                 }
+                this.saveState('Reset Entire Show Look');
                 this.loadLayerToInputs();
                 if (window.canvasRenderer) window.canvasRenderer.render();
             });

--- a/src/static/js/app-export-io.js
+++ b/src/static/js/app-export-io.js
@@ -1767,6 +1767,15 @@ class _ExportIo {
             case 'delete':
                 if (this.currentLayer) this.deleteLayer(this.currentLayer.id);
                 break;
+            case 'center-x':
+                this.centerLayersOnCanvas('x');
+                break;
+            case 'center-y':
+                this.centerLayersOnCanvas('y');
+                break;
+            case 'center-both':
+                this.centerLayersOnCanvas('both');
+                break;
             case 'next-port':
                 this.stepCustomPort(1);
                 break;

--- a/src/static/js/app-history.js
+++ b/src/static/js/app-history.js
@@ -13,13 +13,18 @@ class _History {
     }
     
     saveState(action) {
+        // v0.10.5: a debounced snapshot still waiting to fire must land BEFORE
+        // this one, or history ends up out of order (and the pending timer
+        // would later snapshot a state that already includes this action).
+        this._flushPendingSaveState();
+
         // Save current project state
         const state = {
             action: action,
             project: JSON.parse(JSON.stringify(this.project)),
             timestamp: Date.now()
         };
-        
+
         
         // Remove any future states if we're not at the end
         if (this.historyIndex < this.history.length - 1) {
@@ -47,17 +52,51 @@ class _History {
 
     }
 
-    debouncedSaveState(action, delay = 500) {
+    /**
+     * Coalesce a continuous stream of edits (dragging a slider, typing in a
+     * text field) into ONE undo step.
+     *
+     * `key` identifies what is being edited. When it changes, the pending
+     * snapshot is flushed first so switching controls always starts a new undo
+     * step instead of folding both edits together. Discrete, committed edits
+     * should call saveState() directly rather than coming through here.
+     */
+    debouncedSaveState(action, delay = 500, key = null) {
+        const k = key || action;
+        if (this._saveStateTimer && this._pendingSaveKey !== k) {
+            this._flushPendingSaveState();
+        }
         this._pendingSaveAction = action;
+        this._pendingSaveKey = k;
         if (this._saveStateTimer) clearTimeout(this._saveStateTimer);
         this._saveStateTimer = setTimeout(() => {
-            this.saveState(this._pendingSaveAction || action);
             this._saveStateTimer = null;
+            const pending = this._pendingSaveAction || action;
             this._pendingSaveAction = null;
+            this._pendingSaveKey = null;
+            this.saveState(pending);
         }, delay);
     }
 
+    /**
+     * Commit a pending debounced snapshot immediately. Clearing the timer
+     * first keeps saveState()'s own flush call from recursing.
+     */
+    _flushPendingSaveState() {
+        if (!this._saveStateTimer) return;
+        clearTimeout(this._saveStateTimer);
+        this._saveStateTimer = null;
+        const pending = this._pendingSaveAction;
+        this._pendingSaveAction = null;
+        this._pendingSaveKey = null;
+        if (pending) this.saveState(pending);
+    }
+
     undo() {
+        // Land any in-flight debounced snapshot first, so Ctrl+Z steps back
+        // over the edit the user just made instead of skipping past it (and
+        // so the timer can't overwrite the restored state a moment later).
+        this._flushPendingSaveState();
 
         if (this.historyIndex > 0) {
             this.historyIndex--;
@@ -100,7 +139,8 @@ class _History {
     }
     
     redo() {
-        
+        this._flushPendingSaveState();
+
         if (this.historyIndex < this.history.length - 1) {
             this.historyIndex++;
             const state = this.history[this.historyIndex];

--- a/src/static/js/app-power.js
+++ b/src/static/js/app-power.js
@@ -31,6 +31,15 @@ class _Power {
         menu.querySelectorAll('.pixel-map-only').forEach(el => {
             el.style.display = showPixelMapItems ? '' : 'none';
         });
+        // Centering only applies where screens can actually be positioned:
+        // Pixel Map (processor offset) and Show Look (show offset). Data and
+        // Power mirror the Show Look position, so they're read-only there.
+        const canCenter = window.canvasRenderer
+            && ['pixel-map', 'show-look'].includes(window.canvasRenderer.viewMode)
+            && this.getSelectedLayers().some(l => !l.locked);
+        menu.querySelectorAll('.movable-view-only').forEach(el => {
+            el.style.display = canCenter ? '' : 'none';
+        });
         menu.style.visibility = 'hidden';
         menu.style.display = 'block';
         const menuRect = menu.getBoundingClientRect();
@@ -47,6 +56,76 @@ class _Power {
     hideContextMenu() {
         const menu = document.getElementById('context-menu');
         if (menu) menu.style.display = 'none';
+    }
+
+    /**
+     * v0.10.4: center the selected screens on their canvas's raster, on one
+     * axis or both. Pixel Map writes offset_x/offset_y against the canvas's
+     * pixel raster; Show Look writes showOffsetX/showOffsetY against the show
+     * raster. Data and Power mirror Show Look, so the menu hides there.
+     *
+     * Each screen centers on ITS OWN canvas, so a multi-select spanning two
+     * canvases does the right thing per screen. Rotated screens center by
+     * their visible footprint (getLayerBounds is the rotated box).
+     */
+    centerLayersOnCanvas(axis = 'both') {
+        const cr = window.canvasRenderer;
+        if (!cr || !['pixel-map', 'show-look'].includes(cr.viewMode)) return;
+        const layers = (this.getSelectedLayers() || []).filter(l => l && !l.locked);
+        if (layers.length === 0) return;
+
+        const useShow = cr.viewMode === 'show-look';
+        const canvases = (this.project && this.project.canvases) || [];
+        const moved = [];
+
+        layers.forEach(layer => {
+            const canvasId = useShow ? (layer.show_canvas_id || layer.canvas_id) : layer.canvas_id;
+            const canvas = canvases.find(c => c.id === canvasId);
+            if (!canvas) return;
+            const rasterW = (useShow && canvas.show_raster_width) || canvas.raster_width || 0;
+            const rasterH = (useShow && canvas.show_raster_height) || canvas.raster_height || 0;
+            if (rasterW <= 0 || rasterH <= 0) return;
+
+            // getLayerBounds is the UNROTATED box, so swap for a 90/270 screen
+            // to get the visible footprint. The stored offset is the unrotated
+            // top-left, so subtract the footprint delta to turn a desired
+            // footprint position back into an offset.
+            const b = cr.getLayerBounds(layer);
+            const deg = (((Number(layer.rotation) || 0) % 360) + 360) % 360;
+            const swap = deg === 90 || deg === 270;
+            const fpW = swap ? b.height : b.width;
+            const fpH = swap ? b.width : b.height;
+            const fp = cr.getLayerFootprintOffset(layer);
+            const centeredX = Math.round((rasterW - fpW) / 2 - fp.dx);
+            const centeredY = Math.round((rasterH - fpH) / 2 - fp.dy);
+
+            if (useShow) {
+                if (axis === 'x' || axis === 'both') layer.showOffsetX = centeredX;
+                if (axis === 'y' || axis === 'both') layer.showOffsetY = centeredY;
+            } else {
+                // Keep Show Look following the move while the two are linked
+                // (same rule the Screen Info offset fields use).
+                const linkedX = Number(layer.showOffsetX ?? layer.offset_x ?? 0) === Number(layer.offset_x ?? 0);
+                const linkedY = Number(layer.showOffsetY ?? layer.offset_y ?? 0) === Number(layer.offset_y ?? 0);
+                if (axis === 'x' || axis === 'both') {
+                    layer.offset_x = centeredX;
+                    if (linkedX) layer.showOffsetX = centeredX;
+                }
+                if (axis === 'y' || axis === 'both') {
+                    layer.offset_y = centeredY;
+                    if (linkedY) layer.showOffsetY = centeredY;
+                }
+            }
+            moved.push(layer);
+        });
+
+        if (moved.length === 0) return;
+        const label = axis === 'x' ? 'Center on Canvas X'
+            : axis === 'y' ? 'Center on Canvas Y' : 'Center on Canvas';
+        this.saveState(label);
+        this.updateLayers(moved);
+        this.loadLayerToInputs();
+        cr.render();
     }
 
     stepCustomPort(delta) {

--- a/src/static/js/app-presets.js
+++ b/src/static/js/app-presets.js
@@ -1110,7 +1110,9 @@ class _Presets {
                         layer.textContent = val;
                     }
                 });
-                this.debouncedSaveState('Update Text Label');
+                // Typing is a genuine continuous stream, so a burst of
+                // keystrokes stays one undo step.
+                this.debouncedSaveState('Update Text Label', 500, 'text:content');
                 this.saveClientSideProperties();
                 this.updateLayers(this.getSelectedLayers());
                 window.canvasRenderer.render();
@@ -1187,7 +1189,7 @@ class _Presets {
                     if ((layer.type || 'screen') !== 'text') return;
                     layer[f.prop] = val;
                 });
-                this.debouncedSaveState('Update Text Label');
+                this.debouncedSaveState('Update Text Label', 500, `text:${f.prop}`);
                 this.saveClientSideProperties();
                 this.updateLayers(this.getSelectedLayers());
                 window.canvasRenderer.render();
@@ -1204,7 +1206,7 @@ class _Presets {
                     if ((layer.type || 'screen') !== 'text') return;
                     layer[prop] = val;
                 });
-                this.debouncedSaveState('Update Text Color');
+                this.debouncedSaveState('Update Text Color', 500, `text:${prop}`);
                 this.saveClientSideProperties();
                 window.canvasRenderer.render();
             };
@@ -1226,7 +1228,7 @@ class _Presets {
                     layer[prop] = newVal;
                 });
                 btn.classList.toggle('active', newVal);
-                this.debouncedSaveState('Update Text Style');
+                this.debouncedSaveState('Update Text Style', 500, `text:${prop}`);
                 this.saveClientSideProperties();
                 this.updateLayers(this.getSelectedLayers());
                 window.canvasRenderer.render();

--- a/src/static/js/app-screen-info.js
+++ b/src/static/js/app-screen-info.js
@@ -537,6 +537,9 @@ class _ScreenInfo {
         if (typeof this.updateUI === 'function') {
             try { this.updateUI(); } catch (_) {}
         }
+        // v0.10.5: record the show/hide. Without an entry of its own it rode
+        // along on whatever the user did next, so one Undo reverted both.
+        this.saveState(layer.visible ? 'Show Layer' : 'Hide Layer');
     }
 
     setLockOnSelected(locked) {
@@ -554,6 +557,7 @@ class _ScreenInfo {
             sendClientLog('layer_lock_batch', { locked, layerIds: layers.map(l => l.id) });
         }
         this.renderLayers();
+        this.saveState(locked ? 'Lock Layers' : 'Unlock Layers');
     }
 
     toggleLockOnSelected() {
@@ -576,6 +580,7 @@ class _ScreenInfo {
             sendClientLog('layer_lock_toggle', { layerId: layer.id, locked: layer.locked });
         }
         this.renderLayers();
+        this.saveState(layer.locked ? 'Lock Layer' : 'Unlock Layer');
     }
     
     togglePanelBlank(layerId, panelId) {

--- a/src/static/js/app-screen-info.js
+++ b/src/static/js/app-screen-info.js
@@ -1184,7 +1184,14 @@ class _ScreenInfo {
         }
         
         this.updateLayers(targetLayers);
-        this.debouncedSaveState('Update Properties');
+        // v0.10.5: every caller of this method is a 'change' handler, i.e. an
+        // edit the user has already committed (typed and tabbed out, toggled a
+        // checkbox, picked from a dropdown). Those each deserve their own undo
+        // step. The old debounce folded a run of commits made within 500ms of
+        // each other into a single snapshot, so one Ctrl+Z reverted several
+        // edits at once. Continuous streams (slider drags, typing into the
+        // text-layer content box) still go through debouncedSaveState.
+        this.saveState('Update Properties');
     }
 
     // v0.10.2: Size by Wall Dimensions - how many tiles for the target wall

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3485,11 +3485,14 @@ class CanvasRenderer {
             return;
         }
         
-        // Use normal checkerboard colors (removed blank mode)
-        const color = panel.is_color1 ? layer.color1 : layer.color2;
-        this.ctx.fillStyle = `rgb(${color.r}, ${color.g}, ${color.b})`;
+        // Base cabinet fill: checkerboard / palette, same as Pixel Map, with
+        // the gradient overlay on top (below borders and flow arrows). These
+        // used to hard-code the plain checkerboard, so gradients and palette
+        // modes silently vanished on the Data view.
+        this.ctx.fillStyle = this._panelBaseFill(panel, layer);
         this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-        
+        this._applyGradientOverlay(panel, layer);
+
         // Panel borders, per-layer width, drawn INSIDE the panel.
         if (layer.show_panel_borders) {
             const bw = Math.max(1, Number(layer.panel_border_width) || 2);
@@ -4281,12 +4284,19 @@ class CanvasRenderer {
         }
 
         if (fillHex) {
+            // Circuit color-coded view: keep the flat circuit color readable
+            // (no gradient on top).
             this.ctx.fillStyle = fillHex;
+            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
         } else {
-            const color = panel.is_color1 ? layer.color1 : layer.color2;
-            this.ctx.fillStyle = `rgb(${color.r}, ${color.g}, ${color.b})`;
+            // Base cabinet fill: checkerboard / palette, same as Pixel Map,
+            // with the gradient overlay on top (below borders and circuit
+            // lines). These used to hard-code the plain checkerboard, so
+            // gradients and palette modes silently vanished on the Power view.
+            this.ctx.fillStyle = this._panelBaseFill(panel, layer);
+            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+            this._applyGradientOverlay(panel, layer);
         }
-        this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
 
         if (layer.show_panel_borders) {
             const bw = Math.max(1, Number(layer.panel_border_width) || 2);

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1836,6 +1836,18 @@ class CanvasRenderer {
         // In Pixel Map view: if right-click lands on a panel of currentLayer
         // and the panel is not already in the selection, treat it as a
         // single-panel selection so the menu actions target it.
+        // In the views where screens can be moved, right-clicking a screen that
+        // isn't part of the current selection targets that screen, so "Center
+        // on Canvas" acts on what the user actually pointed at.
+        if (['pixel-map', 'show-look'].includes(this.viewMode)) {
+            const rect = this.canvas.getBoundingClientRect();
+            const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
+            const worldX = this._unmirrorWorldX(((e.clientX - rect.left) - this.panX) / this.zoom, worldY);
+            const hit = this.getLayerAt(worldX, worldY);
+            if (hit && !(window.app.selectedLayerIds || []).includes(hit.id)) {
+                window.app.selectLayer(hit);
+            }
+        }
         if (this.viewMode === 'pixel-map' && window.app.currentLayer) {
             const rect = this.canvas.getBoundingClientRect();
             const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -3499,11 +3499,13 @@ class CanvasRenderer {
         
         // Base cabinet fill: checkerboard / palette, same as Pixel Map, with
         // the gradient overlay on top (below borders and flow arrows). These
-        // used to hard-code the plain checkerboard, so gradients and palette
-        // modes silently vanished on the Data view.
-        this.ctx.fillStyle = this._panelBaseFill(panel, layer);
-        this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-        this._applyGradientOverlay(panel, layer);
+        // used to hard-code the plain checkerboard, so gradients, palette
+        // modes, and Transparent (no fill) were all ignored on the Data view.
+        if (!layer.transparentFill) {
+            this.ctx.fillStyle = this._panelBaseFill(panel, layer);
+            this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
+            this._applyGradientOverlay(panel, layer);
+        }
 
         // Panel borders, per-layer width, drawn INSIDE the panel.
         if (layer.show_panel_borders) {
@@ -4300,11 +4302,13 @@ class CanvasRenderer {
             // (no gradient on top).
             this.ctx.fillStyle = fillHex;
             this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
-        } else {
+        } else if (!layer.transparentFill) {
             // Base cabinet fill: checkerboard / palette, same as Pixel Map,
             // with the gradient overlay on top (below borders and circuit
             // lines). These used to hard-code the plain checkerboard, so
-            // gradients and palette modes silently vanished on the Power view.
+            // gradients, palette modes, and Transparent (no fill) were all
+            // ignored on the Power view. Circuit color-coding above is data,
+            // not decoration, so it still paints on a transparent screen.
             this.ctx.fillStyle = this._panelBaseFill(panel, layer);
             this.ctx.fillRect(panel.x, panel.y, panel.width, panel.height);
             this._applyGradientOverlay(panel, layer);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.2</title>
+    <title>LED Raster Designer v0.10.3</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -92,7 +92,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.2</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.3</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.3</title>
+    <title>LED Raster Designer v0.10.4</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -85,6 +85,10 @@
             <div class="menu-option" data-action="paste" data-label="Paste" data-shortcut-mac="Cmd+V" data-shortcut-win="Ctrl+V"></div>
             <div class="menu-option" data-action="duplicate" data-label="Duplicate" data-shortcut-mac="Cmd+J" data-shortcut-win="Ctrl+J"></div>
             <div class="menu-option" data-action="delete" data-label="Delete Layer" data-shortcut-mac="Del" data-shortcut-win="Del"></div>
+            <div class="menu-divider movable-view-only"></div>
+            <div class="menu-option movable-view-only" data-action="center-x" data-label="Center on Canvas X"></div>
+            <div class="menu-option movable-view-only" data-action="center-y" data-label="Center on Canvas Y"></div>
+            <div class="menu-option movable-view-only" data-action="center-both" data-label="Center on Canvas"></div>
             <div class="menu-divider"></div>
             <div class="menu-option" data-action="prev-port" data-label="Previous Port" data-shortcut-mac="Shift+Tab" data-shortcut-win="Shift+Tab"></div>
             <div class="menu-option" data-action="next-port" data-label="Next Port" data-shortcut-mac="Tab" data-shortcut-win="Tab"></div>
@@ -92,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.3</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.4</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.4</title>
+    <title>LED Raster Designer v0.10.5</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.4</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.5</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
Bundles v0.10.3 through v0.10.5.

## Features
- **Center on Canvas X / Y** — right-click a screen in Pixel Map or Show Look to center it on its canvas on either axis (or both). Multi-select safe, skips locked screens, rotation-aware.

## Fixes
- **Gradients and palette fills now render on the Data and Power views.** Those renderers hard-coded the two-color checkerboard, so an enabled gradient vanished when switching away from Pixel Map. "Transparent (no fill)" had the same problem and is fixed too.
- **Undo steps back one edit at a time.** Screen Info edits were folded together by a 500ms debounce, so one Cmd/Ctrl+Z could wipe out several edits. Continuous streams (slider drags, typing) still collapse to one step.
- **Redo no longer loses a layer reorder or a Show Look reset** — all three snapshotted before mutating instead of after.
- **Show/hide and lock/unlock a layer are now their own undo steps** — they previously left no history entry and rode along on the next action.
- Pending edits are committed before undo/redo and before drags/deletes/duplicates, so history stays in order.