### PR TITLE
v0.10.7: undo records every edit; info label wraps inside screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.6
+# LED Raster Designer v0.10.7
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,26 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.7 - July 25, 2026
+----------------------------
+- FIX: Undo now steps back through EVERY edit, one at a time. Changing a
+  fill color, a border or label color, a data-flow or power setting, the
+  screen rotation, the transparent-fill toggle, port and label templates,
+  processor / bit depth / frame rate, and more did not record an undo step
+  at all - so a single Undo skipped past a whole run of those edits and
+  looked like it "jumped back," wiping several changes at once. Every one of
+  those controls now records exactly one undo step per change, while dragging
+  a color picker still counts as a single step (not one per flicker of the
+  drag). Renaming the project and editing project notes are undoable too.
+- FIX: The Pixel Map Info label stays inside the screen. On a narrow screen
+  the readout (columns/rows, cabinet count, resolution, aspect ratio, weight)
+  ran off both edges as one long line. It now wraps onto as many lines as the
+  screen width allows, stacking up from the bottom, with each piece kept
+  whole. Wide screens still show it on a single line.
+- FIX: Right-clicking a screen no longer throws an error. The v0.10.4
+  right-click "Center on Canvas" work could break the right-click menu on the
+  Pixel Map and Show Look tabs; it works again.
+
 v0.10.6 - July 24, 2026
 ----------------------------
 - FIX: If the launcher window can't start, the app no longer becomes

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.6',
-            'CFBundleVersion': '0.10.6',
+            'CFBundleShortVersionString': '0.10.7',
+            'CFBundleVersion': '0.10.7',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/static/js/app-canvas-ui.js
+++ b/src/static/js/app-canvas-ui.js
@@ -824,9 +824,16 @@ class _CanvasUi {
             proxy.style.top = `${Math.round(r.bottom)}px`;
         }
         proxy.value = canvas.color || '#4A90E2';
-        const apply = (e) => this.updateCanvas(canvas.id, { color: (e.target.value || '').toLowerCase() });
-        proxy.oninput = apply;
-        proxy.onchange = apply;
+        // Split preview from commit like every other color control: dragging
+        // the picker only repaints locally, and the single server PUT + undo
+        // step happens once on change. Bound to both events it used to fire a
+        // full PUT + saveState per drag frame — dozens of history entries for
+        // one color pick.
+        proxy.oninput = (e) => {
+            canvas.color = (e.target.value || '').toLowerCase();
+            if (window.canvasRenderer) window.canvasRenderer.render();
+        };
+        proxy.onchange = (e) => this.updateCanvas(canvas.id, { color: (e.target.value || '').toLowerCase() });
 
         // Same rule as every other color control: custom wheel on PC, native OS
         // picker on macOS. Either way it opens directly on "Change Color".

--- a/src/static/js/app-colors.js
+++ b/src/static/js/app-colors.js
@@ -49,7 +49,10 @@ class _Colors {
             });
         });
         if (window.canvasRenderer) window.canvasRenderer.render();
-        if (isFinal) this.updateLayers(this.getSelectedLayers());
+        // isFinal is the commit (live drags/inputs pass false and only
+        // repaint). Record ONE undo step here — every gradient control funnels
+        // through this method, so the whole editor was previously non-undoable.
+        if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Update Gradient');
     }
 
     _gradientStops() {
@@ -525,7 +528,9 @@ class _Colors {
             });
         });
         if (window.canvasRenderer) window.canvasRenderer.render();
-        if (isFinal) this.updateLayers(this.getSelectedLayers());
+        // isFinal is the commit; record ONE undo step (every palette control
+        // funnels through here, so the whole palette editor was non-undoable).
+        if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Update Palette');
     }
 
     setupPaletteEditor() {

--- a/src/static/js/app-core.js
+++ b/src/static/js/app-core.js
@@ -1443,6 +1443,7 @@ export class LEDRasterApp {
                 if (this.project) {
                     this.project.name = projectNameInput.value.trim() || 'Untitled Project';
                     this.saveProject();
+                    this.saveState('Rename Project');
                 }
                 updateProjectNameWarning();
             });
@@ -1459,6 +1460,7 @@ export class LEDRasterApp {
                 if (this.project) {
                     this.project.notes = notesTextarea.value;
                     this.saveProject();
+                    this.debouncedSaveState('Edit Notes', 500, 'project-notes');
                 }
             });
         }
