### PR TITLE
fix(export): populate canvas picker from File menu

### DIFF
--- a/src/static/js/app-core.js
+++ b/src/static/js/app-core.js
@@ -3237,20 +3237,7 @@ export class LEDRasterApp {
         });
 
         document.getElementById('btn-export').addEventListener('click', () => {
-            // Show export modal
-            document.getElementById('export-modal').style.display = 'block';
-            // Set project name from current project
-            document.getElementById('export-name').value = this.project.name || 'Untitled Project';
-            this.loadExportSuffixesToUI();
-            // Slice 11: rebuild canvas checklist on every open so renames /
-            // additions / deletions show up. Visible canvases default-checked.
-            this.populateExportCanvasesList();
-            // v0.8.7: re-evaluate Scale row visibility on open (the user
-            // may have changed format last session and reopened later).
-            const _f = document.getElementById('export-format');
-            if (_f) _f.dispatchEvent(new Event('change'));
-            // Update preview
-            this.updateExportPreview();
+            this.openExportModal();
         });
         
         // Update preview when options change

--- a/src/static/js/app-export-io.js
+++ b/src/static/js/app-export-io.js
@@ -418,6 +418,34 @@ class _ExportIo {
         sendClientLog('export_resolume_complete', { projectName, rasterW, rasterH });
     }
 
+    /**
+     * Open and fully initialize the export modal.
+     *
+     * All export entry points route through this method so the toolbar and
+     * File menu cannot drift apart as modal options evolve.
+     */
+    openExportModal(format = null) {
+        const modal = document.getElementById('export-modal');
+        if (!modal) return;
+
+        const formatSelect = document.getElementById('export-format');
+        if (formatSelect && format) {
+            formatSelect.value = format;
+        }
+
+        modal.style.display = 'block';
+        document.getElementById('export-name').value =
+            this.project.name || 'Untitled Project';
+        this.loadExportSuffixesToUI();
+        this.populateExportCanvasesList();
+
+        // Re-evaluate format-specific controls such as the PSD scale row.
+        if (formatSelect) {
+            formatSelect.dispatchEvent(new Event('change'));
+        }
+        this.updateExportPreview();
+    }
+
     // Perform export using client-side canvas capture at 1:1 pixel scale
     /**
      * Slice 11: build the dynamic Canvases checklist in the export modal.
@@ -1741,10 +1769,10 @@ class _ExportIo {
                 this.saveProjectToFile();
                 break;
             case 'export-png':
-                this.openExportModalWithFormat('png');
+                this.openExportModal('png');
                 break;
             case 'export-psd':
-                this.openExportModalWithFormat('psd');
+                this.openExportModal('psd');
                 break;
             case 'preferences':
                 this.openPreferencesModal();

--- a/src/static/js/app-power.js
+++ b/src/static/js/app-power.js
@@ -5,22 +5,6 @@ import { sendClientLog } from './helpers.js';
 
 class _Power {
 
-    openExportModalWithFormat(format) {
-        const modal = document.getElementById('export-modal');
-        const formatSelect = document.getElementById('export-format');
-        if (formatSelect) {
-            formatSelect.value = format;
-            // v0.8.7: re-evaluate the PSD-only Scale row visibility.
-            formatSelect.dispatchEvent(new Event('change'));
-        }
-        if (modal) {
-            modal.style.display = 'block';
-            document.getElementById('export-name').value = this.project.name || 'Untitled Project';
-            this.loadExportSuffixesToUI();
-            this.updateExportPreview();
-        }
-    }
-
     showContextMenu(x, y) {
         const menu = document.getElementById('context-menu');
         if (!menu) return;

--- a/tests/test_browser_flows.py
+++ b/tests/test_browser_flows.py
@@ -158,12 +158,57 @@ def test_add_canvas_via_button(page):
 
 
 def test_export_modal_opens_and_closes(page):
+    expected_ids = page.evaluate(
+        "window.app.project.canvases.map(canvas => canvas.id)"
+    )
     page.locator('#btn-export').click()
     page.wait_for_timeout(300)
     assert page.locator('#export-modal').is_visible(), "export modal not shown"
+    actual_ids = page.locator(
+        '#export-canvases-list .export-canvas-checkbox'
+    ).evaluate_all(
+        "(checkboxes) => checkboxes.map(checkbox => checkbox.dataset.canvasId)"
+    )
+    assert actual_ids == expected_ids
     page.locator('#export-cancel').click()
     page.wait_for_timeout(300)
     assert not page.locator('#export-modal').is_visible()
+
+
+@pytest.mark.parametrize(
+    ('action', 'expected_format'),
+    [('export-png', 'png'), ('export-psd', 'psd')],
+)
+def test_file_menu_export_populates_canvas_picker(page, action, expected_format):
+    """File-menu exports rebuild the same canvas picker as the toolbar."""
+    expected_ids = page.evaluate(
+        "window.app.project.canvases.map(canvas => canvas.id)"
+    )
+    previous_format = page.locator('#export-format').input_value()
+    page.evaluate("""() => {
+        document.getElementById('export-modal').style.display = 'none';
+        document.getElementById('export-canvases-list').replaceChildren();
+    }""")
+
+    page.locator('[data-menu="file"]').click()
+    page.locator(f'[data-action="{action}"]').click()
+    page.wait_for_timeout(300)
+
+    actual_ids = page.locator(
+        '#export-canvases-list .export-canvas-checkbox'
+    ).evaluate_all(
+        "(checkboxes) => checkboxes.map(checkbox => checkbox.dataset.canvasId)"
+    )
+    assert actual_ids == expected_ids
+    assert page.locator('#export-format').input_value() == expected_format
+
+    page.locator('#export-cancel').click()
+    page.wait_for_timeout(300)
+    page.evaluate("""(format) => {
+        const select = document.getElementById('export-format');
+        select.value = format;
+        select.dispatchEvent(new Event('change'));
+    }""", previous_format)
 
 
 def test_preferences_modal_opens_and_closes(page):


### PR DESCRIPTION
## Summary

- Centralize export-modal initialization in a single `openExportModal(format?)` method.
- Route the toolbar Export button and File → Export PNG/PSD actions through that method.
- Remove the duplicate initializer from `app-power.js`.
- Add regression coverage for all three entry points.

## Background

The canvas picker was added during the multi-canvas export work in commit `44df7a8` on May 3, 2026.

That change updated the toolbar Export path to populate the canvas picker, but the existing File-menu export path retained its separate initialization logic. Opening Export through File → Export PNG or File → Export PSD therefore displayed an empty canvas list and prevented the export from continuing.

The regression first shipped in v0.9.0 and remained present through v0.10.6. Issue #103 reproduced it in both v0.10.2 and v0.10.6.

## Root cause

The same modal had two independent initialization paths. Only the toolbar path called `populateExportCanvasesList()`, allowing the implementations to drift as export features were added.

This change gives every export entry point one shared initialization path. It also moves the code toward DRY principles, reducing the risk of these paths drifting apart again.

## Validation

The regression test was written first and reproduced the failure for both File-menu actions: the canvas controls were empty instead of matching `project.canvases`.

Manually tested on macOS 26.5.2 (Build 25F84) using Chromium 140.0.7339.132 (Official Build, ungoogled-chromium).

After the fix:

- `40 passed` in the complete Chromium browser suite.
- `277 passed, 3 skipped` in the non-browser suite.
- JavaScript syntax checks passed for all modified modules.
- Toolbar, File → Export PNG, and File → Export PSD now populate matching canvas controls.

Fixes #103