### PR TITLE
v0.10.6: survive launcher-window failure and log startup crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.5.1
+# LED Raster Designer v0.10.6
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,27 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.6 - July 24, 2026
+----------------------------
+- FIX: If the launcher window can't start, the app no longer becomes
+  unusable. Previously the failure killed the app mid-startup and left a
+  tray icon behind that wouldn't open a window, wouldn't show a menu, and
+  couldn't even be quit without Task Manager. The app now tells you what
+  happened, opens itself in your browser, and keeps the tray icon working
+  so you can still quit normally.
+- FIX: Startup failures are recorded. The Windows build has no console
+  window, so a crash during startup previously left no trace anywhere -
+  the app just died silently. Any uncaught error (including one in a
+  background thread) is now written to the app log with its full details,
+  reachable from Help -> Show Logs. If the crash happens before the log
+  is ready, it's written to launcher_crash.log next to the program.
+- Startup now records the machine it's running on (app version, OS,
+  and on Windows the .NET Framework version plus the launcher component
+  versions), so "it won't open on my PC" can be answered from the log.
+- Windows: the launcher window needs .NET Framework 4.7.2 or newer. If
+  yours is older or missing, the app now says so directly instead of
+  failing without explanation.
+
 v0.10.5.1 - July 23, 2026
 ----------------------------
 - FIX: The Show Look raster follows the Pixel Map raster again until you

--- a/src/launcher_window.py
+++ b/src/launcher_window.py
@@ -35,6 +35,160 @@ HTML_FILE = os.path.join(BASE_DIR, 'launcher_window.html')
 _socketio = None
 _server_running = False
 