@@ -1874,7 +1876,7 @@ export class LEDRasterApp {
                 layer.cabinetIdColor = val;
             });
             if (isFinal) {
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Cabinet ID Color');
             }
             window.canvasRenderer.render();
         });
@@ -1904,7 +1906,7 @@ export class LEDRasterApp {
                 layer.border_color_pixel = val;
             });
             if (isFinal) {
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
             }
             window.canvasRenderer.render();
         });
@@ -1927,7 +1929,7 @@ export class LEDRasterApp {
                 layer.border_color_cabinet = val;
             });
             if (isFinal) {
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
             }
             window.canvasRenderer.render();
         });
@@ -1938,7 +1940,7 @@ export class LEDRasterApp {
                 layer.border_color_data = val;
             });
             if (isFinal) {
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
             }
             window.canvasRenderer.render();
         });
@@ -1949,7 +1951,7 @@ export class LEDRasterApp {
                 layer.border_color_power = val;
             });
             if (isFinal) {
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
             }
             window.canvasRenderer.render();
         });
@@ -1972,7 +1974,7 @@ export class LEDRasterApp {
                 });
                 this.applyToSelectedLayers(layer => { layer.panel_border_width = v; });
                 window.canvasRenderer.render();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Width');
             });
         });
 
@@ -2027,7 +2029,7 @@ export class LEDRasterApp {
                 this.applyToSelectedLayers(layer => {
                     layer.infoLabelSize = parseInt(infoLabelSizeInput.value, 10) || 14;
                 });
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Info Label Size');
                 this.saveClientSideProperties();
                 window.canvasRenderer.render();
             });
@@ -2086,7 +2088,7 @@ export class LEDRasterApp {
                 this.saveClientSideProperties();
                 this.updatePortCapacityDisplay();
                 this.updatePortLabelEditor();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Processor Type');
                 window.canvasRenderer.render();
             });
         }
@@ -2100,7 +2102,7 @@ export class LEDRasterApp {
                 this.saveClientSideProperties();
                 this.updatePortCapacityDisplay();
                 this.updatePortLabelEditor();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Bit Depth');
                 window.canvasRenderer.render();
             });
         }
@@ -2113,7 +2115,7 @@ export class LEDRasterApp {
                 this.saveClientSideProperties();
                 this.updatePortCapacityDisplay();
                 this.updatePortLabelEditor();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Frame Rate');
                 window.canvasRenderer.render();
             });
         }
@@ -2145,7 +2147,7 @@ export class LEDRasterApp {
             this.saveClientSideProperties();
             this.updatePortCapacityDisplay();
             this.updatePortLabelEditor();
-            this.updateLayers(this.getSelectedLayers());
+            this.updateLayers(this.getSelectedLayers(), true, 'Change Port Mapping Mode');
             window.canvasRenderer.render();
         };
         
@@ -2177,7 +2179,7 @@ export class LEDRasterApp {
                     this.saveClientSideProperties();
                     this.updatePortCapacityDisplay();  // Update port calculation with new pattern
                     this.updatePortLabelEditor();
-                    this.updateLayers(this.getSelectedLayers());
+                    this.updateLayers(this.getSelectedLayers(), true, 'Change Data Flow Pattern');
                     window.canvasRenderer.render();
                 }
             });
@@ -2200,7 +2202,7 @@ export class LEDRasterApp {
                     this.saveClientSideProperties();
                     this.updatePowerCapacityDisplay();
                     this.updateCustomPowerUI();
-                    this.updateLayers(this.getSelectedLayers());
+                    this.updateLayers(this.getSelectedLayers(), true, 'Change Power Flow Pattern');
                     window.canvasRenderer.render();
                 }
             });
@@ -2214,7 +2216,7 @@ export class LEDRasterApp {
                     layer.arrowLineWidth = parseInt(arrowLineWidthInput.value) || 6;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Arrow Line Width');
                 window.canvasRenderer.render();
             });
         }
@@ -2241,7 +2243,7 @@ export class LEDRasterApp {
                     layer.portLabelTemplatePrimary = portTemplatePrimaryInput.value || 'P#';
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Port Label Template');
                 window.canvasRenderer.render();
             });
         }
@@ -2251,7 +2253,7 @@ export class LEDRasterApp {
                     layer.portLabelTemplateReturn = portTemplateReturnInput.value || 'R#';
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Port Label Template');
                 window.canvasRenderer.render();
             });
         }
