### PR TITLE
v0.10.7.2: color-picker undo debounce + undo refreshes size inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.7.1
+# LED Raster Designer v0.10.7.2
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,22 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.7.2 - July 25, 2026
+----------------------------
+- FIX: Undo behaves correctly after changing colors. Dragging any color
+  control - fill, border, label, data-flow, power, palette, gradient, or
+  canvas background - now records exactly ONE undo step for the whole drag
+  instead of a burst of steps per drag. The burst had been filling up the
+  undo history, so a single Undo appeared to "jump back" several changes at
+  once, and it could push older edits (like moving a panel) out of the undo
+  history entirely - which is why undoing a move sometimes stepped back much
+  further than expected. Moves, color changes, and every other edit now undo
+  one step at a time.
+- FIX: Undo/redo of a size now updates the number you see. Undoing a change
+  to a panel size or the raster width/height reverted the design correctly
+  but left the old number showing in the input box; the field now refreshes
+  to match what was restored.
+
 v0.10.7.1 - July 25, 2026
 ----------------------------
 - FIX: Exporting from the File menu now shows your canvases. Opening Export

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.7.1',
-            'CFBundleVersion': '0.10.7.1',
+            'CFBundleShortVersionString': '0.10.7.2',
+            'CFBundleVersion': '0.10.7.2',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/static/js/app-canvas-ui.js
+++ b/src/static/js/app-canvas-ui.js
@@ -301,7 +301,7 @@ class _CanvasUi {
 
     // Canvas mutation routed through one helper so every mutating call
     // gets one (and only one) post-mutation undo entry.
-    updateCanvas(canvasId, patch) {
+    updateCanvas(canvasId, patch, { skipHistory = false } = {}) {
         // Pick the most informative undo label from the patch keys.
         const keys = patch ? Object.keys(patch) : [];
         let label = 'Update Canvas';
@@ -318,7 +318,10 @@ class _CanvasUi {
             body: JSON.stringify(patch || {})
         }).then(r => r.json()).then(data => {
             this._applyProjectUpdate(data);
-            if (typeof this.saveState === 'function') this.saveState(label);
+            // skipHistory lets a continuous edit (e.g. dragging the native
+            // canvas color picker) persist every frame while a single coalesced
+            // snapshot is recorded by the caller once the drag settles.
+            if (!skipHistory && typeof this.saveState === 'function') this.saveState(label);
         });
     }
 
@@ -833,7 +836,13 @@ class _CanvasUi {
             canvas.color = (e.target.value || '').toLowerCase();
             if (window.canvasRenderer) window.canvasRenderer.render();
         };
-        proxy.onchange = (e) => this.updateCanvas(canvas.id, { color: (e.target.value || '').toLowerCase() });
+        proxy.onchange = (e) => {
+            // Native <input type=color> fires 'change' continuously while the
+            // macOS system picker is dragged. Persist each frame WITHOUT its own
+            // undo entry, then coalesce a single snapshot once the drag settles.
+            this.updateCanvas(canvas.id, { color: (e.target.value || '').toLowerCase() }, { skipHistory: true })
+                .then(() => this.debouncedSaveState('Change Canvas Color', 400, 'canvas-color'));
+        };
 
         // Same rule as every other color control: custom wheel on PC, native OS
         // picker on macOS. Either way it opens directly on "Change Color".

--- a/src/static/js/app-colors.js
+++ b/src/static/js/app-colors.js
@@ -52,7 +52,10 @@ class _Colors {
         // isFinal is the commit (live drags/inputs pass false and only
         // repaint). Record ONE undo step here — every gradient control funnels
         // through this method, so the whole editor was previously non-undoable.
-        if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Update Gradient');
+        if (isFinal) {
+            this.updateLayers(this.getSelectedLayers());
+            this.debouncedSaveState('Update Gradient', 400, 'gradient');
+        }
     }
 
     _gradientStops() {
@@ -530,7 +533,10 @@ class _Colors {
         if (window.canvasRenderer) window.canvasRenderer.render();
         // isFinal is the commit; record ONE undo step (every palette control
         // funnels through here, so the whole palette editor was non-undoable).
-        if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Update Palette');
+        if (isFinal) {
+            this.updateLayers(this.getSelectedLayers());
+            this.debouncedSaveState('Update Palette', 400, 'palette');
+        }
     }
 
     setupPaletteEditor() {

--- a/src/static/js/app-core.js
+++ b/src/static/js/app-core.js
@@ -1876,7 +1876,8 @@ export class LEDRasterApp {
                 layer.cabinetIdColor = val;
             });
             if (isFinal) {
-                this.updateLayers(this.getSelectedLayers(), true, 'Change Cabinet ID Color');
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Cabinet ID Color', 400, 'cabinet-id-color');
             }
             window.canvasRenderer.render();
         });