+# .NET Framework 4.7.2. pythonnet's Python.Runtime.dll targets .NET Standard
+# 2.0, and 4.7.2 is the first Framework release that can bind the netstandard
+# facades in-box. On anything older the CLR opens the DLL but fails to resolve
+# its entry point, so the launcher window can't start.
+DOTNET_FRAMEWORK_MIN_RELEASE = 461808
+
+
+def _launcher_log(action, details, source='launcher'):
+    """Best-effort write into the app's JSON log (Help -> Show Logs).
+
+    Falls back to a plain file next to the executable when app.py can't be
+    imported: a crash that early would otherwise leave nothing on disk at all,
+    which is precisely the case this exists for.
+    """
+    try:
+        import app as app_module
+        app_module.log_event(action, details, source=source)
+        return
+    except Exception:
+        pass
+    try:
+        import json as _json
+        import datetime as _dt
+        line = _json.dumps({
+            'timestamp': _dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            'source': source,
+            'action': action,
+            'details': details or {},
+        }, ensure_ascii=False)
+        with open(os.path.join(APP_DIR, 'launcher_crash.log'), 'a',
+                  encoding='utf-8') as f:
+            f.write(line + '\n')
+    except Exception:
+        pass
+
+
+def _format_exc(exc):
+    import traceback
+    return ''.join(
+        traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+
+def _install_crash_logger():
+    """Record any uncaught exception, on the main thread or a worker.
+
+    The Windows build is windowed (console=False), so without this a startup
+    crash writes its traceback to a stderr nobody can read: the app simply
+    dies, or leaves a tray icon behind with no explanation anywhere on disk.
+    """
+    def _log(exc_type, exc, tb, thread=None):
+        try:
+            import traceback as _tb
+            name = getattr(exc_type, '__name__', str(exc_type))
+            _launcher_log('launcher_crash', {
+                'error': f'{name}: {exc}',
+                'thread': thread or 'main',
+                'traceback': ''.join(_tb.format_exception(exc_type, exc, tb)),
+            })
+        except Exception:
+            pass
+
+    def _hook(exc_type, exc, tb):
+        _log(exc_type, exc, tb)
+        try:
+            sys.__excepthook__(exc_type, exc, tb)
+        except Exception:
+            pass
+
+    sys.excepthook = _hook
+
+    # Python 3.8+: an exception that kills a thread never reaches
+    # sys.excepthook, so the Flask server thread dying would be silent too.
+    try:
+        def _thread_hook(args):
+            _log(args.exc_type, args.exc_value, args.exc_traceback,
+                 thread=getattr(args.thread, 'name', None))
+        threading.excepthook = _thread_hook
+    except Exception:
+        pass
+
+
+def _windows_dotnet_release():
+    """The installed .NET Framework 4.x release number, or None."""
+    try:
+        import winreg
+        path = r'SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full'
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, path) as key:
+            return int(winreg.QueryValueEx(key, 'Release')[0])
+    except Exception:
+        return None
+
+
+def _log_startup_environment():
+    """One line in the log describing the machine we're running on.
+
+    Turns "it won't open on my PC" into something answerable from the log
+    alone, without a remote debugging session.
+    """
+    info = {
+        'version': _read_version(),
+        'platform': sys.platform,
+        'frozen': bool(getattr(sys, 'frozen', False)),
+        'python': sys.version.split()[0],
+    }
+    try:
+        import platform as _pl
+        info['os'] = _pl.platform()
+        info['machine'] = _pl.machine()
+    except Exception:
+        pass
+    if sys.platform == 'win32':
+        release = _windows_dotnet_release()
+        info['dotnet_framework_release'] = release
+        info['dotnet_framework_ok'] = bool(
+            release is not None and release >= DOTNET_FRAMEWORK_MIN_RELEASE)
+        try:
+            import importlib.metadata as _md
+            for dist in ('pywebview', 'pythonnet', 'clr-loader', 'pystray'):
+                try:
+                    info[f'{dist}_version'] = _md.version(dist)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+    _launcher_log('launcher_environment', info)
+
+
+def _launcher_failure_hint():
+    """Plain-language guess at why the native window refused to start."""
+    if sys.platform != 'win32':
+        return 'See the app log for details.'
+    release = _windows_dotnet_release()
+    if release is None:
+        return ('Microsoft .NET Framework 4.8 does not appear to be '
+                'installed. Installing it should restore the window.')
+    if release < DOTNET_FRAMEWORK_MIN_RELEASE:
+        return ('Microsoft .NET Framework looks older than 4.7.2 '
+                f'(release {release}). Updating to 4.8 should restore the '
+                'window.')
+    return ('The file may be blocked by Windows or antivirus. Right-click '
+            'the downloaded .zip, tick Unblock, then extract it again.')
+
+
+def _show_windows_error(title, message):
+    try:
+        import ctypes
+        MB_OK = 0x0
+        MB_ICONWARNING = 0x30
+        MB_SETFOREGROUND = 0x10000
+        ctypes.windll.user32.MessageBoxW(
+            None, message, title, MB_OK | MB_ICONWARNING | MB_SETFOREGROUND)
+    except Exception:
+        pass
+
 
 def _read_version():
     # encoding matters: VERSION.txt is UTF-8, but Windows' default open()
@@ -108,6 +262,10 @@ class LauncherAPI:
     def __init__(self, settings):
         self.settings = settings
         self._window = None
+        # Set when the native window failed to start; show() then falls back
+        # to the browser so the tray's "Show Launcher" still does something
+        # useful instead of raising into a dead window handle.
+        self._window_unavailable = False
 
     # ── state ──────────────────────────────────────────────────────────────
     def get_state(self):
@@ -201,7 +359,15 @@ class LauncherAPI:
         # Kept for compatibility; the launcher hides rather than minimizes.
         self.hide()
 
+    def mark_window_unavailable(self):
+        """The native launcher window could not be created."""
+        self._window = None
+        self._window_unavailable = True
+
     def show(self):
+        if self._window_unavailable:
+            self.open_browser()
+            return
         if self._window:
             self._window.show()
             if sys.platform == 'darwin':
@@ -403,18 +569,75 @@ def run_window(settings):
 
     window.events.closing += on_closing
 
