### PR TITLE
v0.10.5.1: Show Look raster follows Pixel Map until changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.6
+# LED Raster Designer v0.10.5.1
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.5
+# LED Raster Designer v0.10.6
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,21 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.6 - July 23, 2026
+----------------------------
+- FIX: The Show Look raster follows the Pixel Map raster again until you
+  give Show Look a size of its own. Setting the Pixel Map raster to (say)
+  8K and then switching to Show Look left it on the old size, with no
+  indication why. v0.8.10.0 fixed the starting value for a NEW project
+  (it now matches your Preferences raster), but changing the raster
+  afterwards still didn't carry over, because v0.8.5.2 had removed the
+  link in the name of independent layouts.
+  The two are linked per axis while they match, exactly like a screen's
+  Show Look position follows its Pixel Map position until you move it.
+  The moment you type a different width or height into the Show Look
+  toolbar, that axis stops following and stays independent. Editing the
+  Show Look raster never changes the Pixel Map raster.
+
 v0.10.5 - July 23, 2026
 ----------------------------
 - FIX: Undo now steps back one edit at a time. Screen Info changes (columns,

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,7 +1,7 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
-v0.10.6 - July 23, 2026
+v0.10.5.1 - July 23, 2026
 ----------------------------
 - FIX: The Show Look raster follows the Pixel Map raster again until you
   give Show Look a size of its own. Setting the Pixel Map raster to (say)

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.5',
-            'CFBundleVersion': '0.10.5',
+            'CFBundleShortVersionString': '0.10.6',
+            'CFBundleVersion': '0.10.6',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.6',
-            'CFBundleVersion': '0.10.6',
+            'CFBundleShortVersionString': '0.10.5.1',
+            'CFBundleVersion': '0.10.5.1',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/static/js/app-canvas-ui.js
+++ b/src/static/js/app-canvas-ui.js
@@ -950,10 +950,17 @@ class _CanvasUi {
      * project-root mirror. `axis` is 'width' or 'height'; `value` is the new
      * dimension; `isShow` selects show_raster_* vs raster_*.
      *
-     * v0.8.5.2: Pixel Map and Show Look rasters are fully independent.
-     * Editing one never auto-syncs the other (previously a "linked" edit
-     * on Pixel Map also wrote show_raster_*; that contradicted the design
-     * goal of independent layouts).
+     * v0.8.5.2 made the two rasters fully independent, so a Pixel Map edit
+     * never touched Show Look. That left a screen sized before Show Look was
+     * ever opened stuck at the old raster: set 4K, change to 8K, switch to
+     * Show Look, still 4K, with no hint why.
+     *
+     * v0.10.6 restores the v0.7.6.1 link using the same rule the per-layer
+     * show offsets already use: Show Look FOLLOWS Pixel Map while the two
+     * still match, and stops the moment the user sets a different Show Look
+     * raster. Independence is preserved once it actually means something;
+     * until then the two track. The link is one-way, editing the Show Look
+     * raster never rewrites the Pixel Map raster.
      */
     _writeToolbarRasterToActiveCanvas(axis, value, isShow) {
         if (!this.project || !Array.isArray(this.project.canvases)) return;
@@ -965,8 +972,14 @@ class _CanvasUi {
             if (axis === 'width')  patch.show_raster_width  = value;
             if (axis === 'height') patch.show_raster_height = value;
         } else {
-            if (axis === 'width')  patch.raster_width  = value;
-            if (axis === 'height') patch.raster_height = value;
+            const key = axis === 'width' ? 'raster_width' : 'raster_height';
+            const showKey = axis === 'width' ? 'show_raster_width' : 'show_raster_height';
+            const pixelBefore = Number(c[key]) || 0;
+            const showBefore = Number(c[showKey]) || 0;
+            // Linked while equal, or while Show Look has no size of its own yet.
+            const linked = showBefore === 0 || showBefore === pixelBefore;
+            patch[key] = value;
+            if (linked) patch[showKey] = value;
         }
         // Optimistic local update so the renderer (which reads from the
         // canvas object via getters) repaints immediately, before the PUT

--- a/src/static/js/app-canvas-ui.js
+++ b/src/static/js/app-canvas-ui.js
@@ -955,7 +955,7 @@ class _CanvasUi {
      * ever opened stuck at the old raster: set 4K, change to 8K, switch to
      * Show Look, still 4K, with no hint why.
      *
-     * v0.10.6 restores the v0.7.6.1 link using the same rule the per-layer
+     * v0.10.5.1 restores the v0.7.6.1 link using the same rule the per-layer
      * show offsets already use: Show Look FOLLOWS Pixel Map while the two
      * still match, and stops the moment the user sets a different Show Look
      * raster. Independence is preserved once it actually means something;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.5</title>
+    <title>LED Raster Designer v0.10.6</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.5</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.6</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.6</title>
+    <title>LED Raster Designer v0.10.5.1</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.6</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.5.1</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## v0.10.5.1

- **FIX: The Show Look raster follows the Pixel Map raster again until you give Show Look a size of its own.** Setting the Pixel Map raster to 8K and then switching to Show Look left it on the old size. v0.8.10.0 fixed the starting value for a new project (matching the Preferences raster), but changing the raster afterwards still didn't carry over, because v0.8.5.2 had removed the link.

The two are linked per axis while they match, the same way a screen's Show Look position follows its Pixel Map position until you move it. Typing a different width or height on the Show Look toolbar stops that axis following. Editing the Show Look raster never changes the Pixel Map raster.