@@ -1905,21 +1906,20 @@ export class LEDRasterApp {
             this.applyToSelectedLayers(layer => {
                 layer.border_color_pixel = val;
             });
-            if (isFinal) {
-                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
-            }
             window.canvasRenderer.render();
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Border Color', 400, 'border-color');
+            }
         });
         
         // Labels color with hex sync
         setupColorPickerWithHex('labels-color', 'labels-color-hex', (val, isFinal) => {
+            this.applyToSelectedLayers(layer => { layer.labelsColor = val; });
+            window.canvasRenderer.render();
             if (isFinal) {
-                this.updateLayerFromInputs();
-            } else {
-                this.applyToSelectedLayers(layer => {
-                    layer.labelsColor = val;
-                });
-                window.canvasRenderer.render();
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Label Color', 400, 'labels-color');
             }
         });
         
@@ -1928,10 +1928,11 @@ export class LEDRasterApp {
             this.applyToSelectedLayers(layer => {
                 layer.border_color_cabinet = val;
             });
-            if (isFinal) {
-                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
-            }
             window.canvasRenderer.render();
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Border Color', 400, 'border-color-cabinet');
+            }
         });
         
         // Tab-specific border controls - Data Flow
@@ -1939,10 +1940,11 @@ export class LEDRasterApp {
             this.applyToSelectedLayers(layer => {
                 layer.border_color_data = val;
             });
-            if (isFinal) {
-                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
-            }
             window.canvasRenderer.render();
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Border Color', 400, 'border-color-data');
+            }
         });
         
         // Tab-specific border controls - Power
@@ -1950,10 +1952,11 @@ export class LEDRasterApp {
             this.applyToSelectedLayers(layer => {
                 layer.border_color_power = val;
             });
-            if (isFinal) {
-                this.updateLayers(this.getSelectedLayers(), true, 'Change Border Color');
-            }
             window.canvasRenderer.render();
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Border Color', 400, 'border-color-power');
+            }
         });
         
         // v0.8.8.x: per-layer panel border width, in LED pixels. One value
@@ -2978,7 +2981,10 @@ export class LEDRasterApp {
                 layer.dataFlowColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Data Flow Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Data Flow Color', 400, 'data-flow-color');
+            }
             window.canvasRenderer.render();
         });
         
@@ -2988,7 +2994,10 @@ export class LEDRasterApp {
                 layer.arrowColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Arrow Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Arrow Color', 400, 'arrow-color');
+            }
             window.canvasRenderer.render();
         });
         
@@ -2998,7 +3007,10 @@ export class LEDRasterApp {
                 layer.primaryColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Primary Port Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Primary Port Color', 400, 'primary-color');
+            }
             window.canvasRenderer.render();
         });
 
@@ -3008,7 +3020,10 @@ export class LEDRasterApp {
                 layer.primaryTextColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Primary Text Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Primary Text Color', 400, 'primary-text-color');
+            }
             window.canvasRenderer.render();
         });
         
