### PR TITLE
v0.10.8: half-tile undo fix + log time filter (From/To, whole-file search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LED Raster Designer v0.10.7.2
+# LED Raster Designer v0.10.8
 
 A professional LED video wall layout designer for live events, concerts, and installations.
 

--- a/src/VERSION.txt
+++ b/src/VERSION.txt
@@ -1,6 +1,30 @@
 LED RASTER DESIGNER - VERSION HISTORY
 =====================================
 
+v0.10.8 - July 26, 2026
+----------------------------
+- FIX: Undo now works correctly after setting half-tiles. Marking panels as
+  half-width or half-height resizes the whole screen, but that resize is
+  worked out on the server and used to arrive a moment AFTER the undo point
+  was recorded. The saved step therefore held the new half-tile marks on the
+  old full-size layout, so undoing it could leave the screen in a state that
+  never existed - and that broken state was then saved back as if it were
+  correct. The undo point is now recorded only after the resized screen has
+  come back, so undo and redo both restore the screen exactly as it was.
+- FIX: The log viewer's time range now filters correctly, and searches the
+  WHOLE log. Entering a plain date (2026-07-25) was off by the timezone
+  difference and could hide the entire day you asked for; entering a time to
+  the minute (20:14) silently dropped everything after the first second of
+  that minute. Both now cover exactly the period you name, start and end
+  included. The range is also applied to the whole log file instead of only
+  the last few hundred lines that happened to be loaded, so "1d ago" reaches
+  back properly, and the count tells you when there are more matches than
+  are being shown.
+- CHANGE: The log viewer's "Since" and "Until" boxes are now labeled "From"
+  and "To". They also accept "now", "today", and "yesterday", they no longer
+  re-filter on every keystroke while you are still typing, and an entry they
+  can't read now says so plainly instead of quietly showing everything.
+
 v0.10.7.2 - July 25, 2026
 ----------------------------
 - FIX: Undo behaves correctly after changing colors. Dragging any color

--- a/src/led_raster_designer.spec
+++ b/src/led_raster_designer.spec
@@ -104,8 +104,8 @@ if IS_MAC:
         info_plist={
             'CFBundleName': 'LED Raster Designer',
             'CFBundleDisplayName': 'LED Raster Designer',
-            'CFBundleShortVersionString': '0.10.7.2',
-            'CFBundleVersion': '0.10.7.2',
+            'CFBundleShortVersionString': '0.10.8',
+            'CFBundleVersion': '0.10.8',
             'NSHighResolutionCapable': True,
             # Menu-bar app, no Dock icon (same as the pre-window launcher):
             # the launcher window hides to the menu-bar status item, which is

--- a/src/routes_layers.py
+++ b/src/routes_layers.py
@@ -471,4 +471,8 @@ def set_panels_half_tile(layer_id):
     _rebuild_layer_geometry_from_panel_states(layer)
     log_event('bulk_set_panels_half_tile', {'layer_id': layer_id, 'count': updated})
     socketio.emit('layer_updated', layer)
-    return jsonify({'updated': updated})
+    # v0.10.8: return the rebuilt layer alongside the count. The rebuild
+    # above resizes every panel, so a client that only gets `updated` holds
+    # new halfTile flags on stale geometry until the socket event lands -
+    # long enough for an undo snapshot to capture the mismatch.
+    return jsonify({'updated': updated, 'layer': layer})

--- a/src/routes_logs.py
+++ b/src/routes_logs.py
@@ -4,8 +4,11 @@ log ingest endpoint. Log paths + log_event come from app; the logging
 infrastructure itself (rotation, startup setup) stays in app.
 """
 import os
+import re
 import sys
 import subprocess
+from collections import deque
+from datetime import datetime
 
 from flask import Blueprint, request, jsonify
 
@@ -13,41 +16,115 @@ from app import LOG_FILE_PATH, LOG_DIR_PATH, log_event
 
 logs_bp = Blueprint('logs', __name__)
 
+# The outer "timestamp" is always the FIRST one in a log line; details.clientTime
+# is UTC and must never be what the time filter matches.
+_LINE_TIMESTAMP_RE = re.compile(r'"timestamp"\s*:\s*"([^"]+)"')
+_TIMESTAMP_PARTS_RE = re.compile(
+    r'^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})')
+
+
+def _log_line_epoch_ms(line):
+    """Epoch-ms of a log line's outer timestamp, or None if unreadable.
+
+    Log timestamps are written in server-LOCAL time, so they are rebuilt as
+    local time here (naive datetime.timestamp() uses the local zone).
+    """
+    m = _LINE_TIMESTAMP_RE.search(line)
+    if not m:
+        return None
+    parts = _TIMESTAMP_PARTS_RE.match(m.group(1))
+    if not parts:
+        return None
+    try:
+        dt = datetime(*(int(p) for p in parts.groups()))
+        return int(dt.timestamp() * 1000)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def _epoch_ms_arg(name):
+    """Read an optional epoch-ms query param. Missing/blank/garbage -> None.
+
+    Ignoring a non-numeric value (rather than erroring) keeps the viewer
+    showing the unfiltered log instead of a 500.
+    """
+    raw = (request.args.get(name) or '').strip()
+    if not raw:
+        return None
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return None
+
 
 @logs_bp.route('/api/logs', methods=['GET'])
 def get_logs():
-    """Return last N lines of the current log file (most recent at bottom)."""
+    """Return last N lines of the current log file (most recent at bottom).
+
+    Optional `since` / `until` query params (epoch milliseconds, inclusive on
+    both ends) filter by each line's outer timestamp across the WHOLE file, not
+    just the tail; `lines` then caps the result to the most recent N matches.
+    """
     try:
         lines_arg = int(request.args.get('lines', '500'))
     except ValueError:
         lines_arg = 500
     lines_arg = max(50, min(lines_arg, 20000))
+    since_ms = _epoch_ms_arg('since')
+    until_ms = _epoch_ms_arg('until')
+    filtering = since_ms is not None or until_ms is not None
     result_lines = []
+    matched_count = None
     file_size = 0
     try:
         if os.path.isfile(LOG_FILE_PATH):
             file_size = os.path.getsize(LOG_FILE_PATH)
-            tail_bytes = b''
-            chunk_size = 0
-            # Read up to 4 MB from the end (plenty for ~20k lines)
-            max_chunk = 4 * 1024 * 1024
-            try:
-                with open(LOG_FILE_PATH, 'rb') as f:
-                    f.seek(0, os.SEEK_END)
-                    pos = f.tell()
-                    chunk_size = min(pos, max_chunk)
-                    f.seek(pos - chunk_size, os.SEEK_SET)
-                    tail_bytes = f.read()
-            except OSError:
-                pass
-            text = tail_bytes.decode('utf-8', errors='replace')
-            # Drop a partial first line if we didn't read from byte 0
-            if 0 < chunk_size < file_size and text:
-                nl = text.find('\n')
-                if nl != -1:
-                    text = text[nl + 1:]
-            all_lines = text.splitlines()
-            result_lines = all_lines[-lines_arg:]
+            if filtering:
+                # Whole-file scan, streamed a line at a time and kept in a
+                # bounded deque, so a 20 MB log never lands in memory at once.
+                kept = deque(maxlen=lines_arg)
+                matched_count = 0
+                try:
+                    with open(LOG_FILE_PATH, 'r', encoding='utf-8',
+                              errors='replace') as f:
+                        for raw_line in f:
+                            line = raw_line.rstrip('\r\n')
+                            if not line:
+                                continue
+                            ts = _log_line_epoch_ms(line)
+                            if ts is None:
+                                continue  # no readable timestamp: not in range
+                            if since_ms is not None and ts < since_ms:
+                                continue
+                            if until_ms is not None and ts > until_ms:
+                                continue
+                            matched_count += 1
+                            kept.append(line)
+                except OSError:
+                    pass
+                result_lines = list(kept)
+            else:
+                tail_bytes = b''
+                chunk_size = 0
+                # Read up to 4 MB from the end (plenty for ~20k lines)
+                max_chunk = 4 * 1024 * 1024
+                try:
+                    with open(LOG_FILE_PATH, 'rb') as f:
+                        f.seek(0, os.SEEK_END)
+                        pos = f.tell()
+                        chunk_size = min(pos, max_chunk)
+                        f.seek(pos - chunk_size, os.SEEK_SET)
+                        tail_bytes = f.read()
+                except OSError:
+                    pass
+                text = tail_bytes.decode('utf-8', errors='replace')
+                # Drop a partial first line if we didn't read from byte 0
+                if 0 < chunk_size < file_size and text:
+                    nl = text.find('\n')
+                    if nl != -1:
+                        text = text[nl + 1:]
+                all_lines = text.splitlines()
+                result_lines = all_lines[-lines_arg:]
     except OSError:
         pass
     # Count archived log files in the same directory
@@ -64,7 +141,11 @@ def get_logs():
         'file_path': LOG_FILE_PATH,
         'dir_path': LOG_DIR_PATH,
         'archive_count': archive_count,
-        'returned_count': len(result_lines)
+        'returned_count': len(result_lines),
+        # None when no time filter was applied; otherwise how many lines in the
+        # whole file matched, so the viewer can say "most recent N of M".
+        'matched_count': matched_count,
+        'filtered': filtering
     })
 
 

--- a/src/static/js/app-core.js
+++ b/src/static/js/app-core.js
@@ -288,29 +288,8 @@ export class LEDRasterApp {
         this.socket.on('layer_updated', (layer) => {
             console.log('WEBSOCKET layer_updated received for layer:', layer.id);
             sendClientLog('socket_layer_updated', { id: layer.id });
-            const index = this.project.layers.findIndex(l => l.id === layer.id);
-            if (index >= 0) {
-                // Preserve client-side properties when server sends layer update
-                const clientProps = this.extractClientSideProps(this.project.layers[index]);
-                this.project.layers[index] = layer;
-                
-                // Restore client props
-                Object.keys(clientProps).forEach(key => {
-                    if (clientProps[key] !== undefined) {
-                        this.project.layers[index][key] = clientProps[key];
-                    }
-                });
-                
-                if (this.currentLayer && this.currentLayer.id === layer.id) {
-                    this.currentLayer = this.project.layers[index];
-                }
-                this.dedupeProjectLayers('socket_layer_updated');
-                this.updateUI();
-            } else {
-                this.upsertProjectLayer(layer);
-                this.dedupeProjectLayers('socket_layer_updated_upsert');
-                this.updateUI();
-            }
+            this.applyServerLayer(layer, 'socket_layer_updated');
+            this.updateUI();
         });
         this.socket.on('preferences_updated', (prefs) => {
             console.log('WEBSOCKET preferences_updated received');
@@ -441,7 +420,38 @@ export class LEDRasterApp {
             fontUnderline: layer.fontUnderline
         };
     }
-    
+
+    // v0.10.8: merge a server-sent layer into this.project, preserving the
+    // client-side-only props the server never round-trips. Shared by the
+    // socket `layer_updated` handler and by fetch callers whose response
+    // carries the rebuilt layer, so both paths merge identically. Returns
+    // false when there is nothing to apply (no layer / no project yet).
+    applyServerLayer(layer, reason = 'apply_server_layer') {
+        if (!layer || !this.project || !this.project.layers) return false;
+        const index = this.project.layers.findIndex(l => l.id === layer.id);
+        if (index >= 0) {
+            // Preserve client-side properties when server sends layer update
+            const clientProps = this.extractClientSideProps(this.project.layers[index]);
+            this.project.layers[index] = layer;
+
+            // Restore client props
+            Object.keys(clientProps).forEach(key => {
+                if (clientProps[key] !== undefined) {
+                    this.project.layers[index][key] = clientProps[key];
+                }
+            });
+
+            if (this.currentLayer && this.currentLayer.id === layer.id) {
+                this.currentLayer = this.project.layers[index];
+            }
+            this.dedupeProjectLayers(reason);
+        } else {
+            this.upsertProjectLayer(layer);
+            this.dedupeProjectLayers(`${reason}_upsert`);
+        }
+        return true;
+    }
+
     loadProject() {
         fetch('/api/project')
             .then(res => res.json())

--- a/src/static/js/app-logs-recent.js
+++ b/src/static/js/app-logs-recent.js
@@ -18,6 +18,11 @@ class _LogsRecent {
         const modal = document.getElementById('logs-modal');
         if (modal) modal.style.display = 'none';
         this._stopLogsAutoRefresh();
+        // v0.10.8: a debounced filter fetch must not fire after the close
+        if (this._logsFilterTimer) {
+            clearTimeout(this._logsFilterTimer);
+            this._logsFilterTimer = null;
+        }
     }
 
     _ensureLogsModalWired() {
@@ -52,15 +57,32 @@ class _LogsRecent {
                 pre.style.whiteSpace = wrapCb.checked ? 'pre-wrap' : 'pre';
             });
         }
-        // Filter inputs: re-render on input without re-fetching
-        const applyFilter = () => this._rerenderLogsWithFilter();
-        if (sinceInput) sinceInput.addEventListener('input', applyFilter);
-        if (untilInput) untilInput.addEventListener('input', applyFilter);
+        // Filter inputs: re-fetch through the current window (the bounds are
+        // applied server-side now, so a filter change needs a new request).
+        // v0.10.8: typing used to filter on every keystroke, so a half-typed
+        // "2026" briefly emptied the pane. Debounce the keystroke path;
+        // change/blur (and Clear filter) apply immediately.
+        const applyFilter = () => this._debouncedLogFilter();
+        const applyFilterNow = () => {
+            if (this._logsFilterTimer) {
+                clearTimeout(this._logsFilterTimer);
+                this._logsFilterTimer = null;
+            }
+            this.refreshLogs(true);
+        };
+        if (sinceInput) {
+            sinceInput.addEventListener('input', applyFilter);
+            sinceInput.addEventListener('change', applyFilterNow);
+        }
+        if (untilInput) {
+            untilInput.addEventListener('input', applyFilter);
+            untilInput.addEventListener('change', applyFilterNow);
+        }
         if (filterClearBtn) {
             filterClearBtn.addEventListener('click', () => {
                 if (sinceInput) sinceInput.value = '';
                 if (untilInput) untilInput.value = '';
-                applyFilter();
+                applyFilterNow();
             });
         }
         if (pre) {
@@ -77,16 +99,33 @@ class _LogsRecent {
         }
     }
 
-    // Parse relative ("10 min ago", "2h ago", "30s", "1d ago") or absolute
-    // timestamps ("YYYY-MM-DD HH:MM:SS" or any Date-parseable string) into an
-    // epoch-ms number. Returns null for empty/unparseable input.
-    parseLogFilterTime(input) {
+    // Parse one filter field into an epoch-ms bound. Accepts relative
+    // ("10 min ago", "2h ago", "30s", "1d ago"), the words now / today /
+    // yesterday, and absolute "YYYY-MM-DD[ HH:MM[:SS]]".
+    // `bound` is 'start' or 'end'. v0.10.8: an absolute value is snapped to the
+    // precision the user actually typed so BOTH ends of the range are
+    // inclusive - "To: 2026-07-25" means through 23:59:59.999 that day, and
+    // "To: 2026-07-25 20:14" means through 20:14:59.999. The old code took
+    // "20:14" to mean 20:14:00 and then compared exclusively, dropping
+    // everything in the minute the user asked for.
+    // Returns null for empty/unparseable input.
+    parseLogFilterTime(input, bound = 'start') {
         if (!input) return null;
         const trimmed = String(input).trim();
         if (!trimmed) return null;
+        const lower = trimmed.toLowerCase();
+        const end = bound === 'end';
+        // Word forms
+        if (lower === 'now') return Date.now();
+        if (lower === 'today' || lower === 'yesterday') {
+            const d = new Date();
+            if (lower === 'yesterday') d.setDate(d.getDate() - 1);
+            return end
+                ? new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999).getTime()
+                : new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0).getTime();
+        }
         // Relative: "<n> <unit> ago" or just "<n><unit>" / "<n> <unit>"
-        const relMatch = trimmed
-            .toLowerCase()
+        const relMatch = lower
             .replace(/\s+ago\s*$/, '')  // strip trailing "ago"
             .trim()
             .match(/^(\d+(?:\.\d+)?)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$/);
@@ -101,49 +140,89 @@ class _LogsRecent {
             else return null;
             return Date.now() - ms;
         }
-        // Absolute: try Date.parse. Accepts ISO, "YYYY-MM-DD HH:MM:SS",
-        // "YYYY-MM-DDTHH:MM:SS", etc.
-        // Log format "2026-04-22 13:20:48" is not strict ISO; convert space to T.
-        const iso = trimmed.replace(' ', 'T');
-        const parsed = Date.parse(iso);
-        if (!isNaN(parsed)) return parsed;
-        const parsed2 = Date.parse(trimmed);
-        if (!isNaN(parsed2)) return parsed2;
-        return null;
+        // Absolute. v0.10.8: built field-by-field as LOCAL time instead of
+        // handed to Date.parse. The spec reads a bare "2026-07-25" as UTC but
+        // "2026-07-25T20:14:16" as local, so a date-only bound was skewed by
+        // the UTC offset (4h in EDT) and "To: 2026-07-25" hid the whole day.
+        // The regex also refuses partial input ("2026"), which Date.parse
+        // happily turned into a valid-but-wrong instant while the user typed.
+        const abs = trimmed.match(/^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T ](\d{1,2}):(\d{2})(?::(\d{2}))?)?$/);
+        if (!abs) return null;
+        const y = parseInt(abs[1], 10);
+        const mo = parseInt(abs[2], 10);
+        const day = parseInt(abs[3], 10);
+        const hasTime = abs[4] !== undefined;
+        const hasSec = abs[6] !== undefined;
+        const h = hasTime ? parseInt(abs[4], 10) : (end ? 23 : 0);
+        const mi = hasTime ? parseInt(abs[5], 10) : (end ? 59 : 0);
+        const s = hasSec ? parseInt(abs[6], 10) : (end ? 59 : 0);
+        const ms = end ? 999 : 0;
+        if (mo < 1 || mo > 12 || day < 1 || day > 31) return null;
+        if (h > 23 || mi > 59 || s > 59) return null;
+        const dt = new Date(y, mo - 1, day, h, mi, s, ms);
+        // Reject dates that rolled over ("2026-02-30" would land in March)
+        if (dt.getFullYear() !== y || dt.getMonth() !== mo - 1 || dt.getDate() !== day) return null;
+        return dt.getTime();
     }
 
     // Extract the log line's timestamp in epoch ms. Log lines are JSON with a
     // "timestamp": "YYYY-MM-DD HH:MM:SS" field. Returns null if not parseable.
     parseLogLineTime(line) {
         if (!line) return null;
-        // Fast path: pull out the first "timestamp": "..." occurrence
+        // Fast path: pull out the first "timestamp": "..." occurrence. The
+        // outer timestamp is always first; details.clientTime is UTC and is
+        // deliberately never what this matches.
         const m = line.match(/"timestamp"\s*:\s*"([^"]+)"/);
         if (!m) return null;
-        const iso = m[1].replace(' ', 'T');
-        const parsed = Date.parse(iso);
-        return isNaN(parsed) ? null : parsed;
+        // v0.10.8: built as LOCAL time to match the writer, rather than relying
+        // on Date.parse's format-dependent UTC/local behaviour.
+        const p = m[1].match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})/);
+        if (!p) return null;
+        return new Date(+p[1], +p[2] - 1, +p[3], +p[4], +p[5], +p[6]).getTime();
     }
 
-    _filterLogLines(lines) {
+    // v0.10.8: single reader for both fields, so the fetch query and the
+    // client-side pass can never disagree about the window.
+    _logFilterBounds() {
         const sinceInput = document.getElementById('logs-since');
         const untilInput = document.getElementById('logs-until');
-        const sinceMs = this.parseLogFilterTime(sinceInput && sinceInput.value);
-        const untilMs = this.parseLogFilterTime(untilInput && untilInput.value);
+        const sinceText = ((sinceInput && sinceInput.value) || '').trim();
+        const untilText = ((untilInput && untilInput.value) || '').trim();
+        const sinceMs = sinceText ? this.parseLogFilterTime(sinceText, 'start') : null;
+        const untilMs = untilText ? this.parseLogFilterTime(untilText, 'end') : null;
+        const bad = [];
+        if (sinceText && sinceMs === null) bad.push('From');
+        if (untilText && untilMs === null) bad.push('To');
+        return {
+            sinceMs,
+            untilMs,
+            bad,
+            hasText: !!(sinceText || untilText),
+            valid: bad.length === 0
+        };
+    }
+
+    _filterLogLines(lines, meta) {
         const statusEl = document.getElementById('logs-filter-status');
-        const hasSinceText = !!(sinceInput && sinceInput.value.trim());
-        const hasUntilText = !!(untilInput && untilInput.value.trim());
-        if (!hasSinceText && !hasUntilText) {
-            if (statusEl) statusEl.textContent = '';
+        const { sinceMs, untilMs, bad, hasText, valid } = this._logFilterBounds();
+        if (!hasText) {
+            if (statusEl) { statusEl.style.color = '#888'; statusEl.textContent = ''; }
             return { lines, sinceMs: null, untilMs: null, valid: true };
         }
-        // Validate: if user typed text but it didn't parse, highlight the issue
-        const parts = [];
-        if (hasSinceText && sinceMs === null) parts.push('Since: invalid');
-        if (hasUntilText && untilMs === null) parts.push('Until: invalid');
-        if (parts.length) {
-            if (statusEl) { statusEl.textContent = parts.join(' · '); statusEl.style.color = '#f0ad4e'; }
+        if (!valid) {
+            // v0.10.8: an unparseable field used to fall open and quietly show
+            // the whole unfiltered log behind a vague "invalid" note. Say
+            // plainly that no filtering happened.
+            if (statusEl) {
+                statusEl.style.color = '#f0ad4e';
+                statusEl.textContent = `${bad.join(' and ')} unrecognized — filter not applied`;
+            }
             return { lines, sinceMs, untilMs, valid: false };
         }
+        // Second pass over lines the server already filtered: same bounds and
+        // same timestamp parsing, so it normally changes nothing. It exists to
+        // catch anything the server could not read and to keep the count right
+        // when a response arrives after the fields moved on.
         const filtered = lines.filter(line => {
             const t = this.parseLogLineTime(line);
             if (t === null) return false;  // drop lines without a timestamp
@@ -153,19 +232,24 @@ class _LogsRecent {
         });
         if (statusEl) {
             statusEl.style.color = '#888';
-            statusEl.textContent = `filtered to ${filtered.length} of ${lines.length}`;
+            // v0.10.8: the server knows how many lines in the WHOLE file match;
+            // say so instead of implying the capped page is the whole answer.
+            const total = meta && typeof meta.matched_count === 'number'
+                ? meta.matched_count
+                : filtered.length;
+            statusEl.textContent = total > filtered.length
+                ? `showing most recent ${filtered.length} of ${total} matching entries`
+                : `${filtered.length} matching ${filtered.length === 1 ? 'entry' : 'entries'}`;
         }
         return { lines: filtered, sinceMs, untilMs, valid: true };
     }
 
-    _rerenderLogsWithFilter() {
-        // Re-render last-fetched lines through the current filter (no re-fetch)
-        if (!this._logsLastLines) return;
-        const pre = document.getElementById('logs-content');
-        if (!pre) return;
-        const { lines } = this._filterLogLines(this._logsLastLines);
-        pre.textContent = lines.join('\n');
-        if (!this._logsUserScrolledUp) pre.scrollTop = pre.scrollHeight;
+    _debouncedLogFilter(delay = 300) {
+        if (this._logsFilterTimer) clearTimeout(this._logsFilterTimer);
+        this._logsFilterTimer = setTimeout(() => {
+            this._logsFilterTimer = null;
+            this.refreshLogs(true);
+        }, delay);
     }
 
     _startLogsAutoRefresh() {
@@ -183,7 +267,18 @@ class _LogsRecent {
     refreshLogs(force) {
         const linesSel = document.getElementById('logs-lines');
         const lines = linesSel ? parseInt(linesSel.value, 10) || 500 : 500;
-        fetch(`/api/logs?lines=${lines}`)
+        // v0.10.8: the window goes to the server as epoch ms so the WHOLE log
+        // file is searched. Filtering only the fetched tail meant "From: 1d
+        // ago" could never reach anything older than the last N lines. Bounds
+        // are sent only when every filled-in field parses; a bad field means
+        // "not filtering" on both sides.
+        const { sinceMs, untilMs, valid } = this._logFilterBounds();
+        let url = `/api/logs?lines=${lines}`;
+        if (valid) {
+            if (sinceMs !== null) url += `&since=${Math.floor(sinceMs)}`;
+            if (untilMs !== null) url += `&until=${Math.floor(untilMs)}`;
+        }
+        fetch(url)
             .then(r => r.json())
             .then(data => this._renderLogs(data, force))
             .catch(err => this._renderLogsError(err));
@@ -194,8 +289,7 @@ class _LogsRecent {
         const meta = document.getElementById('logs-meta');
         if (!pre) return;
         const rawLines = Array.isArray(data.lines) ? data.lines : [];
-        this._logsLastLines = rawLines;
-        const { lines: visibleLines } = this._filterLogLines(rawLines);
+        const { lines: visibleLines } = this._filterLogLines(rawLines, data);
         pre.textContent = visibleLines.join('\n');
         if (meta) {
             const sizeKB = (data.file_size_bytes || 0) / 1024;

--- a/src/static/js/app-power.js
+++ b/src/static/js/app-power.js
@@ -1023,26 +1023,35 @@ class _Power {
                 halfTile: resolved,
             })),
         };
-        // Apply locally BEFORE saving history (the server response is
-        // discarded, so nothing else writes it back). Without this the
-        // snapshot captured the pre-change halfTile and Undo-then-Redo
-        // silently lost the change — the twin setPanelsBlankBulk does the
-        // same local-first mutation for exactly this reason.
+        // Apply locally so the canvas updates immediately while the POST is in
+        // flight; the flags alone are enough to redraw at the old geometry.
         panels.forEach(p => { p.halfTile = resolved; });
         if (window.canvasRenderer) window.canvasRenderer.render();
+        // v0.10.8: the snapshot must wait for the server's rebuilt layer.
+        // Setting halfTile resizes every panel, and that rebuild only happens
+        // server-side, so a saveState() taken here would pair the new flags
+        // with full-size geometry. Undo restored that mismatch and PUT it back
+        // to /api/project, which does no rebuild — making the corruption
+        // permanent. Merge the response first, snapshot second.
+        let applied = false;
         try {
             const res = await fetch(`/api/layer/${layerId}/panels/set_half_tile`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(body),
             });
-            await res.json();
+            const data = await res.json();
+            if (data && data.layer) {
+                applied = this.applyServerLayer(data.layer, 'bulk_set_half_tile');
+                if (window.canvasRenderer) window.canvasRenderer.render();
+            }
         } catch (err) {
-            // Local state already changed; still record it (same optimistic
-            // behaviour as setPanelsBlankBulk) so it stays undoable.
             console.error('setPanelsHalfTileBulk failed', err);
         }
-        this.saveState('Bulk Set Half-tile');
+        // No rebuilt layer means no trustworthy snapshot to take. Skip the
+        // history entry rather than record the stale-geometry one; the socket
+        // `layer_updated` event still reconciles the live state.
+        if (applied) this.saveState('Bulk Set Half-tile');
         sendClientLog && sendClientLog('bulk_set_half_tile', {
             layer_id: layerId,
             count: panels.length,

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LED Raster Designer v0.10.7.2</title>
+    <title>LED Raster Designer v0.10.8</title>
     <link rel="icon" type="image/svg+xml" href="/static/img/logo.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/color_picker.css">
@@ -96,7 +96,7 @@
 
         <div id="toolbar">
             <div class="toolbar-section toolbar-project">
-                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.7.2</span></span></h1>
+                    <h1><svg class="lrd-logo-mark" width="38" height="38" viewBox="0 0 48 48" aria-hidden="true" style="vertical-align:middle; margin-right:11px;"><rect x="3" y="3" width="42" height="42" rx="10" fill="#161616" stroke="#3a3a3a" stroke-width="1.5"/><rect x="11" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="11" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="29" y="11" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="20" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/><rect x="20" y="20" width="8" height="8" rx="2" fill="#cfcfcf"/><rect x="29" y="20" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="11" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="20" y="29" width="8" height="8" rx="2" fill="#5a5a5a"/><rect x="29" y="29" width="8" height="8" rx="2" fill="var(--ps-accent, #e22330)"/></svg><span style="white-space:nowrap; vertical-align:middle;">LED Raster Designer <span style="font-size: 0.6em; color: #888;">v0.10.8</span></span></h1>
                 <div style="position:relative;">
                     <input type="text" id="project-name" value="Untitled Project" class="editable-project-name">
                     <div id="project-name-warning" style="display:none; position:absolute; top:100%; left:0; margin-top:4px; padding:4px 8px; font-size:11px; color:#f5a623; background:#1a1a1a; border:1px solid #f5a623; border-radius:4px; white-space:nowrap; z-index:1000; pointer-events:none;"></div>
@@ -1960,14 +1960,14 @@
                 <button id="logs-refresh" class="btn" style="background: #3a3a3a; padding: 4px 12px; font-size: 12px;">Refresh</button>
             </div>
             <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 10px; flex-wrap: wrap;">
-                <label style="color: #ccc; font-size: 12px;">Since:
+                <label style="color: #ccc; font-size: 12px;">From:
                     <input id="logs-since" type="text" placeholder="e.g. 10 min ago"
-                           title="Relative (e.g. 10 min ago, 2h ago, 30s ago, 1d ago) or absolute (YYYY-MM-DD HH:MM:SS). Blank = no start bound."
+                           title="Start of range, included. Relative (10 min ago, 2h ago, 30s ago, 1d ago), or now / today / yesterday, or absolute (YYYY-MM-DD, or YYYY-MM-DD HH:MM:SS). A date with no time starts at 00:00:00. Blank = no start bound."
                            style="background: #1a1a1a; border: 1px solid #333; color: #fff; padding: 4px 6px; border-radius: 4px; margin-left: 4px; width: 180px; font-family: inherit; font-size: 12px;">
                 </label>
-                <label style="color: #ccc; font-size: 12px;">Until:
+                <label style="color: #ccc; font-size: 12px;">To:
                     <input id="logs-until" type="text" placeholder="e.g. 5 min ago (blank = now)"
-                           title="Relative or absolute. Blank means now, all entries after Since are shown."
+                           title="End of range, included. Same formats as From. A date with no time covers that whole day; HH:MM covers that whole minute. Blank = no end bound."
                            style="background: #1a1a1a; border: 1px solid #333; color: #fff; padding: 4px 6px; border-radius: 4px; margin-left: 4px; width: 200px; font-family: inherit; font-size: 12px;">
                 </label>
                 <button id="logs-filter-clear" class="btn" style="background: #3a3a3a; padding: 4px 10px; font-size: 12px;">Clear filter</button>

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,153 @@
+"""Tests for the in-app log viewer API (/api/logs), mainly the optional
+`since` / `until` epoch-ms time filter used by Help -> Show Logs."""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+import routes_logs
+
+
+def _epoch_ms(dt):
+    """Epoch ms for a naive LOCAL datetime, matching how log lines are read."""
+    return int(dt.timestamp() * 1000)
+
+
+def _log_line(dt, action='test_action'):
+    """One log line in the real on-disk shape: outer local timestamp plus a
+    details.clientTime in UTC that the filter must ignore."""
+    return json.dumps({
+        'timestamp': dt.strftime('%Y-%m-%d %H:%M:%S'),
+        'source': 'client',
+        'action': action,
+        'details': {'clientTime': '2000-01-01T00:00:00.000Z'}
+    })
+
+
+@pytest.fixture()
+def log_file(tmp_path, monkeypatch):
+    """Point the logs blueprint at a throwaway log file and return its path."""
+    path = tmp_path / 'led_raster_designer.log'
+    path.write_text('', encoding='utf-8')
+    monkeypatch.setattr(routes_logs, 'LOG_FILE_PATH', str(path))
+    monkeypatch.setattr(routes_logs, 'LOG_DIR_PATH', str(tmp_path))
+    return path
+
+
+def _write_lines(path, lines):
+    path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+BASE = datetime(2026, 7, 25, 20, 0, 0)
+
+
+def test_logs_no_filter_returns_everything(client, log_file):
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(5)])
+    data = client.get('/api/logs').get_json()
+    assert len(data['lines']) == 5
+    assert data['filtered'] is False
+    assert data['matched_count'] is None
+
+
+def test_logs_since_filters_out_older_lines(client, log_file):
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(5)])
+    since = _epoch_ms(BASE + timedelta(minutes=3))
+    data = client.get(f'/api/logs?since={since}').get_json()
+    assert len(data['lines']) == 2
+    assert data['filtered'] is True
+    assert data['matched_count'] == 2
+    assert '20:03:00' in data['lines'][0]
+    assert '20:04:00' in data['lines'][1]
+
+
+def test_logs_until_is_inclusive(client, log_file):
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(5)])
+    until = _epoch_ms(BASE + timedelta(minutes=2))
+    data = client.get(f'/api/logs?until={until}').get_json()
+    # 20:00, 20:01 and the 20:02 line the user asked "to"
+    assert len(data['lines']) == 3
+    assert '20:02:00' in data['lines'][-1]
+
+
+def test_logs_since_and_until_window(client, log_file):
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(10)])
+    since = _epoch_ms(BASE + timedelta(minutes=4))
+    until = _epoch_ms(BASE + timedelta(minutes=6))
+    data = client.get(f'/api/logs?since={since}&until={until}').get_json()
+    assert len(data['lines']) == 3
+    assert data['matched_count'] == 3
+
+
+def test_logs_filter_searches_whole_file_not_just_tail(client, log_file):
+    # 300 lines: a "From: 1d ago" style window must reach past the tail the
+    # unfiltered request would have returned.
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(300)])
+    since = _epoch_ms(BASE)
+    until = _epoch_ms(BASE + timedelta(minutes=9))
+    data = client.get(f'/api/logs?since={since}&until={until}').get_json()
+    assert data['matched_count'] == 10
+    assert len(data['lines']) == 10
+    assert '20:00:00' in data['lines'][0]
+
+
+def test_logs_lines_cap_applied_after_filtering(client, log_file):
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(120)])
+    since = _epoch_ms(BASE)
+    # 50 is the smallest cap the endpoint honours
+    data = client.get(f'/api/logs?since={since}&lines=50').get_json()
+    assert data['matched_count'] == 120   # everything matched
+    assert len(data['lines']) == 50       # ...but only the most recent 50 came back
+    assert data['returned_count'] == 50
+    assert '21:59:00' in data['lines'][-1]
+
+
+def test_logs_non_numeric_filter_params_are_ignored(client, log_file):
+    _write_lines(log_file, [_log_line(BASE + timedelta(minutes=i)) for i in range(5)])
+    resp = client.get('/api/logs?since=notanumber&until=')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data['lines']) == 5
+    assert data['filtered'] is False
+
+
+def test_logs_filter_drops_lines_without_a_timestamp(client, log_file):
+    _write_lines(log_file, [
+        'not json at all',
+        '{"source": "server", "action": "no_timestamp_here"}',
+        _log_line(BASE),
+    ])
+    since = _epoch_ms(BASE - timedelta(hours=1))
+    data = client.get(f'/api/logs?since={since}').get_json()
+    assert data['lines'] == [_log_line(BASE)]
+    assert data['matched_count'] == 1
+    # Unfiltered, the junk lines are still shown verbatim
+    assert len(client.get('/api/logs').get_json()['lines']) == 3
+
+
+def test_logs_filter_ignores_details_client_time(client, log_file):
+    # details.clientTime is UTC and years away from the outer timestamp; the
+    # filter must key off the outer (local) timestamp only.
+    _write_lines(log_file, [_log_line(BASE)])
+    since = _epoch_ms(BASE - timedelta(minutes=1))
+    until = _epoch_ms(BASE + timedelta(minutes=1))
+    data = client.get(f'/api/logs?since={since}&until={until}').get_json()
+    assert data['matched_count'] == 1
+
+
+def test_logs_filter_on_missing_file_is_empty_not_error(client, tmp_path, monkeypatch):
+    monkeypatch.setattr(routes_logs, 'LOG_FILE_PATH',
+                        str(tmp_path / 'does_not_exist.log'))
+    monkeypatch.setattr(routes_logs, 'LOG_DIR_PATH', str(tmp_path))
+    resp = client.get(f'/api/logs?since={_epoch_ms(BASE)}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['lines'] == []
+    assert data['file_size_bytes'] == 0
+
+
+def test_log_line_epoch_ms_helper():
+    line = _log_line(BASE)
+    assert routes_logs._log_line_epoch_ms(line) == _epoch_ms(BASE)
+    assert routes_logs._log_line_epoch_ms('{"action": "x"}') is None
+    assert routes_logs._log_line_epoch_ms('{"timestamp": "not-a-date"}') is None


### PR DESCRIPTION
## Summary
Two user-reported bugs, both root-caused and fixed.

### 1. Undo was broken after setting half-tiles
The bulk half-tile route rebuilds **every panel's geometry** server-side, but returned only `{'updated': n}`. So when `saveState()` ran, the client held **new half-tile flags paired with stale full-size geometry** — the rebuilt layer only arrived via socket ~1 ms later, too late for the snapshot. (Visible in the user's log as `save_state` at `.555` → `socket_layer_updated` at `.556`.) Undo then restored that hybrid and PUT it to `/api/project`, which performs no rebuild — making the corruption authoritative until some later edit triggered a rebuild and the wall snapped for no apparent reason.

- `routes_layers.py` now returns `{'updated': n, 'layer': layer}`.
- The client merges the rebuilt layer **before** snapshotting, matching the existing `app-canvas-ui.js` precedent.
- Extracted the socket handler's merge into `applyServerLayer()` so both paths preserve client-side props identically (no duplicated logic).
- If no trustworthy layer comes back, no history entry is recorded rather than a corrupt one.

### 2. Log viewer time range didn't filter correctly
- **Timezone skew (primary):** a date-only value was parsed as UTC per the `Date.parse` spec while log lines are server-local — a 4-hour skew, so `To: 2026-07-25` hid the entire day. Absolute values are now built field-by-field as local time.
- **Precision:** bounds are end-inclusive at the typed precision — a bare date covers the whole day, `HH:MM` covers the whole minute (previously dropped `:01`–`:59`).
- **Keystroke filtering:** debounced; no longer filters half-typed input like `2026`, which silently parsed to a valid-but-wrong date.
- **Whole-file search:** `/api/logs` accepts `since`/`until` as epoch ms and streams the entire file, applying the line cap **after** filtering and returning `matched_count`. Previously only the last 500 fetched lines were searched, so "1 d ago" couldn't reach older entries. Bad params are ignored rather than 500.
- **Labels:** `Since`/`Until` → **`From`/`To`** (IDs unchanged). Accepts `now`/`today`/`yesterday`. Unparseable input now says plainly that no filter was applied instead of quietly showing everything.

## Verification (in the running app, not just unit tests)
- Half-tile on a full row: heights `128 → 64`, next row reflowed `128 → 64`, **exactly one** history step; undo restored geometry, flags and reflow; redo re-applied.
- The **stored snapshot itself** is now coherent — flags and halved geometry together — which is precisely what was corrupt before.
- Log filter: date-only spans local `00:00:00 → 23:59:59`; minute bound covers `:59`; `2026`, `2026-07`, `2026-02-30`, `2026-13-01`, `25:00` all rejected; server matched **2620** whole-file with the cap applied after filtering; invalid input shows "From unrecognized — filter not applied".
- Clean console, no errors.
- `pytest`: **328 passed, 3 skipped** (11 new tests covering `/api/logs` time filtering, which had none).