@@ -2301,7 +2303,7 @@ export class LEDRasterApp {
 
                 this.saveClientSideProperties();
                 this.updatePortLabelEditor();
-                this.updateLayers(targetLayers);
+                this.updateLayers(targetLayers, true, 'Apply Port Labels');
                 window.canvasRenderer.render();
             });
         }
@@ -2326,7 +2328,7 @@ export class LEDRasterApp {
 
                 this.saveClientSideProperties();
                 this.updatePortLabelEditor();
-                this.updateLayers(targetLayers);
+                this.updateLayers(targetLayers, true, 'Clear Port Labels');
                 window.canvasRenderer.render();
             });
         }
@@ -2452,7 +2454,7 @@ export class LEDRasterApp {
                     layer.arrowSize = parseInt(arrowSizeInput.value) || 12;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Arrow Size');
                 window.canvasRenderer.render();
             });
         }
@@ -2464,7 +2466,7 @@ export class LEDRasterApp {
                     layer.randomDataColors = randomColorsCheck.checked;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Toggle Random Data Colors');
                 window.canvasRenderer.render();
             });
         }
@@ -2594,7 +2596,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerCapacityDisplay();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Voltage');
                 window.canvasRenderer.render();
             });
             powerVoltageCustomInput.addEventListener('change', () => {
@@ -2605,7 +2607,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerCapacityDisplay();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Voltage');
                 window.canvasRenderer.render();
             });
         }
@@ -2624,7 +2626,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerCapacityDisplay();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Amperage');
                 window.canvasRenderer.render();
             });
             powerAmperageCustomInput.addEventListener('change', () => {
@@ -2635,7 +2637,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerCapacityDisplay();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Amperage');
                 window.canvasRenderer.render();
             });
         }
@@ -2653,7 +2655,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerCapacityDisplay();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Panel Watts');
                 window.canvasRenderer.render();
             });
         }
@@ -2664,7 +2666,7 @@ export class LEDRasterApp {
                     layer.powerLineWidth = parseInt(powerLineWidthInput.value, 10) || 8;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Line Width');
                 window.canvasRenderer.render();
             });
         }
@@ -2675,7 +2677,7 @@ export class LEDRasterApp {
                     layer.powerLabelSize = parseInt(powerLabelSizeInput.value, 10) || 14;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Label Size');
                 window.canvasRenderer.render();
             });
         }
@@ -2693,7 +2695,7 @@ export class LEDRasterApp {
                 if (powerOrganizedCheckbox && powerMaximizeCheckbox.checked) {
                     powerOrganizedCheckbox.checked = false;
                 }
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Mode');
                 window.canvasRenderer.render();
             });
         }
@@ -2711,7 +2713,7 @@ export class LEDRasterApp {
                 if (powerMaximizeCheckbox && powerOrganizedCheckbox.checked) {
                     powerMaximizeCheckbox.checked = false;
                 }
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Mode');
                 window.canvasRenderer.render();
             });
         }
@@ -2722,7 +2724,7 @@ export class LEDRasterApp {
                     layer.powerRandomColors = powerRandomColorsCheckbox.checked;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Toggle Power Random Colors');
                 window.canvasRenderer.render();
             });
         }
@@ -2732,7 +2734,7 @@ export class LEDRasterApp {
                     layer.powerColorCodedView = powerColorCodedViewCheckbox.checked;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Toggle Power Color Coding');
                 updatePowerCircuitColorSection();
                 window.canvasRenderer.render();
             });
@@ -2759,7 +2761,7 @@ export class LEDRasterApp {
                     layer.powerCircuitColors = colors;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Circuit Colors');
                 updatePowerCircuitColorSection();
                 window.canvasRenderer.render();
             });
@@ -2779,7 +2781,7 @@ export class LEDRasterApp {
                     layer.showDataFlowPortInfo = showDataFlowPortInfoEl.checked;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Toggle Port Info Labels');
                 window.canvasRenderer.render();
             });
         }
@@ -2789,7 +2791,7 @@ export class LEDRasterApp {
                     layer.showPowerCircuitInfo = showPowerCircuitInfoEl.checked;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Toggle Circuit Info Labels');
                 window.canvasRenderer.render();
             });
         }
@@ -2819,7 +2821,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerLabelEditor();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Power Label Template');
                 window.canvasRenderer.render();
             });
         }