@@ -3018,7 +3033,10 @@ export class LEDRasterApp {
                 layer.backupColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Backup Port Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Backup Port Color', 400, 'backup-color');
+            }
             window.canvasRenderer.render();
         });
 
@@ -3028,7 +3046,10 @@ export class LEDRasterApp {
                 layer.backupTextColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Backup Text Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Backup Text Color', 400, 'backup-text-color');
+            }
             window.canvasRenderer.render();
         });
 
@@ -3037,7 +3058,10 @@ export class LEDRasterApp {
                 layer.powerLineColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Line Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Power Line Color', 400, 'power-line-color');
+            }
             window.canvasRenderer.render();
         });
 
@@ -3046,7 +3070,10 @@ export class LEDRasterApp {
                 layer.powerArrowColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Arrow Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Power Arrow Color', 400, 'power-arrow-color');
+            }
             window.canvasRenderer.render();
         });
 
@@ -3055,7 +3082,10 @@ export class LEDRasterApp {
                 layer.powerLabelBgColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Label Background');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Power Label Background', 400, 'power-label-bg-color');
+            }
             window.canvasRenderer.render();
         });
 
@@ -3064,7 +3094,10 @@ export class LEDRasterApp {
                 layer.powerLabelTextColor = val;
             });
             this.saveClientSideProperties();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Power Label Text Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Power Label Text Color', 400, 'power-label-text-color');
+            }
             window.canvasRenderer.render();
         });
         
@@ -3145,7 +3178,14 @@ export class LEDRasterApp {
                 layer.color1 = rgb;
             });
             window.canvasRenderer.render();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Fill Color');
+            // Native <input type=color> fires 'change' continuously while the
+            // system picker is dragged, so record ONE coalesced undo step per
+            // drag (debounced) instead of one per frame - the latter buries the
+            // real history under dozens of 1-value colour steps.
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Fill Color', 400, 'color1-picker');
+            }
         });
         setupColorPickerWithHex('color2-picker', 'color2-hex', (val, isFinal) => {
             const rgb = this.hexToRgb(val);
@@ -3153,7 +3193,10 @@ export class LEDRasterApp {
                 layer.color2 = rgb;
             });
             window.canvasRenderer.render();
-            if (isFinal) this.updateLayers(this.getSelectedLayers(), true, 'Change Fill Color');
+            if (isFinal) {
+                this.updateLayers(this.getSelectedLayers());
+                this.debouncedSaveState('Change Fill Color', 400, 'color2-picker');
+            }
         });
 
         // Transparent (no fill) override: render cabinets see-through so only