-    if sys.platform == 'win32':
-        _start_tray_windows(api)
-        webview.start()
-    elif sys.platform == 'darwin':
-        # The status item must be created after the Cocoa app starts; start()
-        # runs the callback once the window/run loop are up.
-        webview.start(func=_start_statusitem_mac, args=(api,))
-    else:
-        webview.start()
+    # A failure in any of this used to escape main() entirely. With no console
+    # on the frozen Windows build the traceback went nowhere, and because
+    # pystray's detached icon runs on a non-daemon thread the process then sat
+    # wedged in interpreter shutdown: a tray icon the user could neither open
+    # nor quit. Every path below now degrades instead of dying.
+    try:
+        if sys.platform == 'win32':
+            try:
+                _start_tray_windows(api)
+            except Exception as exc:
+                _launcher_log('launcher_tray_failed', {
+                    'error': f'{type(exc).__name__}: {exc}',
+                    'traceback': _format_exc(exc),
+                })
+            webview.start()
+        elif sys.platform == 'darwin':
+            # The status item must be created after the Cocoa app starts;
+            # start() runs the callback once the window/run loop are up.
+            webview.start(func=_start_statusitem_mac, args=(api,))
+        else:
+            webview.start()
+    except Exception as exc:
+        _launcher_window_fallback(settings, api, exc)
+        return
     # webview.start() only returns when the window is destroyed (Quit path).
     # Exit so the background Flask thread doesn't keep a headless server alive.
     os._exit(0)
+
+
+def _launcher_window_fallback(settings, api, exc):
+    """Keep the app usable when the native launcher window can't start.
+
+    The window is only a control panel; the Flask server behind it is the
+    actual app and is already running by this point. So log what happened,
+    tell the user, hand them the browser, and hold the process open so the
+    tray icon (including its Quit) keeps working.
+    """
+    hint = _launcher_failure_hint()
+    _launcher_log('launcher_window_failed', {
+        'error': f'{type(exc).__name__}: {exc}',
+        'traceback': _format_exc(exc),
+        'hint': hint,
+    })
+    api.mark_window_unavailable()
+
+    url = get_display_url(settings)
+    try:
+        open_url(url, settings)
+    except Exception:
+        pass
+
+    if sys.platform == 'win32':
+        _show_windows_error(
+            'LED Raster Designer',
+            "The launcher window couldn't start, so the app opened in your "
+            'browser instead.\n\n'
+            f'Address: {url}\n\n'
+            f'{hint}\n\n'
+            'Full details were saved to the app log (Help → Show Logs).')
+
+    # Hold the main thread. The tray icon's menu runs on its own thread and
+    # needs a live interpreter to call back into; letting main() return here
+    # would drop us into the same wedged shutdown this fix exists to prevent.
+    # Quit from the tray calls os._exit().
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        os._exit(0)
 
 
 def _setup_launcher_debug_log():
@@ -452,6 +675,8 @@ def _setup_launcher_debug_log():
 
 
 def main():
+    # First thing: from here on, nothing can fail silently.
+    _install_crash_logger()
     settings = load_settings()
     _setup_launcher_debug_log()
 
@@ -473,6 +698,9 @@ def main():
     server_thread = threading.Thread(target=start_flask_server, args=(settings,), daemon=True)
     server_thread.start()
     time.sleep(1.0)
+    # Logged after the server thread so app.py (which owns the log file) is
+    # already imported, and before the window so it lands even if that fails.
+    _log_startup_environment()
 
     if settings.get('open_browser_on_launch', False):
         open_url(get_display_url(settings), settings)

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.5.1',
-            'CFBundleVersion': '0.10.5.1',
+            'CFBundleShortVersionString': '0.10.6',
+            'CFBundleVersion': '0.10.6',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.5.1</title>
+    <title>LED Raster Designer v0.10.6</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.5.1</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.6</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>