@@ -2842,7 +2844,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerLabelEditor();
-                this.updateLayers(targetLayers);
+                this.updateLayers(targetLayers, true, 'Apply Power Labels');
                 window.canvasRenderer.render();
             });
         }
@@ -2862,7 +2864,7 @@ export class LEDRasterApp {
                 });
                 this.saveClientSideProperties();
                 this.updatePowerLabelEditor();
-                this.updateLayers(targetLayers);
+                this.updateLayers(targetLayers, true, 'Clear Power Labels');
                 window.canvasRenderer.render();
             });
         }
@@ -2976,7 +2978,7 @@ export class LEDRasterApp {
                 layer.dataFlowColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Data Flow Color');
             window.canvasRenderer.render();
         });
         
@@ -2986,7 +2988,7 @@ export class LEDRasterApp {
                 layer.arrowColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Arrow Color');
             window.canvasRenderer.render();
         });
         
@@ -2996,7 +2998,7 @@ export class LEDRasterApp {
                 layer.primaryColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Primary Port Color');
             window.canvasRenderer.render();
         });
 
@@ -3006,7 +3008,7 @@ export class LEDRasterApp {
                 layer.primaryTextColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Primary Text Color');
             window.canvasRenderer.render();
         });
         
@@ -3016,7 +3018,7 @@ export class LEDRasterApp {
                 layer.backupColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Backup Port Color');
             window.canvasRenderer.render();
         });
 
@@ -3026,7 +3028,7 @@ export class LEDRasterApp {
                 layer.backupTextColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Backup Text Color');
             window.canvasRenderer.render();
         });
 
@@ -3035,7 +3037,7 @@ export class LEDRasterApp {
                 layer.powerLineColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Line Color');
             window.canvasRenderer.render();
         });
 
@@ -3044,7 +3046,7 @@ export class LEDRasterApp {
                 layer.powerArrowColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Arrow Color');
             window.canvasRenderer.render();
         });
 
@@ -3053,7 +3055,7 @@ export class LEDRasterApp {
                 layer.powerLabelBgColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Label Background');
             window.canvasRenderer.render();
         });
 
@@ -3062,7 +3064,7 @@ export class LEDRasterApp {
                 layer.powerLabelTextColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Label Text Color');
             window.canvasRenderer.render();
         });
         
@@ -3073,7 +3075,7 @@ export class LEDRasterApp {
                     layer.dataFlowLabelSize = parseInt(labelSizeInput.value) || 12;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Data Flow Label Size');
                 window.canvasRenderer.render();
             });
         }
@@ -3086,7 +3088,7 @@ export class LEDRasterApp {
                     layer.screenNameSizeDataFlow = parseInt(screenNameSizeInput.value) || 30;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Screen Name Size');
                 window.canvasRenderer.render();
             });
         }
@@ -3099,7 +3101,7 @@ export class LEDRasterApp {
                     layer.screenNameSizeCabinet = parseInt(screenNameSizeCabinetInput.value) || 30;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Screen Name Size');
                 window.canvasRenderer.render();
             });
         }
@@ -3112,7 +3114,7 @@ export class LEDRasterApp {
                     layer.screenNameSizePower = parseInt(screenNameSizePowerInput.value) || 30;
                 });
                 this.saveClientSideProperties();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Change Screen Name Size');
                 window.canvasRenderer.render();
             });
         }
@@ -3143,7 +3145,7 @@ export class LEDRasterApp {
                 layer.color1 = rgb;
             });
             window.canvasRenderer.render();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Fill Color');
         });
         setupColorPickerWithHex('color2-picker', 'color2-hex', (val, isFinal) => {
             const rgb = this.hexToRgb(val);
@@ -3151,7 +3153,7 @@ export class LEDRasterApp {
                 layer.color2 = rgb;
             });
             window.canvasRenderer.render();
-            if (isFinal) this.updateLayers(this.getSelectedLayers());
+            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Fill Color');
         });
 
         // Transparent (no fill) override: render cabinets see-through so only
@@ -3162,7 +3164,7 @@ export class LEDRasterApp {
                 const checked = transparentFillEl.checked;
                 this.applyToSelectedLayers(layer => { layer.transparentFill = checked; });
                 window.canvasRenderer.render();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Toggle Transparent Fill');
             });
         }
 