--- a/src/static/js/app-history.js
+++ b/src/static/js/app-history.js
@@ -13,6 +13,11 @@ class _History {
     }
     
     saveState(action) {
+        // v0.10.7.2: history isn't allocated until resetHistory() runs, which is
+        // after setupEventListeners(). Guard against any save that fires before
+        // then (e.g. a debounced picker commit flushing during setup) rather than
+        // throwing on this.history.length and aborting the caller mid-setup.
+        if (!Array.isArray(this.history)) return;
         // v0.10.5: a debounced snapshot still waiting to fire must land BEFORE
         // this one, or history ends up out of order (and the pending timer
         // would later snapshot a state that already includes this action).
@@ -118,6 +123,18 @@ class _History {
                 this.currentLayer = this.project.layers.find(l => l.id === this.currentLayer.id) || null;
             }
             this.updateCustomFlowUI();
+            // v0.10.7.2: updateUI() re-renders the canvas but does NOT reload the
+            // Screen Info fields or the toolbar Raster inputs, so without this an
+            // undo/redo reverts the geometry while the sidebar keeps showing the
+            // pre-undo numbers (panel size / columns / rows / raster) - the value
+            // and the actual size disagree. Refresh them from the restored state,
+            // exactly as deleteCurrentLayer already does for the same reason.
+            if (typeof this.loadLayerToInputs === 'function') {
+                try { this.loadLayerToInputs(); } catch (_) {}
+            }
+            if (typeof this.syncRasterFromProject === 'function') {
+                try { this.syncRasterFromProject(); } catch (_) {}
+            }
             
             // Sync the restored state to the backend
             fetch('/api/project', {
@@ -161,6 +178,18 @@ class _History {
                 this.currentLayer = this.project.layers.find(l => l.id === this.currentLayer.id) || null;
             }
             this.updateCustomFlowUI();
+            // v0.10.7.2: updateUI() re-renders the canvas but does NOT reload the
+            // Screen Info fields or the toolbar Raster inputs, so without this an
+            // undo/redo reverts the geometry while the sidebar keeps showing the
+            // pre-undo numbers (panel size / columns / rows / raster) - the value
+            // and the actual size disagree. Refresh them from the restored state,
+            // exactly as deleteCurrentLayer already does for the same reason.
+            if (typeof this.loadLayerToInputs === 'function') {
+                try { this.loadLayerToInputs(); } catch (_) {}
+            }
+            if (typeof this.syncRasterFromProject === 'function') {
+                try { this.syncRasterFromProject(); } catch (_) {}
+            }
             
             // Sync the restored state to the backend
             fetch('/api/project', {

--- a/src/static/js/helpers.js
+++ b/src/static/js/helpers.js
@@ -141,7 +141,15 @@ function setupColorPickerWithHex(pickerId, hexId, onChangeCallback) {
     picker.addEventListener('input', (e) => setColor(e.target.value, false));
     picker.addEventListener('change', (e) => setColor(e.target.value, true));
     hex.addEventListener('change', () => setColor(hex.value, true));
-    setColor(picker.value || hex.value || '#ffffff', true);
+    // v0.10.7.2: initialize the DISPLAY only (isFinal=false). Passing true here
+    // made every picker simulate a user commit during setup - running
+    // updateLayers()/debouncedSaveState() before the history system is even
+    // initialized (resetHistory() runs after setupEventListeners). The first
+    // picker whose init-commit flushed a prior pending save called saveState()
+    // while this.history was still undefined, throwing and aborting the rest of
+    // setupEventListeners - leaving every later color picker unwired. isFinal=false
+    // is the same path every 'input' event takes, so all callbacks handle it safely.
+    setColor(picker.value || hex.value || '#ffffff', false);
 }
 
 function normalizeHex(val) {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.7.1</title>
+    <title>LED Raster Designer v0.10.7.2</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.7.1</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.7.2</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>


### PR DESCRIPTION
## Summary
Patch release fixing the remaining undo/history issues reported against v0.10.7.1.

### Undo/history fixes
- **Color drags = one undo step.** Every color control (fill, border, label, data-flow, power, palette, gradient, canvas background) now coalesces a drag into a single `debouncedSaveState` step instead of a burst per drag. The burst had been saturating the 50-entry history buffer, so a single Undo appeared to "jump back" several changes and could push older edits (like moving a panel) out of history — the cause of "undo a move steps back too far."
- **Fixed the wiring regression** that extending the debounce to all pickers introduced: the color-picker helper's init call fired the callback with `isFinal=true`, simulating a user commit during `setupEventListeners`. The first init-commit that flushed a pending save called `saveState()` before `resetHistory()` had allocated `this.history`, throwing and aborting the rest of setup — leaving every color picker after the first two unwired. Init now syncs the **display only** (`isFinal=false`), and `saveState()` guards against a pre-init call.
- **Undo/redo refreshes size inputs.** Undoing a panel-size or raster width/height change now updates the number shown in the field, not just the design.

### Verification
- All 10 color pickers wired (regression gone)
- An 8-event color drag → exactly **1** `saveState`
- Interleaved moves + color drags → each **1** undo step, undo walks back one at a time
- Size-field undo reverts the input value
- Clean console on load
- `pytest`: **317 passed, 3 skipped**