--- a/tests/test_launcher_diagnostics.py
+++ b/tests/test_launcher_diagnostics.py
@@ -1,0 +1,180 @@
+"""Launcher crash logging and window-fallback behaviour.
+
+The frozen Windows build is windowed (console=False), so a startup failure has
+nowhere to print. These cover the machinery that makes such a failure visible
+and survivable instead of leaving an unquittable tray icon.
+"""
+import json
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+SRC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src')
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+launcher_window = pytest.importorskip('launcher_window')
+
+
+@pytest.fixture
+def caplog_events(monkeypatch):
+    """Capture whatever the launcher writes to the app log."""
+    events = []
+    monkeypatch.setattr(
+        launcher_window, '_launcher_log',
+        lambda action, details, source='launcher': events.append(
+            {'action': action, 'details': details}))
+    return events
+
+
+# ── crash logging ────────────────────────────────────────────────────────────
+
+def test_excepthook_logs_uncaught_exception(caplog_events):
+    launcher_window._install_crash_logger()
+    try:
+        raise ValueError('kaboom')
+    except ValueError:
+        sys.excepthook(*sys.exc_info())
+
+    crashes = [e for e in caplog_events if e['action'] == 'launcher_crash']
+    assert crashes, 'uncaught exception was not logged'
+    details = crashes[0]['details']
+    assert 'kaboom' in details['error']
+    assert 'Traceback' in details['traceback']
+
+
+def test_thread_excepthook_logs_and_names_thread(caplog_events):
+    launcher_window._install_crash_logger()
+
+    def boom():
+        raise RuntimeError('thread-kaboom')
+
+    t = threading.Thread(target=boom, name='probe')
+    t.start()
+    t.join()
+    time.sleep(0.2)
+
+    crashes = [e for e in caplog_events if e['action'] == 'launcher_crash']
+    assert crashes, 'a thread death must not be silent'
+    assert 'thread-kaboom' in crashes[0]['details']['error']
+    assert crashes[0]['details']['thread'] == 'probe'
+
+
+def test_format_exc_includes_traceback_for_raised_exception():
+    def boom():
+        raise RuntimeError('nope')
+    try:
+        boom()
+    except RuntimeError as exc:
+        text = launcher_window._format_exc(exc)
+    assert 'Traceback' in text and 'nope' in text
+
+
+# ── startup environment ──────────────────────────────────────────────────────
+
+def test_startup_environment_logged(caplog_events):
+    launcher_window._log_startup_environment()
+    env = [e for e in caplog_events if e['action'] == 'launcher_environment']
+    assert env, 'environment block missing'
+    details = env[0]['details']
+    for key in ('version', 'platform', 'frozen', 'python'):
+        assert key in details
+
+
+def test_startup_environment_reports_dotnet_on_windows(monkeypatch, caplog_events):
+    monkeypatch.setattr(launcher_window.sys, 'platform', 'win32')
+    monkeypatch.setattr(launcher_window, '_windows_dotnet_release', lambda: 394802)
+    launcher_window._log_startup_environment()
+    details = [e for e in caplog_events
+               if e['action'] == 'launcher_environment'][0]['details']
+    assert details['dotnet_framework_release'] == 394802
+    # 4.6.2 is below the 4.7.2 needed to load pythonnet's netstandard2.0 DLL
+    assert details['dotnet_framework_ok'] is False
+
+
+@pytest.mark.parametrize('release,expected', [
+    (None, 'does not appear to be installed'),
+    (394802, 'older than 4.7.2'),          # 4.6.2
+    (461808, 'blocked'),                   # 4.7.2 — .NET is fine, suspect MOTW/AV
+    (528040, 'blocked'),                   # 4.8
+])
+def test_failure_hint_matches_dotnet_state(monkeypatch, release, expected):
+    monkeypatch.setattr(launcher_window.sys, 'platform', 'win32')
+    monkeypatch.setattr(launcher_window, '_windows_dotnet_release', lambda: release)
+    assert expected in launcher_window._launcher_failure_hint()
+
+
+# ── window fallback ──────────────────────────────────────────────────────────
+
+def test_window_fallback_logs_opens_browser_and_degrades_api(monkeypatch, caplog_events):
+    opened = []
+    monkeypatch.setattr(launcher_window, 'open_url',
+                        lambda url, settings: opened.append(url))
+    monkeypatch.setattr(launcher_window, '_show_windows_error', lambda *a, **k: None)
+    # Don't block the test in the keep-alive loop.
+    monkeypatch.setattr(launcher_window.time, 'sleep',
+                        lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    monkeypatch.setattr(launcher_window.os, '_exit', lambda code: None)
+
+    settings = {'interface': '127.0.0.1', 'port': 8050}
+    api = launcher_window.LauncherAPI(settings)
+    try:
+        boom = RuntimeError('simulated webview failure')
+        raise boom
+    except RuntimeError as exc:
+        launcher_window._launcher_window_fallback(settings, api, exc)
+
+    failed = [e for e in caplog_events if e['action'] == 'launcher_window_failed']
+    assert failed, 'window failure was not logged'
+    details = failed[0]['details']
+    assert 'simulated webview failure' in details['error']
+    assert 'Traceback' in details['traceback']
+    assert details['hint']
+
+    assert opened == ['http://127.0.0.1:8050/'], 'browser fallback did not open'
+    assert api._window_unavailable is True
+
+
+def test_show_falls_back_to_browser_when_window_unavailable(monkeypatch):
+    opened = []
+    monkeypatch.setattr(launcher_window, 'open_url',
+                        lambda url, settings: opened.append(url))
+    api = launcher_window.LauncherAPI({'interface': '127.0.0.1', 'port': 8050})
+    api.mark_window_unavailable()
+    api.show()
+    assert opened == ['http://127.0.0.1:8050/']
+
+
+def test_quit_exits_even_without_a_window(monkeypatch):
+    exits = []
+    monkeypatch.setattr(launcher_window.os, '_exit', lambda code: exits.append(code))
+    api = launcher_window.LauncherAPI({'interface': '127.0.0.1', 'port': 8050})
+    api.mark_window_unavailable()
+    api.quit()
+    assert exits == [0], 'tray Quit must still exit with no window'
+
+
+def test_launcher_log_falls_back_to_file_when_app_unimportable(monkeypatch, tmp_path):
+    """A crash before app.py imports must still land on disk."""
+    monkeypatch.setattr(launcher_window, 'APP_DIR', str(tmp_path))
+    real_import = __builtins__['__import__'] if isinstance(__builtins__, dict) \
+        else __builtins__.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name == 'app':
+            raise ImportError('simulated: app not importable yet')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setitem(sys.modules, 'app', None)
+    monkeypatch.setattr('builtins.__import__', blocked)
+    launcher_window._launcher_log('launcher_crash', {'error': 'early boom'})
+    monkeypatch.setattr('builtins.__import__', real_import)
+
+    fallback = tmp_path / 'launcher_crash.log'
+    assert fallback.exists(), 'no on-disk record of an early crash'
+    entry = json.loads(fallback.read_text().strip().splitlines()[-1])
+    assert entry['action'] == 'launcher_crash'
+    assert entry['details']['error'] == 'early boom'


### PR DESCRIPTION
## v0.10.6

A pythonnet failure inside `webview.start()` escaped `main()` entirely. With `console=False` on the frozen Windows build the traceback went nowhere, and pystray's detached icon runs on a **non-daemon** thread — so the process sat wedged in interpreter shutdown: a tray icon that opened nothing, showed no menu, and could only be killed from Task Manager.

### Fixes
- **Launcher-window failure is now survivable.** Guarded on all platforms: log it, mark the API window-unavailable, open the browser, show a Windows message box, and hold the main thread so the tray (and its Quit) keep working.
- **Startup crashes are recorded.** `sys.excepthook` + `threading.excepthook` write any uncaught exception with traceback to the app log; falls back to `launcher_crash.log` beside the executable when `app.py` isn't importable yet.
- **Startup logs the environment** — version, OS, frozen flag, Python, and on Windows the .NET Framework release plus pywebview/pythonnet/clr-loader/pystray versions.
- **The Windows message names the real cause.** `Python.Runtime.dll` targets .NET Standard 2.0, which needs .NET Framework 4.7.2+; below that the CLR can't bind the netstandard facades and entry-point resolution fails.
- `LauncherAPI.show()` degrades to the browser instead of raising into a dead window handle.

13 regression tests cover the crash hooks, environment block, all four hint branches, and the fallback path. Verified with an untagged test build on dev/draft.