@@ -3173,7 +3175,7 @@ export class LEDRasterApp {
                 const deg = parseInt(screenRotationEl.value, 10) || 0;
                 this.applyToSelectedLayers(layer => { layer.rotation = deg; });
                 window.canvasRenderer.render();
-                this.updateLayers(this.getSelectedLayers());
+                this.updateLayers(this.getSelectedLayers(), true, 'Rotate Screen');
             });
         }
 

--- a/src/static/js/app-power.js
+++ b/src/static/js/app-power.js
@@ -1039,6 +1039,13 @@ class _Power {
                 halfTile: resolved,
             })),
         };
+        // Apply locally BEFORE saving history (the server response is
+        // discarded, so nothing else writes it back). Without this the
+        // snapshot captured the pre-change halfTile and Undo-then-Redo
+        // silently lost the change — the twin setPanelsBlankBulk does the
+        // same local-first mutation for exactly this reason.
+        panels.forEach(p => { p.halfTile = resolved; });
+        if (window.canvasRenderer) window.canvasRenderer.render();
         try {
             const res = await fetch(`/api/layer/${layerId}/panels/set_half_tile`, {
                 method: 'POST',
@@ -1047,8 +1054,9 @@ class _Power {
             });
             await res.json();
         } catch (err) {
+            // Local state already changed; still record it (same optimistic
+            // behaviour as setPanelsBlankBulk) so it stays undoable.
             console.error('setPanelsHalfTileBulk failed', err);
-            return;
         }
         this.saveState('Bulk Set Half-tile');
         sendClientLog && sendClientLog('bulk_set_half_tile', {
@@ -1644,6 +1652,11 @@ class _Power {
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ name: newName })
                     });
+                    // Record the rename so it's undoable on its own; without
+                    // this the local name change rode along on the next action
+                    // and a later undo restored a stale name (client/server
+                    // desync). The renameLayer() path already does this.
+                    this.saveState('Rename Layer');
                 }
             };
 

--- a/src/static/js/app-presets.js
+++ b/src/static/js/app-presets.js
@@ -962,7 +962,6 @@ class _Presets {
 
     addImageLayer(imageData, imageWidth, imageHeight) {
         const name = this.getNextImageLayerName();
-        this.saveState('Add Image Layer');
         fetch('/api/layer/add-image', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -990,6 +989,10 @@ class _Presets {
                 layer._imageObj = img;
             }
             this.upsertProjectLayer(layer);
+            // Snapshot AFTER the layer is in the project. Taken before the
+            // async add (as it was), Undo-then-Redo restored a snapshot with
+            // no image layer and the add was lost — the v0.10.0 Add Layer bug.
+            this.saveState('Add Image Layer');
             this.selectLayer(layer);
             window.canvasRenderer.fitToView();
             window.canvasRenderer.render();
@@ -999,7 +1002,6 @@ class _Presets {
 
     addTextLayer() {
         const name = this.getNextTextLayerName();
-        this.saveState('Add Text Layer');
         fetch('/api/layer/add-text', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -1009,6 +1011,8 @@ class _Presets {
         .then(layer => {
             sendClientLog('add_text_layer', { id: layer.id, name: layer.name });
             this.upsertProjectLayer(layer);
+            // Snapshot AFTER the layer exists (see addImageLayer).
+            this.saveState('Add Text Layer');
             this.selectLayer(layer);
             window.canvasRenderer.fitToView();
             window.canvasRenderer.render();

--- a/src/static/js/canvas.js
+++ b/src/static/js/canvas.js
@@ -1844,7 +1844,14 @@ class CanvasRenderer {
             const worldY = ((e.clientY - rect.top) - this.panY) / this.zoom;
             const worldX = this._unmirrorWorldX(((e.clientX - rect.left) - this.panX) / this.zoom, worldY);
             const hit = this.getLayerAt(worldX, worldY);
-            if (hit && !(window.app.selectedLayerIds || []).includes(hit.id)) {
+            // selectedLayerIds is a Set — use .has(), not Array.includes()
+            // (which threw a TypeError here and aborted the handler).
+            const selectedIds = window.app.selectedLayerIds;
+            const alreadySelected = selectedIds
+                && (typeof selectedIds.has === 'function'
+                    ? selectedIds.has(hit && hit.id)
+                    : Array.from(selectedIds).includes(hit && hit.id));
+            if (hit && !alreadySelected) {
                 window.app.selectLayer(hit);
             }
         }
@@ -4597,15 +4604,20 @@ class CanvasRenderer {
             }
         }
         
-        // Build Info label text (separate, at bottom) - only in pixel-map mode
-        // Single row format for compact display
-        const infoLines = [];
+        // Build Info label clauses (separate bar, at bottom) - only in pixel-map
+        // mode. v0.10.7: emit discrete clauses instead of one long string so the
+        // draw step can pack them into as many lines as the screen width allows,
+        // keeping the whole info bar bound inside the layer instead of spilling
+        // past both edges on a narrow screen.
+        const infoParts = [];
         if (this.viewMode === 'pixel-map' && layer.showLabelInfo) {
-            // Calculate aspect ratio
             const aspectRatio = layerWidth / layerHeight;
             const aspectRatioStr = `${aspectRatio.toFixed(2)}`;
-            
-            infoLines.push(`${layer.columns} Columns X ${layer.rows} Rows • ${activePanels} Cabinets Total / Resolution: ${layerWidth} X ${layerHeight} • Aspect Ratio: ${aspectRatioStr} • Weight: ${totalWeightKg.toFixed(1)} kg / ${totalWeightLb.toFixed(1)} lb`);
+            infoParts.push(`${layer.columns} Columns X ${layer.rows} Rows`);
+            infoParts.push(`${activePanels} Cabinets Total`);
+            infoParts.push(`Resolution: ${layerWidth} X ${layerHeight}`);
+            infoParts.push(`Aspect Ratio: ${aspectRatioStr}`);
+            infoParts.push(`Weight: ${totalWeightKg.toFixed(1)} kg / ${totalWeightLb.toFixed(1)} lb`);
         }
         
         // Use absolute pixel sizes - no scaling with zoom
@@ -4870,20 +4882,39 @@ class CanvasRenderer {
             this.ctx.restore();
         }
         
-        // Render Info label at bottom with background (fixed 14px screen size)
-        if (infoLines.length > 0) {
+        // Render Info label at bottom with background.
+        if (infoParts.length > 0) {
             // Use world coordinates directly (transform is already applied)
             this.ctx.font = `${infoFontSize}px ${projectFontFamily()}`;
             this.ctx.textAlign = 'center';
             this.ctx.textBaseline = 'bottom';
-            
+
+            // v0.10.7: greedily pack the clauses into lines that stay within the
+            // layer's inner width, joined by " • ", so the info bar wraps and
+            // stacks upward from the bottom edge instead of overflowing the
+            // sides of a narrow screen. Wide screens still collapse to one line.
+            const sep = ' • ';
+            const maxLineWidth = Math.max(layerWidth - padding * 2, infoFontSize * 4);
+            const infoLines = [];
+            let currentLine = '';
+            infoParts.forEach(part => {
+                const candidate = currentLine ? currentLine + sep + part : part;
+                if (currentLine && this.ctx.measureText(candidate).width > maxLineWidth) {
+                    infoLines.push(currentLine);
+                    currentLine = part;
+                } else {
+                    currentLine = candidate;
+                }
+            });
+            if (currentLine) infoLines.push(currentLine);
+
             // Measure text for background
             let maxWidth = 0;
             infoLines.forEach(line => {
                 const metrics = this.ctx.measureText(line);
                 maxWidth = Math.max(maxWidth, metrics.width);
             });
-            
+
             const bgWidth = maxWidth + padding * 2;
             const bgHeight = infoLines.length * infoLineHeight + padding * 2;
             // v0.8.7.7: bottom-anchored info bar follows the screen-name

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.6</title>
+    <title>LED Raster Designer v0.10.7</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.6</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.7</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## v0.10.7

**Undo now records every edit, one step at a time.** Many committed controls mutated a layer but never recorded an undo step, so a single Undo skipped past a whole run of edits and appeared to "jump back," wiping several changes at once. Fixed so each commit records exactly one step:
- 57 handlers in `app-core.js`: fill/border/label colors, data-flow + power settings, rotation, transparent-fill, port/label templates, processor/bit-depth/frame-rate, project rename + notes. Live color drags still record nothing.
- Gradient + palette editors (20 controls), add image/text layer ordering, sidebar rename, bulk half-tile, and the canvas color picker.

**Pixel Map Info label stays inside the screen** — wraps onto stacked, clause-intact lines within the screen width instead of overflowing a narrow screen; wide screens stay on one line.

**Right-click no longer crashes** — `selectedLayerIds` Set fix (regression from v0.10.4 Center on Canvas).

315 tests pass; version bumped across README, VERSION.txt, spec, and index.html.